### PR TITLE
feat(gateway-mode): add Gateway Mode API for direct LLM calls

### DIFF
--- a/axonflow.go
+++ b/axonflow.go
@@ -953,6 +953,9 @@ func (c *AxonFlowClient) GetPolicyApprovedContext(
 	if err != nil {
 		// Use a default expiration if parsing fails
 		expiresAt = time.Now().Add(5 * time.Minute)
+		if c.config.Debug {
+			log.Printf("[AxonFlow] Warning: Failed to parse expires_at '%s', using default 5 minute expiration", rawResp.ExpiresAt)
+		}
 	}
 
 	result := &PolicyApprovalResult{
@@ -966,7 +969,10 @@ func (c *AxonFlowClient) GetPolicyApprovedContext(
 
 	// Parse rate limit info if present
 	if rawResp.RateLimit != nil {
-		resetAt, _ := time.Parse(time.RFC3339, rawResp.RateLimit.ResetAt)
+		resetAt, err := time.Parse(time.RFC3339, rawResp.RateLimit.ResetAt)
+		if err != nil && c.config.Debug {
+			log.Printf("[AxonFlow] Warning: Failed to parse rate_limit.reset_at '%s'", rawResp.RateLimit.ResetAt)
+		}
 		result.RateLimitInfo = &RateLimitInfo{
 			Limit:     rawResp.RateLimit.Limit,
 			Remaining: rawResp.RateLimit.Remaining,


### PR DESCRIPTION
## Summary

Add Gateway Mode methods to enable direct LLM calls with AxonFlow governance. This achieves feature parity with the Python SDK.

### New Methods
- `GetPolicyApprovedContext()` - Pre-check policy approval before LLM call
- `AuditLLMCall()` - Audit the LLM call after completion
- `PreCheck()` - Alias for `GetPolicyApprovedContext()` for simpler API

### New Types
- `TokenUsage` - Token usage information for audit logging
- `RateLimitInfo` - Rate limit information from pre-check
- `PolicyApprovalResult` - Result from policy pre-check
- `AuditResult` - Result from audit logging

### Use Case
Gateway Mode enables lowest-latency governance by letting applications:
1. Pre-check policies before calling LLM directly
2. Make LLM calls with full control over provider/model
3. Audit the call for compliance after completion

## Test Plan
- [ ] Verify Go build passes
- [ ] Verify existing tests pass
- [ ] Test with mock HTTP server
- [ ] Verify JSON marshaling/unmarshaling
- [ ] Test error handling scenarios