### PR TITLE
fix: send Basic auth on all authenticated endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.3.1] - 2026-04-10
+## [5.3.1] - 2026-04-11
 
 ### Fixed
 
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `httpClient.Get()` directly, causing 401 errors on authenticated servers.
 - `GetPlanStatus` now sends Basic auth credentials (same fix).
 - All execution replay methods (`ListExecutions`, `GetExecution`,
-  `GetExecutionTimeline`, `GetExecutionAudit`, `ReplayExecution`) now send
-  Basic auth credentials.
+  `GetExecutionSteps`, `GetExecutionTimeline`, `ExportExecution`,
+  `DeleteExecution`) now send Basic auth credentials.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.3.1] - 2026-04-10
+
+### Fixed
+
+- `ListConnectors`, `GetConnector`, `GetConnectorHealth` now send Basic auth
+  credentials. Previously bypassed the centralized auth mechanism by using
+  `httpClient.Get()` directly, causing 401 errors on authenticated servers.
+- `GetPlanStatus` now sends Basic auth credentials (same fix).
+- All execution replay methods (`ListExecutions`, `GetExecution`,
+  `GetExecutionTimeline`, `GetExecutionAudit`, `ReplayExecution`) now send
+  Basic auth credentials.
+
+---
+
 ## [5.3.0] - 2026-04-09
 
 ### Added

--- a/axonflow.go
+++ b/axonflow.go
@@ -1126,7 +1126,12 @@ func getMetadataKeys(metadata map[string]interface{}) []string {
 
 // ListConnectors returns all available MCP connectors from the marketplace
 func (c *AxonFlowClient) ListConnectors() ([]ConnectorMetadata, error) {
-	resp, err := c.httpClient.Get(c.config.Endpoint + "/api/v1/connectors")
+	req, err := http.NewRequest("GET", c.config.Endpoint+"/api/v1/connectors", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	c.addAuthHeaders(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list connectors: %w", err)
 	}
@@ -1155,8 +1160,13 @@ func (c *AxonFlowClient) ListConnectors() ([]ConnectorMetadata, error) {
 
 // GetConnector returns details for a specific connector by ID
 func (c *AxonFlowClient) GetConnector(connectorID string) (*ConnectorMetadata, error) {
-	url := fmt.Sprintf("%s/api/v1/connectors/%s", c.config.Endpoint, connectorID)
-	resp, err := c.httpClient.Get(url)
+	reqURL := fmt.Sprintf("%s/api/v1/connectors/%s", c.config.Endpoint, connectorID)
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	c.addAuthHeaders(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get connector: %w", err)
 	}
@@ -1185,8 +1195,13 @@ func (c *AxonFlowClient) GetConnector(connectorID string) (*ConnectorMetadata, e
 
 // GetConnectorHealth returns the health status of an installed connector
 func (c *AxonFlowClient) GetConnectorHealth(connectorID string) (*ConnectorHealthStatus, error) {
-	url := fmt.Sprintf("%s/api/v1/connectors/%s/health", c.config.Endpoint, connectorID)
-	resp, err := c.httpClient.Get(url)
+	reqURL := fmt.Sprintf("%s/api/v1/connectors/%s/health", c.config.Endpoint, connectorID)
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	c.addAuthHeaders(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get connector health: %w", err)
 	}
@@ -1688,7 +1703,12 @@ func (c *AxonFlowClient) ExecutePlan(planID string, userToken ...string) (*PlanE
 
 // GetPlanStatus retrieves the status of a running or completed plan
 func (c *AxonFlowClient) GetPlanStatus(planID string) (*PlanExecutionResponse, error) {
-	resp, err := c.httpClient.Get(c.config.Endpoint + "/api/v1/plan/" + planID)
+	req, err := http.NewRequest("GET", c.config.Endpoint+"/api/v1/plan/"+planID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	c.addAuthHeaders(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get plan status: %w", err)
 	}

--- a/execution_replay.go
+++ b/execution_replay.go
@@ -155,7 +155,12 @@ func (c *AxonFlowClient) ListExecutions(options *ListExecutionsOptions) (*ListEx
 		reqURL += "?" + params.Encode()
 	}
 
-	resp, err := c.httpClient.Get(reqURL)
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	c.addAuthHeaders(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list executions: %w", err)
 	}
@@ -198,7 +203,12 @@ func (c *AxonFlowClient) GetExecution(executionID string) (*ExecutionDetail, err
 	baseURL := c.config.Endpoint
 	reqURL := fmt.Sprintf("%s/api/v1/executions/%s", baseURL, executionID)
 
-	resp, err := c.httpClient.Get(reqURL)
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	c.addAuthHeaders(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get execution: %w", err)
 	}
@@ -245,7 +255,12 @@ func (c *AxonFlowClient) GetExecutionSteps(executionID string) ([]ExecutionSnaps
 	baseURL := c.config.Endpoint
 	reqURL := fmt.Sprintf("%s/api/v1/executions/%s/steps", baseURL, executionID)
 
-	resp, err := c.httpClient.Get(reqURL)
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	c.addAuthHeaders(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get execution steps: %w", err)
 	}
@@ -295,7 +310,12 @@ func (c *AxonFlowClient) GetExecutionTimeline(executionID string) ([]TimelineEnt
 	baseURL := c.config.Endpoint
 	reqURL := fmt.Sprintf("%s/api/v1/executions/%s/timeline", baseURL, executionID)
 
-	resp, err := c.httpClient.Get(reqURL)
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	c.addAuthHeaders(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get execution timeline: %w", err)
 	}
@@ -365,7 +385,12 @@ func (c *AxonFlowClient) ExportExecution(executionID string, options *ExecutionE
 		reqURL += "?" + params.Encode()
 	}
 
-	resp, err := c.httpClient.Get(reqURL)
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	c.addAuthHeaders(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to export execution: %w", err)
 	}

--- a/execution_replay.go
+++ b/execution_replay.go
@@ -440,6 +440,7 @@ func (c *AxonFlowClient) DeleteExecution(executionID string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create delete request: %w", err)
 	}
+	c.addAuthHeaders(req)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package axonflow
 
 // Version is the SDK version.
-const Version = "5.3.0"
+const Version = "5.3.1"


### PR DESCRIPTION
## Summary

- `ListConnectors`, `GetConnector`, `GetConnectorHealth`, `GetPlanStatus` and all execution replay methods were using `httpClient.Get()` directly, bypassing `addAuthHeaders()`
- This caused 401 errors on any server requiring authentication (enterprise, evaluation, community-saas modes)
- Fixed by building `http.Request` and calling `addAuthHeaders()` before sending

## Test plan

- [x] `go build ./...` passes
- [ ] CI checks green
- [ ] E2E test: `ListConnectors` works in enterprise mode with Basic auth