### PR TITLE
prep(v5.3.0): fix Version constant miss from v5.2.0 — Release Pending (2026-04-09)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,19 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.2.0] - 2026-04-09
+## [5.3.0] - Release Pending (2026-04-09)
+
+### Fixed
+
+- **`Version` constant corrected to `5.3.0`.** The v5.2.0 release shipped with `version.go` still declaring `const Version = "5.1.0"` — the constant was never bumped in the v5.2.0 PR. Any caller of `axonflow.Version` on v5.2.0 receives the string `"5.1.0"`, not `"5.2.0"`. This bug was discovered during the v5.2.0 post-release review. The constant is now corrected to `"5.3.0"` for the upcoming release. Go module proxy immutability means the v5.2.0 tag cannot be patched in place; downstream consumers on v5.2.0 who rely on the `Version` constant should upgrade to v5.3.0.
+
+### Added
+
+- No runtime classifier changes — Go's `net.IP.IsPrivate()` already handles IPv6 ULA (`fc00::/7`) correctly, so the IPv6 review finding from the TS/Java classifiers does not apply here.
+
+---
+
+## [5.2.0] - 2026-04-08
 
 ### Added
 
@@ -15,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Examples and documentation updated to reflect the new AxonFlow platform v6.2.0 defaults for `PII_ACTION` (now `warn` — was `redact`) and the new `AXONFLOW_PROFILE` env var. No SDK API changes.
+
+### Known issue (fixed in v5.3.0)
+
+- `version.go` `Version` constant was not bumped in this release and still declares `"5.1.0"`. Published tag is `v5.2.0` but `axonflow.Version` returns `"5.1.0"`. Use v5.3.0 or later if you need an accurate SDK version string at runtime.
 
 ---
 

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package axonflow
 
 // Version is the SDK version.
-const Version = "5.1.0"
+const Version = "5.3.0"


### PR DESCRIPTION
## Summary

**v5.3.0 prep — Release Pending (2026-04-09).** Staged for tomorrow's release with Greg's work. NOT released here.

## Review findings addressed

### v5.2.0 shipping bug (discovered during v6.2.0 review) — Version constant never bumped

- [x] `version.go` now correctly declares `const Version = "5.3.0"`. The v5.2.0 release shipped with this still at `"5.1.0"` — the constant was never bumped in the v5.2.0 PR. Any caller of `axonflow.Version` on v5.2.0 receives `"5.1.0"`, not `"5.2.0"`.
- Go module proxy immutability means v5.2.0 cannot be patched in place — the buggy state is locked into the published tag forever.
- v5.2.0 changelog entry updated with a "Known issue" subsection documenting the miss so downstream consumers aren't surprised.

### No runtime classifier changes needed

- Go's `net.IP.IsPrivate()` already handles IPv6 ULA (`fc00::/7`) correctly, so the TS/Java IPv6 review fix does not apply here. No new code.

## Manifest bump

- `version.go`: `Version` constant 5.1.0 (sic, from v5.2.0 bug) → 5.3.0

## Changelog

- **`## [5.3.0] - Release Pending (2026-04-09)`** — user finalizes at release time
- v5.2.0 entry date corrected 2026-04-09 → 2026-04-08
- v5.2.0 entry gains a "Known issue (fixed in v5.3.0)" subsection

## Tests

Existing 30 `TestClassifyEndpoint` cases pass. No new tests needed (no runtime changes).

## Not released

No tag, no publish, no merge. PR stays OPEN for user review.