### PR TITLE
feat(client): add demo mode via AXONFLOW_DEMO env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.3.0] - Unreleased
+## [5.3.0] - 2026-04-09
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,23 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.3.0] - Release Pending (2026-04-09)
+## [5.3.0] - Unreleased
+
+### Added
+
+- `AXONFLOW_TRY=1` environment variable to connect to `try.getaxonflow.com` shared evaluation server
+- `RegisterTry()` and `RegisterTryWithEndpoint()` helpers for self-registering a tenant
+- Checkpoint telemetry reports `endpoint_type: "community-saas"` when try mode is active
+- No runtime classifier changes — Go's `net.IP.IsPrivate()` already handles IPv6 ULA (`fc00::/7`) correctly, so the IPv6 review finding from the TS/Java classifiers does not apply here.
+
+### Changed
+
+- Renamed `AXONFLOW_DEMO` to `AXONFLOW_TRY` (demo mode → try mode)
+- Removed client-side random suffix from ClientID (server generates UUID tenant_id)
 
 ### Fixed
 
 - **`Version` constant corrected to `5.3.0`.** The v5.2.0 release shipped with `version.go` still declaring `const Version = "5.1.0"` — the constant was never bumped in the v5.2.0 PR. Any caller of `axonflow.Version` on v5.2.0 receives the string `"5.1.0"`, not `"5.2.0"`. This bug was discovered during the v5.2.0 post-release review. The constant is now corrected to `"5.3.0"` for the upcoming release. Go module proxy immutability means the v5.2.0 tag cannot be patched in place; downstream consumers on v5.2.0 who rely on the `Version` constant should upgrade to v5.3.0.
-
-### Added
-
-- No runtime classifier changes — Go's `net.IP.IsPrivate()` already handles IPv6 ULA (`fc00::/7`) correctly, so the IPv6 review finding from the TS/Java classifiers does not apply here.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AXONFLOW_TRY=1` environment variable to connect to `try.getaxonflow.com` shared evaluation server
 - `RegisterTry()` and `RegisterTryWithEndpoint()` helpers for self-registering a tenant
 - Checkpoint telemetry reports `endpoint_type: "community-saas"` when try mode is active
-- No runtime classifier changes — Go's `net.IP.IsPrivate()` already handles IPv6 ULA (`fc00::/7`) correctly, so the IPv6 review finding from the TS/Java classifiers does not apply here.
-
-### Changed
-
-- Renamed `AXONFLOW_DEMO` to `AXONFLOW_TRY` (demo mode → try mode)
-- Removed client-side random suffix from ClientID (server generates UUID tenant_id)
-
-### Fixed
-
-- **`Version` constant corrected to `5.3.0`.** The v5.2.0 release shipped with `version.go` still declaring `const Version = "5.1.0"` — the constant was never bumped in the v5.2.0 PR. Any caller of `axonflow.Version` on v5.2.0 receives the string `"5.1.0"`, not `"5.2.0"`. This bug was discovered during the v5.2.0 post-release review. The constant is now corrected to `"5.3.0"` for the upcoming release. Go module proxy immutability means the v5.2.0 tag cannot be patched in place; downstream consumers on v5.2.0 who rely on the `Version` constant should upgrade to v5.3.0.
 
 ---
 

--- a/axonflow.go
+++ b/axonflow.go
@@ -6,9 +6,7 @@ package axonflow
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
 	"crypto/tls"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -544,9 +542,6 @@ func NewClient(config AxonFlowConfig) *AxonFlowClient {
 		if config.ClientID == "" {
 			panic("ClientID is required in try mode (AXONFLOW_TRY=1). Register at https://try.getaxonflow.com/api/v1/register")
 		}
-		b := make([]byte, 3)
-		_, _ = rand.Read(b)
-		config.ClientID = fmt.Sprintf("%s-%s", config.ClientID, hex.EncodeToString(b))
 	}
 
 	// Reject ClientSecret without ClientID — licensed mode must specify tenant.

--- a/axonflow.go
+++ b/axonflow.go
@@ -6,7 +6,9 @@ package axonflow
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -542,6 +544,9 @@ func NewClient(config AxonFlowConfig) *AxonFlowClient {
 		if config.ClientID == "" {
 			panic("ClientID is required in try mode (AXONFLOW_TRY=1). Register at https://try.getaxonflow.com/api/v1/register")
 		}
+		b := make([]byte, 3)
+		_, _ = rand.Read(b)
+		config.ClientID = fmt.Sprintf("%s-%s", config.ClientID, hex.EncodeToString(b))
 	}
 
 	// Reject ClientSecret without ClientID — licensed mode must specify tenant.

--- a/axonflow.go
+++ b/axonflow.go
@@ -535,6 +535,15 @@ func (c *cache) cleanup() {
 
 // NewClient creates a new AxonFlow client with the given configuration
 func NewClient(config AxonFlowConfig) *AxonFlowClient {
+	// Try mode: override endpoint to try.getaxonflow.com for evaluation.
+	// ClientID is mandatory — the server needs it for tenant isolation.
+	if os.Getenv("AXONFLOW_TRY") == "1" {
+		config.Endpoint = "https://try.getaxonflow.com"
+		if config.ClientID == "" {
+			panic("ClientID is required in try mode (AXONFLOW_TRY=1). Register at https://try.getaxonflow.com/api/v1/register")
+		}
+	}
+
 	// Reject ClientSecret without ClientID — licensed mode must specify tenant.
 	// Log loudly but don't crash the process — the server will reject requests
 	// and the error will surface at first API call.

--- a/register.go
+++ b/register.go
@@ -1,0 +1,61 @@
+package axonflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const TryEndpoint = "https://try.getaxonflow.com"
+
+type TryRegistration struct {
+	TenantID     string `json:"tenant_id"`
+	Secret       string `json:"secret"`
+	SecretPrefix string `json:"secret_prefix"`
+	ExpiresAt    string `json:"expires_at"`
+	Endpoint     string `json:"endpoint"`
+	Note         string `json:"note"`
+}
+
+// RegisterTry registers a new tenant on try.getaxonflow.com.
+// Store the secret securely — it is shown only once.
+func RegisterTry(ctx context.Context, label string) (*TryRegistration, error) {
+	return RegisterTryWithEndpoint(ctx, label, TryEndpoint)
+}
+
+// RegisterTryWithEndpoint registers a new tenant on the specified endpoint.
+// Use this for local testing with a different endpoint URL.
+func RegisterTryWithEndpoint(ctx context.Context, label, endpoint string) (*TryRegistration, error) {
+	body := "{}"
+	if label != "" {
+		body = fmt.Sprintf(`{"label":%q}`, label)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST",
+		endpoint+"/api/v1/register",
+		strings.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("registration request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("registration failed with status %d", resp.StatusCode)
+	}
+
+	var reg TryRegistration
+	if err := json.NewDecoder(resp.Body).Decode(&reg); err != nil {
+		return nil, fmt.Errorf("failed to parse registration response: %w", err)
+	}
+	return &reg, nil
+}

--- a/telemetry.go
+++ b/telemetry.go
@@ -58,6 +58,9 @@ const (
 //   - "remote": everything else
 //   - "unknown": on parse failure
 func ClassifyEndpoint(endpoint string) string {
+	if os.Getenv("AXONFLOW_TRY") == "1" {
+		return "community-saas"
+	}
 	if endpoint == "" {
 		return EndpointTypeUnknown
 	}


### PR DESCRIPTION
Addresses https://github.com/getaxonflow/axonflow-enterprise/issues/1500.

## Changes

**Commit 1 — demo mode:** When `AXONFLOW_DEMO=1` is set, `NewClient` overrides `Endpoint` to the public demo instance (`https://demo.getaxonflow.com`, placeholder URL pending the instance being stood up) and panics if `ClientID` is empty (consistent with the existing fatal misconfiguration pattern in this package).

**Commit 2 — random suffix:** In demo mode, a 6-character random hex suffix is appended to the provided `ClientID` (e.g. `acme` → `acme-3f9a1c`) using `crypto/rand`. This gives each evaluator session a unique namespace on the shared demo instance without requiring them to choose a globally unique ID.

## Notes

- No behavior change when `AXONFLOW_DEMO` is unset.
- Demo URL is a placeholder — PRs will be updated with the real URL before merge.