### PR TITLE
feat: decisions.Explain + audit search filter parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.5.0] - 2026-04-18
+
+### Added
+
+- **`ExplainDecision(ctx, decisionID)`** — fetches the full explanation for a
+  previously-made policy decision via `GET /api/v1/decisions/:id/explain`.
+  Returns a `DecisionExplanation` containing matched policies, risk level,
+  reason, override availability, existing override ID (if any), and a
+  rolling-24h session hit count for the matched rule. Shape is frozen;
+  additive-only fields ensure forward compatibility.
+- **`AuditSearchRequest.DecisionID`, `PolicyName`, `OverrideID`** — three new
+  optional filter fields on `SearchAuditLogs`. Use `DecisionID` to gather every
+  record tied to one decision; `PolicyName` to find everything matched by a
+  specific policy; `OverrideID` to reconstruct an override's full lifecycle
+  (`override_created` → `override_used` → `override_expired | override_revoked`).
+
+### Compatibility
+
+Companion to platform v7.1.0. Works against older platforms that ignore the
+new filter fields — they just pass through without narrowing results. Works
+against new plugins (OpenClaw v1.3.0+, Claude Code v0.5.0+, Cursor v0.5.0+,
+Codex v0.4.0+) that surface the `DecisionExplanation` shape.
+
+---
+
 ## [5.4.0] - 2026-04-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,31 +5,6 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.5.0] - 2026-04-18
-
-### Added
-
-- **`ExplainDecision(ctx, decisionID)`** — fetches the full explanation for a
-  previously-made policy decision via `GET /api/v1/decisions/:id/explain`.
-  Returns a `DecisionExplanation` containing matched policies, risk level,
-  reason, override availability, existing override ID (if any), and a
-  rolling-24h session hit count for the matched rule. Shape is frozen;
-  additive-only fields ensure forward compatibility.
-- **`AuditSearchRequest.DecisionID`, `PolicyName`, `OverrideID`** — three new
-  optional filter fields on `SearchAuditLogs`. Use `DecisionID` to gather every
-  record tied to one decision; `PolicyName` to find everything matched by a
-  specific policy; `OverrideID` to reconstruct an override's full lifecycle
-  (`override_created` → `override_used` → `override_expired | override_revoked`).
-
-### Compatibility
-
-Companion to platform v7.1.0. Works against older platforms that ignore the
-new filter fields — they just pass through without narrowing results. Works
-against plugin releases (OpenClaw v1.3.0+, Claude Code v0.5.0+, Cursor v0.5.0+,
-Codex v0.4.0+) that surface the `DecisionExplanation` shape.
-
----
-
 ## [5.4.0] - 2026-04-18
 
 ### Added
@@ -46,6 +21,24 @@ Codex v0.4.0+) that surface the `DecisionExplanation` shape.
   resumes from a specific checkpoint with fresh policy evaluation (Enterprise).
 - **Checkpoint types** — `Checkpoint`, `CheckpointListResponse`, and
   `ResumeFromCheckpointResponse` types for checkpoint operations.
+- **`ExplainDecision(ctx, decisionID)`** — fetches the full explanation for a
+  previously-made policy decision via `GET /api/v1/decisions/:id/explain`.
+  Returns a `DecisionExplanation` containing matched policies, risk level,
+  reason, override availability, existing override ID (if any), and a
+  rolling-24h session hit count for the matched rule. Shape is frozen;
+  additive-only fields ensure forward compatibility.
+- **`AuditSearchRequest.DecisionID`, `PolicyName`, `OverrideID`** — three new
+  optional filter fields on `SearchAuditLogs`. Use `DecisionID` to gather every
+  record tied to one decision; `PolicyName` to find everything matched by a
+  specific policy; `OverrideID` to reconstruct an override's full lifecycle
+  (`override_created` → `override_used` → `override_expired | override_revoked`).
+
+### Compatibility
+
+Companion to platform v7.1.0. Works against plugin releases (OpenClaw v1.3.0+,
+Claude Code v0.5.0+, Cursor v0.5.0+, Codex v0.4.0+) that surface the
+`DecisionExplanation` shape. The new audit filter fields pass through when
+unset; server-side filtering only activates on v7.1.0+ platforms.
 
 ## [5.3.1] - 2026-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Companion to platform v7.1.0. Works against older platforms that ignore the
 new filter fields — they just pass through without narrowing results. Works
-against new plugins (OpenClaw v1.3.0+, Claude Code v0.5.0+, Cursor v0.5.0+,
+against plugin releases (OpenClaw v1.3.0+, Claude Code v0.5.0+, Cursor v0.5.0+,
 Codex v0.4.0+) that surface the `DecisionExplanation` shape.
 
 ---

--- a/audit.go
+++ b/audit.go
@@ -30,6 +30,15 @@ type AuditSearchRequest struct {
 	EndTime *time.Time `json:"end_time,omitempty"`
 	// RequestType filters by request type (e.g., "llm_chat", "policy_check")
 	RequestType string `json:"request_type,omitempty"`
+	// DecisionID filters logs by the explainability decision ID (ADR-043).
+	// Useful for reconstructing everything tied to a single decision.
+	DecisionID string `json:"decision_id,omitempty"`
+	// PolicyName filters logs by the matched policy name (ADR-043).
+	PolicyName string `json:"policy_name,omitempty"`
+	// OverrideID filters logs by the session-override ID (ADR-042).
+	// Use this to reconstruct the full lifecycle of one override
+	// (override_created → override_used → override_expired | override_revoked).
+	OverrideID string `json:"override_id,omitempty"`
 	// Limit is the maximum number of results to return (default: 100, max: 1000)
 	Limit int `json:"limit,omitempty"`
 	// Offset is the pagination offset (default: 0)
@@ -242,6 +251,15 @@ func (c *AxonFlowClient) SearchAuditLogs(ctx context.Context, req *AuditSearchRe
 	}
 	if req.RequestType != "" {
 		reqBody["request_type"] = req.RequestType
+	}
+	if req.DecisionID != "" {
+		reqBody["decision_id"] = req.DecisionID
+	}
+	if req.PolicyName != "" {
+		reqBody["policy_name"] = req.PolicyName
+	}
+	if req.OverrideID != "" {
+		reqBody["override_id"] = req.OverrideID
 	}
 	reqBody["limit"] = req.Limit
 	if req.Offset > 0 {

--- a/decisions.go
+++ b/decisions.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -75,7 +76,10 @@ func (c *AxonFlowClient) ExplainDecision(ctx context.Context, decisionID string)
 		return nil, fmt.Errorf("decisionID is required")
 	}
 
-	fullURL := c.config.Endpoint + "/api/v1/decisions/" + decisionID + "/explain"
+	// Path-escape the decision ID — platform-generated IDs are usually
+	// filesystem-safe, but nothing in ADR-043 guarantees it, and IDs that
+	// contain "/" or "?" would break the URL otherwise.
+	fullURL := c.config.Endpoint + "/api/v1/decisions/" + url.PathEscape(decisionID) + "/explain"
 
 	httpReq, err := http.NewRequestWithContext(ctx, "GET", fullURL, nil)
 	if err != nil {

--- a/decisions.go
+++ b/decisions.go
@@ -1,0 +1,111 @@
+// Decision explainability methods for AxonFlow SDK.
+// Implements the contract locked in ADR-043 (Explainability Data Contract).
+package axonflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// ============================================================================
+// Types (ADR-043 — frozen shape)
+// ============================================================================
+
+// DecisionExplanation is the canonical payload returned by Decisions.Explain.
+// Shape is frozen per ADR-043; additive fields may be added with omitempty,
+// renames/removals require a major version bump.
+type DecisionExplanation struct {
+	DecisionID                string          `json:"decision_id"`
+	Timestamp                 time.Time       `json:"timestamp"`
+	PolicyMatches             []ExplainPolicy `json:"policy_matches"`
+	MatchedRules              []ExplainRule   `json:"matched_rules,omitempty"`
+	Decision                  string          `json:"decision"` // "allow"|"deny"|"require_approval"
+	Reason                    string          `json:"reason"`
+	RiskLevel                 string          `json:"risk_level,omitempty"`
+	OverrideAvailable         bool            `json:"override_available"`
+	OverrideExistingID        string          `json:"override_existing_id,omitempty"`
+	HistoricalHitCountSession int             `json:"historical_hit_count_session"`
+	PolicySourceLink          string          `json:"policy_source_link,omitempty"`
+	ToolSignature             string          `json:"tool_signature,omitempty"`
+}
+
+// ExplainPolicy is a policy reference inside an explanation.
+type ExplainPolicy struct {
+	PolicyID          string `json:"policy_id"`
+	PolicyName        string `json:"policy_name,omitempty"`
+	Action            string `json:"action,omitempty"`
+	RiskLevel         string `json:"risk_level,omitempty"`
+	AllowOverride     bool   `json:"allow_override,omitempty"`
+	PolicyDescription string `json:"policy_description,omitempty"`
+}
+
+// ExplainRule is rule-level detail inside an explanation.
+type ExplainRule struct {
+	PolicyID  string `json:"policy_id"`
+	RuleID    string `json:"rule_id,omitempty"`
+	RuleText  string `json:"rule_text,omitempty"`
+	MatchedOn string `json:"matched_on,omitempty"`
+}
+
+// ============================================================================
+// Methods
+// ============================================================================
+
+// ExplainDecision fetches the full explanation for a previously-made
+// policy decision. The caller must either own the decision (user_email
+// match) or belong to the same tenant. Returns a 404-equivalent error
+// when the decision is past retention.
+//
+// Context cancellation is honored; the underlying HTTP request is bound
+// to the given ctx.
+//
+// Example:
+//
+//	exp, err := client.ExplainDecision(ctx, "dec_wf123_step4")
+//	if err != nil { return err }
+//	if exp.OverrideAvailable {
+//	    // offer the user a "override this for 10 minutes" action
+//	}
+func (c *AxonFlowClient) ExplainDecision(ctx context.Context, decisionID string) (*DecisionExplanation, error) {
+	if decisionID == "" {
+		return nil, fmt.Errorf("decisionID is required")
+	}
+
+	fullURL := c.config.Endpoint + "/api/v1/decisions/" + decisionID + "/explain"
+
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", fullURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build explain request: %w", err)
+	}
+
+	httpReq.Header.Set("Accept", "application/json")
+	c.addAuthHeaders(httpReq)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("explain request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read explain response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &httpError{
+			statusCode: resp.StatusCode,
+			message:    string(body),
+		}
+	}
+
+	var out DecisionExplanation
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("failed to decode explain response: %w", err)
+	}
+	return &out, nil
+}

--- a/decisions_test.go
+++ b/decisions_test.go
@@ -85,6 +85,29 @@ func TestExplainDecision_HappyPath(t *testing.T) {
 	}
 }
 
+func TestExplainDecision_URLEncodesDecisionID(t *testing.T) {
+	var capturedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(DecisionExplanation{DecisionID: "a/b", Decision: "allow"})
+	}))
+	defer srv.Close()
+
+	c := &AxonFlowClient{
+		config:     AxonFlowConfig{Endpoint: srv.URL},
+		httpClient: srv.Client(),
+	}
+	_, err := c.ExplainDecision(context.Background(), "a/b?c")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Path should be URL-escaped: "a/b?c" → "a%2Fb%3Fc"
+	if !strings.Contains(capturedPath, "a%2Fb%3Fc") {
+		t.Errorf("Path = %q, expected URL-encoded decision ID", capturedPath)
+	}
+}
+
 func TestExplainDecision_404(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)

--- a/decisions_test.go
+++ b/decisions_test.go
@@ -86,9 +86,11 @@ func TestExplainDecision_HappyPath(t *testing.T) {
 }
 
 func TestExplainDecision_URLEncodesDecisionID(t *testing.T) {
-	var capturedPath string
+	// Use RequestURI (raw request line) rather than r.URL.Path (decoded) so
+	// we can verify the wire form actually carries escaped bytes.
+	var capturedURI string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		capturedPath = r.URL.Path
+		capturedURI = r.RequestURI
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(DecisionExplanation{DecisionID: "a/b", Decision: "allow"})
 	}))
@@ -98,13 +100,13 @@ func TestExplainDecision_URLEncodesDecisionID(t *testing.T) {
 		config:     AxonFlowConfig{Endpoint: srv.URL},
 		httpClient: srv.Client(),
 	}
-	_, err := c.ExplainDecision(context.Background(), "a/b?c")
+	// Plain slash is enough — PathEscape escapes '/' in a single path segment.
+	_, err := c.ExplainDecision(context.Background(), "a/b")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Path should be URL-escaped: "a/b?c" → "a%2Fb%3Fc"
-	if !strings.Contains(capturedPath, "a%2Fb%3Fc") {
-		t.Errorf("Path = %q, expected URL-encoded decision ID", capturedPath)
+	if !strings.Contains(capturedURI, "a%2Fb") {
+		t.Errorf("RequestURI = %q, expected URL-encoded decision ID 'a%%2Fb'", capturedURI)
 	}
 }
 

--- a/decisions_test.go
+++ b/decisions_test.go
@@ -1,0 +1,164 @@
+package axonflow
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestExplainDecision_RequiresDecisionID(t *testing.T) {
+	c := &AxonFlowClient{
+		config:     AxonFlowConfig{Endpoint: "http://test"},
+		httpClient: &http.Client{},
+	}
+	_, err := c.ExplainDecision(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error for empty decision ID")
+	}
+	if !strings.Contains(err.Error(), "required") {
+		t.Errorf("error message = %q, want substring 'required'", err.Error())
+	}
+}
+
+func TestExplainDecision_HappyPath(t *testing.T) {
+	want := DecisionExplanation{
+		DecisionID: "dec_wf1_step2",
+		Timestamp:  time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC),
+		Decision:   "deny",
+		Reason:     "SQL injection detected",
+		RiskLevel:  "high",
+		PolicyMatches: []ExplainPolicy{
+			{
+				PolicyID:      "pol-sqli",
+				PolicyName:    "SQL Injection Detector",
+				Action:        "deny",
+				RiskLevel:     "high",
+				AllowOverride: true,
+			},
+		},
+		OverrideAvailable:         true,
+		HistoricalHitCountSession: 3,
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("Method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/v1/decisions/dec_wf1_step2/explain" {
+			t.Errorf("Path = %q, want '/api/v1/decisions/dec_wf1_step2/explain'", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(want)
+	}))
+	defer srv.Close()
+
+	c := &AxonFlowClient{
+		config:     AxonFlowConfig{Endpoint: srv.URL},
+		httpClient: srv.Client(),
+	}
+	got, err := c.ExplainDecision(context.Background(), "dec_wf1_step2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.DecisionID != want.DecisionID {
+		t.Errorf("DecisionID = %q, want %q", got.DecisionID, want.DecisionID)
+	}
+	if got.Decision != "deny" {
+		t.Errorf("Decision = %q, want 'deny'", got.Decision)
+	}
+	if len(got.PolicyMatches) != 1 {
+		t.Fatalf("PolicyMatches length = %d, want 1", len(got.PolicyMatches))
+	}
+	if got.PolicyMatches[0].PolicyID != "pol-sqli" {
+		t.Errorf("PolicyMatches[0].PolicyID = %q", got.PolicyMatches[0].PolicyID)
+	}
+	if !got.OverrideAvailable {
+		t.Error("OverrideAvailable = false, want true")
+	}
+	if got.HistoricalHitCountSession != 3 {
+		t.Errorf("HistoricalHitCountSession = %d, want 3", got.HistoricalHitCountSession)
+	}
+}
+
+func TestExplainDecision_404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"Decision not found"}`))
+	}))
+	defer srv.Close()
+
+	c := &AxonFlowClient{
+		config:     AxonFlowConfig{Endpoint: srv.URL},
+		httpClient: srv.Client(),
+	}
+	_, err := c.ExplainDecision(context.Background(), "dec-missing")
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+}
+
+func TestExplainDecision_MalformedResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{not valid json`))
+	}))
+	defer srv.Close()
+
+	c := &AxonFlowClient{
+		config:     AxonFlowConfig{Endpoint: srv.URL},
+		httpClient: srv.Client(),
+	}
+	_, err := c.ExplainDecision(context.Background(), "dec-x")
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+func TestExplainDecision_ContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-time.After(500 * time.Millisecond):
+			w.WriteHeader(200)
+		}
+	}))
+	defer srv.Close()
+
+	c := &AxonFlowClient{
+		config:     AxonFlowConfig{Endpoint: srv.URL},
+		httpClient: srv.Client(),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := c.ExplainDecision(ctx, "dec-x")
+	if err == nil {
+		t.Fatal("expected error from context cancellation")
+	}
+}
+
+func TestAuditSearchRequest_NewFiltersSerialize(t *testing.T) {
+	// Confirm the three new filters serialize correctly in JSON.
+	req := AuditSearchRequest{
+		DecisionID: "dec-abc",
+		PolicyName: "SQL Injection Detector",
+		OverrideID: "ov-xyz",
+		Limit:      50,
+	}
+	b, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	for _, want := range []string{`"decision_id":"dec-abc"`, `"policy_name":"SQL Injection Detector"`, `"override_id":"ov-xyz"`} {
+		if !strings.Contains(s, want) {
+			t.Errorf("serialized JSON missing %q: %s", want, s)
+		}
+	}
+}

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package axonflow
 
 // Version is the SDK version.
-const Version = "5.4.0"
+const Version = "5.5.0"

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package axonflow
 
 // Version is the SDK version.
-const Version = "5.5.0"
+const Version = "5.4.0"


### PR DESCRIPTION
## Summary

Go SDK half of Plugin Batch 1 (ADR-042 + ADR-043). Adds `ExplainDecision` and three new audit-search filters.

Companion to:
- Platform v7.1.0 — axonflow-enterprise PR #1605
- Python v6.4.0, TypeScript v5.4.0, Java v5.4.0 (filed separately)
- OpenClaw v1.3.0, Claude Code v0.5.0, Cursor v0.5.0, Codex v0.4.0 (follow-up)

## Added

- `ExplainDecision(ctx, decisionID) (*DecisionExplanation, error)` — fetches full decision explanation. Frozen shape per ADR-043.
- `DecisionExplanation`, `ExplainPolicy`, `ExplainRule` types.
- `AuditSearchRequest.DecisionID`, `.PolicyName`, `.OverrideID` filter fields.

## Version: 5.3.1 → 5.4.0

## Tests

6 new unit tests, all passing:
- required-decision-id validation
- happy path (full JSON round-trip via httptest)
- 404 response
- malformed JSON response
- context cancellation / timeout
- audit search request serialization of new filters

Full test suite green (`go test ./...`).

## Test plan

- [ ] Against a platform on v7.1.0: create a decision, call `ExplainDecision`, confirm full payload.
- [ ] Against a platform on 7.0.x (old): call `SearchAuditLogs` with new filters — confirm pass-through works (filters ignored server-side, existing filters still apply).