### PR TITLE
feat(wcp): retry_context + idempotency_key (#1673 P1+P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [5.5.0] - 2026-04-21
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`retry_context` and `idempotency_key` support on the step gate** — `StepGateResponse`
+  now carries a non-nullable `RetryContext` object on every gate call with the true
+  `(workflow_id, step_id)` lifecycle: `GateCount`, `CompletionCount`,
+  `PriorCompletionStatus` (`"none"` / `"completed"` / `"gated_not_completed"`),
+  `PriorOutputAvailable`, `PriorOutput`, `PriorCompletionAt`, `FirstAttemptAt`,
+  `LastAttemptAt`, `LastDecision`, and `IdempotencyKey`. Prefer these to the legacy
+  `Cached` / `DecisionSource` fields.
+- **`StepGateWithOptions`** — new method taking `StepGateOptions{IncludePriorOutput: bool}`
+  (default `false`). When `true`, the SDK sends `?include_prior_output=true` and
+  `RetryContext.PriorOutput` is populated when a prior `/complete` has landed. Existing
+  `StepGate(workflowID, stepID, req)` is unchanged and calls `StepGateWithOptions` with
+  zero options, so existing callers keep working.
+- **`StepGateRequest.IdempotencyKey`** — caller-supplied opaque business-level key
+  (max 255 chars). Immutable once recorded on the first gate call for a
+  `(workflow_id, step_id)`; subsequent gate/complete calls must pass the same key.
+- **`MarkStepCompletedRequest.IdempotencyKey`** — must match the key set on the
+  corresponding gate call, if any. Mismatch (including missing-vs-set on either side)
+  surfaces as a typed `*IdempotencyKeyMismatchError`.
+- **`IdempotencyKeyMismatchError`** — typed error returned by `StepGate`,
+  `StepGateWithOptions`, and `MarkStepCompleted` when the platform returns HTTP 409
+  with `error.code == "IDEMPOTENCY_KEY_MISMATCH"`. Surfaces `WorkflowID`, `StepID`,
+  `ExpectedIdempotencyKey`, `ReceivedIdempotencyKey`, and `Message`. Use
+  `errors.As(err, &idemErr)` to unwrap.
+
+### Deprecated
+
+- **`StepGateResponse.Cached`** and **`StepGateResponse.DecisionSource`** — still populated
+  but deprecated in favor of `RetryContext.GateCount > 1` and
+  `RetryContext.PriorCompletionStatus`. Planned for removal in a future major version.
+
+### Compatibility
+
+Companion to the platform change that introduces `retry_context` on
+`POST /api/v1/workflows/{workflow_id}/steps/{step_id}/gate`. Additive only — existing
+callers that never set `IdempotencyKey` or `IncludePriorOutput` see no behavior change.
+
 ## [5.4.0] - 2026-04-18
 
 ### Added

--- a/examples/wcp-retry-idempotency/.gitignore
+++ b/examples/wcp-retry-idempotency/.gitignore
@@ -1,0 +1,1 @@
+wcp-retry-idempotency

--- a/examples/wcp-retry-idempotency/go.mod
+++ b/examples/wcp-retry-idempotency/go.mod
@@ -1,0 +1,7 @@
+module github.com/getaxonflow/axonflow-sdk-go/v5/examples/wcp-retry-idempotency
+
+go 1.23
+
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.0.0
+
+replace github.com/getaxonflow/axonflow-sdk-go/v5 => ../..

--- a/examples/wcp-retry-idempotency/main.go
+++ b/examples/wcp-retry-idempotency/main.go
@@ -1,0 +1,192 @@
+// Copyright 2026 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Go SDK example for Issue #1673 Phase 1 (retry_context) + Phase 2
+// (idempotency_key). Exercises the full feature set end-to-end through the
+// SDK against a running enterprise stack.
+//
+// Usage:
+//   source /tmp/axonflow-e2e-env.sh
+//   export AXONFLOW_BASE_URL=http://localhost:8080
+//   go run main.go
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	axonflow "github.com/getaxonflow/axonflow-sdk-go/v5"
+)
+
+func main() {
+	endpoint := envOrDefault("AXONFLOW_BASE_URL", "http://localhost:8080")
+	clientID := mustEnv("AXONFLOW_CLIENT_ID")
+	clientSecret := mustEnv("AXONFLOW_CLIENT_SECRET")
+
+	client := axonflow.NewClient(axonflow.AxonFlowConfig{
+		Endpoint:     endpoint,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+	})
+
+	banner("Act 1 — retry_context (Go SDK)")
+	act1(client)
+
+	banner("Act 2 — idempotency_key (Go SDK)")
+	act2(client)
+
+	banner("All assertions passed ✔")
+}
+
+func act1(c *axonflow.AxonFlowClient) {
+	wf, err := c.CreateWorkflow(axonflow.CreateWorkflowRequest{
+		WorkflowName: "go-sdk-retry-context",
+	})
+	must(err, "create workflow")
+	fmt.Printf("workflow: %s\n", wf.WorkflowID)
+
+	// 1) First gate — first-call invariants
+	resp, err := c.StepGate(wf.WorkflowID, "step-1", axonflow.StepGateRequest{
+		StepName: "first-step",
+		StepType: axonflow.StepTypeToolCall,
+	})
+	must(err, "first gate")
+	assertEqInt("first gate_count", 1, resp.RetryContext.GateCount)
+	assertEqInt("first completion_count", 0, resp.RetryContext.CompletionCount)
+	assertEqStr("first prior_completion_status", "none", string(resp.RetryContext.PriorCompletionStatus))
+	assertTrue("first !PriorOutputAvailable", !resp.RetryContext.PriorOutputAvailable)
+	assertEqStr("first last_decision (first-call invariant)", string(resp.Decision), string(resp.RetryContext.LastDecision))
+	assertTrue("first FirstAttemptAt == LastAttemptAt", resp.RetryContext.FirstAttemptAt.Equal(resp.RetryContext.LastAttemptAt))
+	fmt.Println("  first gate invariants ✔")
+
+	// 2) Complete, then re-gate (cached path)
+	out := map[string]interface{}{"transfer_id": "TXN-go-1", "amount": 500.0}
+	must(c.MarkStepCompleted(wf.WorkflowID, "step-1", &axonflow.MarkStepCompletedRequest{Output: out}), "complete")
+	resp, err = c.StepGate(wf.WorkflowID, "step-1", axonflow.StepGateRequest{StepType: axonflow.StepTypeToolCall})
+	must(err, "re-gate post-complete")
+	assertEqInt("re-gate post-complete gate_count", 2, resp.RetryContext.GateCount)
+	assertEqInt("re-gate post-complete completion_count", 1, resp.RetryContext.CompletionCount)
+	assertEqStr("re-gate post-complete prior_completion_status", "completed", string(resp.RetryContext.PriorCompletionStatus))
+	assertTrue("re-gate post-complete PriorOutputAvailable", resp.RetryContext.PriorOutputAvailable)
+	assertTrue("re-gate post-complete PriorOutput omitted by default", resp.RetryContext.PriorOutput == nil)
+	assertTrue("re-gate post-complete Cached==true", resp.Cached)
+	fmt.Println("  re-gate post-complete ✔")
+
+	// 3) Gate on step-2 without completion (agent crash simulation)
+	_, err = c.StepGate(wf.WorkflowID, "step-2", axonflow.StepGateRequest{
+		StepName: "second-step", StepType: axonflow.StepTypeToolCall,
+	})
+	must(err, "step-2 first gate")
+	resp, err = c.StepGate(wf.WorkflowID, "step-2", axonflow.StepGateRequest{StepType: axonflow.StepTypeToolCall})
+	must(err, "step-2 re-gate")
+	assertEqStr("gated_not_completed status", "gated_not_completed", string(resp.RetryContext.PriorCompletionStatus))
+	assertEqInt("gated_not_completed completion_count", 0, resp.RetryContext.CompletionCount)
+	fmt.Println("  gated_not_completed ✔")
+
+	// 4) include_prior_output=true recovers the payload
+	resp, err = c.StepGateWithOptions(wf.WorkflowID, "step-1",
+		axonflow.StepGateRequest{StepType: axonflow.StepTypeToolCall},
+		axonflow.StepGateOptions{IncludePriorOutput: true},
+	)
+	must(err, "re-gate with include_prior_output")
+	assertTrue("PriorOutput populated", resp.RetryContext.PriorOutput != nil)
+	assertEqStr("PriorOutput[transfer_id]", "TXN-go-1", fmt.Sprint(resp.RetryContext.PriorOutput["transfer_id"]))
+	fmt.Println("  prior_output recovery ✔")
+}
+
+func act2(c *axonflow.AxonFlowClient) {
+	wf, err := c.CreateWorkflow(axonflow.CreateWorkflowRequest{
+		WorkflowName: "go-sdk-idempotency-key",
+	})
+	must(err, "create workflow")
+	fmt.Printf("workflow: %s\n", wf.WorkflowID)
+
+	originalKey := "payment:wire:go-sdk-invoice-1"
+
+	// 5) Gate with key — retry_context.idempotency_key echoes
+	resp, err := c.StepGate(wf.WorkflowID, "step-1", axonflow.StepGateRequest{
+		StepName: "wire", StepType: axonflow.StepTypeToolCall,
+		IdempotencyKey: originalKey,
+	})
+	must(err, "gate 1 with key")
+	assertEqStr("retry_context.idempotency_key echo", originalKey, resp.RetryContext.IdempotencyKey)
+	fmt.Println("  key round-trip ✔")
+
+	// 6) Re-gate with different key → IdempotencyKeyMismatchError
+	_, err = c.StepGate(wf.WorkflowID, "step-1", axonflow.StepGateRequest{
+		StepType: axonflow.StepTypeToolCall, IdempotencyKey: "payment:wire:different-2",
+	})
+	if err == nil {
+		fail("expected IdempotencyKeyMismatchError on gate with different key")
+	}
+	var mismatch *axonflow.IdempotencyKeyMismatchError
+	if !errors.As(err, &mismatch) {
+		fail(fmt.Sprintf("expected *IdempotencyKeyMismatchError, got %T: %v", err, err))
+	}
+	assertEqStr("mismatch expected_key", originalKey, mismatch.ExpectedIdempotencyKey)
+	assertEqStr("mismatch received_key", "payment:wire:different-2", mismatch.ReceivedIdempotencyKey)
+	assertTrue("mismatch workflow_id populated", strings.HasPrefix(mismatch.WorkflowID, "wf_"))
+	assertEqStr("mismatch step_id", "step-1", mismatch.StepID)
+	fmt.Println("  typed 409 error ✔")
+
+	// 7) Complete with matching key → success
+	must(c.MarkStepCompleted(wf.WorkflowID, "step-1", &axonflow.MarkStepCompletedRequest{
+		Output:         map[string]interface{}{"transfer_id": "TXN-K1"},
+		IdempotencyKey: originalKey,
+	}), "complete with matching key")
+	fmt.Println("  complete with matching key ✔")
+}
+
+// --- helpers ---
+
+func envOrDefault(k, d string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return d
+}
+
+func mustEnv(k string) string {
+	v := os.Getenv(k)
+	if v == "" {
+		fail("missing env: " + k)
+	}
+	return v
+}
+
+func must(err error, label string) {
+	if err != nil {
+		fail(label + ": " + err.Error())
+	}
+}
+
+func assertTrue(label string, cond bool) {
+	if !cond {
+		fail("assertion failed: " + label)
+	}
+}
+
+func assertEqStr(label, want, got string) {
+	if want != got {
+		fail(fmt.Sprintf("%s: want %q, got %q", label, want, got))
+	}
+}
+
+func assertEqInt(label string, want, got int) {
+	if want != got {
+		fail(fmt.Sprintf("%s: want %d, got %d", label, want, got))
+	}
+}
+
+func fail(msg string) {
+	fmt.Fprintln(os.Stderr, "FAIL: "+msg)
+	os.Exit(1)
+}
+
+func banner(s string) {
+	fmt.Println()
+	fmt.Println("━━━", s, "━━━")
+}

--- a/retry_context.go
+++ b/retry_context.go
@@ -1,0 +1,136 @@
+package axonflow
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// PriorCompletionStatus reports the state of the prior gate+complete cycle for a step.
+type PriorCompletionStatus string
+
+const (
+	// PriorCompletionStatusNone is returned on the first gate call for a step.
+	PriorCompletionStatusNone PriorCompletionStatus = "none"
+
+	// PriorCompletionStatusCompleted is returned when a prior gate call and a prior /complete
+	// both landed for this (workflow_id, step_id).
+	PriorCompletionStatusCompleted PriorCompletionStatus = "completed"
+
+	// PriorCompletionStatusGatedNotCompleted is returned when a prior gate call landed
+	// but no /complete has followed yet for this (workflow_id, step_id).
+	PriorCompletionStatusGatedNotCompleted PriorCompletionStatus = "gated_not_completed"
+)
+
+// RetryContext is the first-class state signal returned on every StepGateResponse.
+// It replaces the ambiguous `cached: bool` flag; callers should migrate off `Cached`
+// and `DecisionSource` to RetryContext fields.
+type RetryContext struct {
+	// GateCount is the number of times /gate has been called for this (workflow_id, step_id),
+	// including the current call. First call returns 1. Always >= 1.
+	GateCount int `json:"gate_count"`
+
+	// CompletionCount is the number of times /complete has been successfully called
+	// for this (workflow_id, step_id). Typically 0 on first gate call, 1 after the step completes.
+	CompletionCount int `json:"completion_count"`
+
+	// PriorCompletionStatus reports whether a prior gate+complete cycle has landed.
+	PriorCompletionStatus PriorCompletionStatus `json:"prior_completion_status"`
+
+	// PriorOutputAvailable is true iff PriorCompletionStatus == PriorCompletionStatusCompleted.
+	// Mirrors whether PriorOutput *could* be returned if the caller opts in with
+	// StepGateOptions.IncludePriorOutput.
+	PriorOutputAvailable bool `json:"prior_output_available"`
+
+	// PriorOutput is the output from the prior /complete, or nil. Non-nil only when the gate
+	// call set StepGateOptions.IncludePriorOutput == true AND PriorCompletionStatus == PriorCompletionStatusCompleted.
+	PriorOutput map[string]interface{} `json:"prior_output"`
+
+	// PriorCompletionAt is the timestamp of the prior /complete, if any.
+	PriorCompletionAt *time.Time `json:"prior_completion_at"`
+
+	// FirstAttemptAt is the timestamp of the first gate call for this (workflow_id, step_id).
+	// On the first call, equals LastAttemptAt.
+	FirstAttemptAt time.Time `json:"first_attempt_at"`
+
+	// LastAttemptAt is the timestamp of the current gate call (the one that produced this response).
+	LastAttemptAt time.Time `json:"last_attempt_at"`
+
+	// LastDecision is the decision of the immediately prior gate call. On the first call
+	// (GateCount == 1), equals the current call's Decision field.
+	LastDecision GateDecision `json:"last_decision"`
+
+	// IdempotencyKey is the key the caller set on this step (from the first gate call that
+	// supplied one), or empty string if the caller never supplied one. Once set, it is immutable.
+	IdempotencyKey string `json:"idempotency_key"`
+}
+
+// IdempotencyKeyMismatchError is returned when a /gate or /complete request supplies an
+// idempotency_key that conflicts with the key recorded on an earlier gate call for the same
+// (workflow_id, step_id). Maps to HTTP 409 with error.code == "IDEMPOTENCY_KEY_MISMATCH".
+type IdempotencyKeyMismatchError struct {
+	// Message is the human-readable error message from the platform.
+	Message string
+
+	// WorkflowID is the workflow ID on which the mismatch occurred.
+	WorkflowID string
+
+	// StepID is the step ID on which the mismatch occurred.
+	StepID string
+
+	// ExpectedIdempotencyKey is the key recorded on the first gate call. Empty string
+	// if the gate call had no key but /complete did.
+	ExpectedIdempotencyKey string
+
+	// ReceivedIdempotencyKey is the key supplied on the current request. Empty string
+	// if /complete omitted a key that gate had set.
+	ReceivedIdempotencyKey string
+}
+
+func (e *IdempotencyKeyMismatchError) Error() string {
+	return fmt.Sprintf("idempotency_key mismatch on workflow=%s step=%s: expected=%q received=%q: %s",
+		e.WorkflowID, e.StepID, e.ExpectedIdempotencyKey, e.ReceivedIdempotencyKey, e.Message)
+}
+
+// parseIdempotencyKeyMismatch returns a typed *IdempotencyKeyMismatchError if err wraps
+// a 409 response with error.code == "IDEMPOTENCY_KEY_MISMATCH", otherwise nil.
+func parseIdempotencyKeyMismatch(err error) *IdempotencyKeyMismatchError {
+	if err == nil {
+		return nil
+	}
+	var httpErr *httpError
+	if !errors.As(err, &httpErr) {
+		return nil
+	}
+	if httpErr.statusCode != 409 {
+		return nil
+	}
+
+	var envelope struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+			Details struct {
+				WorkflowID             string `json:"workflow_id"`
+				StepID                 string `json:"step_id"`
+				ExpectedIdempotencyKey string `json:"expected_idempotency_key"`
+				ReceivedIdempotencyKey string `json:"received_idempotency_key"`
+			} `json:"details"`
+		} `json:"error"`
+	}
+	if jerr := json.Unmarshal([]byte(httpErr.message), &envelope); jerr != nil {
+		return nil
+	}
+	if envelope.Error.Code != "IDEMPOTENCY_KEY_MISMATCH" {
+		return nil
+	}
+
+	return &IdempotencyKeyMismatchError{
+		Message:                envelope.Error.Message,
+		WorkflowID:             envelope.Error.Details.WorkflowID,
+		StepID:                 envelope.Error.Details.StepID,
+		ExpectedIdempotencyKey: envelope.Error.Details.ExpectedIdempotencyKey,
+		ReceivedIdempotencyKey: envelope.Error.Details.ReceivedIdempotencyKey,
+	}
+}

--- a/retry_context_test.go
+++ b/retry_context_test.go
@@ -1,0 +1,400 @@
+package axonflow
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// Test a: First-call response shape.
+// gate_count == 1, prior_completion_status == "none", first_attempt_at == last_attempt_at,
+// last_decision == decision.
+func TestStepGate_RetryContext_FirstCall(t *testing.T) {
+	now := "2026-04-21T15:30:45.123Z"
+	resp := map[string]interface{}{
+		"decision":        "allow",
+		"step_id":         "step_1",
+		"cached":          false,
+		"decision_source": "fresh",
+		"retry_context": map[string]interface{}{
+			"gate_count":              1,
+			"completion_count":        0,
+			"prior_completion_status": "none",
+			"prior_output_available":  false,
+			"prior_output":            nil,
+			"prior_completion_at":     nil,
+			"first_attempt_at":        now,
+			"last_attempt_at":         now,
+			"last_decision":           "allow",
+			"idempotency_key":         "",
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.RawQuery; got != "" {
+			t.Errorf("Expected no query params on default gate, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL, ClientID: "t"})
+
+	gate, err := client.StepGate("wf_1", "step_1", StepGateRequest{StepType: StepTypeLLMCall})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	rc := gate.RetryContext
+	if rc.GateCount != 1 {
+		t.Errorf("GateCount = %d, want 1", rc.GateCount)
+	}
+	if rc.CompletionCount != 0 {
+		t.Errorf("CompletionCount = %d, want 0", rc.CompletionCount)
+	}
+	if rc.PriorCompletionStatus != PriorCompletionStatusNone {
+		t.Errorf("PriorCompletionStatus = %q, want %q", rc.PriorCompletionStatus, PriorCompletionStatusNone)
+	}
+	if rc.PriorOutputAvailable {
+		t.Errorf("PriorOutputAvailable = true, want false")
+	}
+	if rc.PriorOutput != nil {
+		t.Errorf("PriorOutput = %v, want nil", rc.PriorOutput)
+	}
+	if rc.PriorCompletionAt != nil {
+		t.Errorf("PriorCompletionAt = %v, want nil", rc.PriorCompletionAt)
+	}
+	if !rc.FirstAttemptAt.Equal(rc.LastAttemptAt) {
+		t.Errorf("FirstAttemptAt (%s) != LastAttemptAt (%s) on first call", rc.FirstAttemptAt, rc.LastAttemptAt)
+	}
+	if rc.LastDecision != GateDecisionAllow {
+		t.Errorf("LastDecision = %q, want %q on first call", rc.LastDecision, GateDecisionAllow)
+	}
+	if rc.IdempotencyKey != "" {
+		t.Errorf("IdempotencyKey = %q, want empty", rc.IdempotencyKey)
+	}
+}
+
+// Test b: Second-call after completion.
+// gate_count == 2, completion_count == 1, prior_completion_status == "completed",
+// prior_output_available == true.
+func TestStepGate_RetryContext_SecondCallAfterCompletion(t *testing.T) {
+	first := "2026-04-21T15:30:00.000Z"
+	now := "2026-04-21T15:31:00.000Z"
+	completedAt := "2026-04-21T15:30:30.000Z"
+	resp := map[string]interface{}{
+		"decision": "allow",
+		"step_id":  "step_1",
+		"retry_context": map[string]interface{}{
+			"gate_count":              2,
+			"completion_count":        1,
+			"prior_completion_status": "completed",
+			"prior_output_available":  true,
+			"prior_output":            nil,
+			"prior_completion_at":     completedAt,
+			"first_attempt_at":        first,
+			"last_attempt_at":         now,
+			"last_decision":           "allow",
+			"idempotency_key":         "",
+		},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL, ClientID: "t"})
+	gate, err := client.StepGate("wf_1", "step_1", StepGateRequest{StepType: StepTypeLLMCall})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	rc := gate.RetryContext
+	if rc.GateCount != 2 {
+		t.Errorf("GateCount = %d, want 2", rc.GateCount)
+	}
+	if rc.CompletionCount != 1 {
+		t.Errorf("CompletionCount = %d, want 1", rc.CompletionCount)
+	}
+	if rc.PriorCompletionStatus != PriorCompletionStatusCompleted {
+		t.Errorf("PriorCompletionStatus = %q, want %q", rc.PriorCompletionStatus, PriorCompletionStatusCompleted)
+	}
+	if !rc.PriorOutputAvailable {
+		t.Errorf("PriorOutputAvailable = false, want true")
+	}
+	if rc.PriorCompletionAt == nil {
+		t.Fatal("PriorCompletionAt = nil, want non-nil")
+	}
+	if rc.FirstAttemptAt.Equal(rc.LastAttemptAt) {
+		t.Errorf("FirstAttemptAt should differ from LastAttemptAt on second call")
+	}
+}
+
+// Test c: Second-call without completion.
+// gate_count == 2, completion_count == 0, prior_completion_status == "gated_not_completed",
+// prior_output_available == false.
+func TestStepGate_RetryContext_SecondCallWithoutCompletion(t *testing.T) {
+	resp := map[string]interface{}{
+		"decision": "allow",
+		"step_id":  "step_1",
+		"retry_context": map[string]interface{}{
+			"gate_count":              2,
+			"completion_count":        0,
+			"prior_completion_status": "gated_not_completed",
+			"prior_output_available":  false,
+			"prior_output":            nil,
+			"prior_completion_at":     nil,
+			"first_attempt_at":        "2026-04-21T15:30:00.000Z",
+			"last_attempt_at":         "2026-04-21T15:31:00.000Z",
+			"last_decision":           "allow",
+			"idempotency_key":         "",
+		},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL, ClientID: "t"})
+	gate, err := client.StepGate("wf_1", "step_1", StepGateRequest{StepType: StepTypeLLMCall})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	rc := gate.RetryContext
+	if rc.GateCount != 2 {
+		t.Errorf("GateCount = %d, want 2", rc.GateCount)
+	}
+	if rc.CompletionCount != 0 {
+		t.Errorf("CompletionCount = %d, want 0", rc.CompletionCount)
+	}
+	if rc.PriorCompletionStatus != PriorCompletionStatusGatedNotCompleted {
+		t.Errorf("PriorCompletionStatus = %q, want %q", rc.PriorCompletionStatus, PriorCompletionStatusGatedNotCompleted)
+	}
+	if rc.PriorOutputAvailable {
+		t.Errorf("PriorOutputAvailable = true, want false")
+	}
+	if rc.PriorCompletionAt != nil {
+		t.Errorf("PriorCompletionAt = %v, want nil", rc.PriorCompletionAt)
+	}
+}
+
+// Test d: include_prior_output=true populates prior_output when available.
+func TestStepGate_IncludePriorOutput_QueryParamAndPayload(t *testing.T) {
+	priorOutput := map[string]interface{}{"result": "ok", "score": 0.92}
+	var gotIncludeFlag bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotIncludeFlag = r.URL.Query().Get("include_prior_output") == "true"
+		payload := map[string]interface{}{
+			"decision": "allow",
+			"step_id":  "step_1",
+			"retry_context": map[string]interface{}{
+				"gate_count":              2,
+				"completion_count":        1,
+				"prior_completion_status": "completed",
+				"prior_output_available":  true,
+				"prior_output":            priorOutput,
+				"prior_completion_at":     "2026-04-21T15:30:30.000Z",
+				"first_attempt_at":        "2026-04-21T15:30:00.000Z",
+				"last_attempt_at":         "2026-04-21T15:31:00.000Z",
+				"last_decision":           "allow",
+				"idempotency_key":         "",
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL, ClientID: "t"})
+
+	gate, err := client.StepGateWithOptions(
+		"wf_1", "step_1",
+		StepGateRequest{StepType: StepTypeLLMCall},
+		StepGateOptions{IncludePriorOutput: true},
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !gotIncludeFlag {
+		t.Error("Expected include_prior_output=true to be sent on query string")
+	}
+	if gate.RetryContext.PriorOutput == nil {
+		t.Fatal("Expected prior_output to be populated, got nil")
+	}
+	if got, ok := gate.RetryContext.PriorOutput["result"].(string); !ok || got != "ok" {
+		t.Errorf("Expected prior_output.result = \"ok\", got %v", gate.RetryContext.PriorOutput["result"])
+	}
+}
+
+// Test e: Idempotency key round-trip — pass on gate, echoed on retry_context.idempotency_key,
+// same key required on /complete.
+func TestStepGate_IdempotencyKey_RoundTrip(t *testing.T) {
+	const key = "payment:wire:acct4471:invoice-7721"
+	var gotGateKey, gotCompleteKey string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/workflows/wf_1/steps/step_1/gate", func(w http.ResponseWriter, r *http.Request) {
+		var req StepGateRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("Failed to decode gate request: %v", err)
+		}
+		gotGateKey = req.IdempotencyKey
+		payload := map[string]interface{}{
+			"decision": "allow",
+			"step_id":  "step_1",
+			"retry_context": map[string]interface{}{
+				"gate_count":              1,
+				"completion_count":        0,
+				"prior_completion_status": "none",
+				"prior_output_available":  false,
+				"prior_output":            nil,
+				"prior_completion_at":     nil,
+				"first_attempt_at":        "2026-04-21T15:30:00.000Z",
+				"last_attempt_at":         "2026-04-21T15:30:00.000Z",
+				"last_decision":           "allow",
+				"idempotency_key":         key,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	})
+	mux.HandleFunc("/api/v1/workflows/wf_1/steps/step_1/complete", func(w http.ResponseWriter, r *http.Request) {
+		var req MarkStepCompletedRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("Failed to decode complete request: %v", err)
+		}
+		gotCompleteKey = req.IdempotencyKey
+		w.WriteHeader(http.StatusOK)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL, ClientID: "t"})
+
+	gate, err := client.StepGate("wf_1", "step_1", StepGateRequest{
+		StepType:       StepTypeLLMCall,
+		IdempotencyKey: key,
+	})
+	if err != nil {
+		t.Fatalf("Unexpected gate error: %v", err)
+	}
+	if gotGateKey != key {
+		t.Errorf("Gate request idempotency_key = %q, want %q", gotGateKey, key)
+	}
+	if gate.RetryContext.IdempotencyKey != key {
+		t.Errorf("Response retry_context.idempotency_key = %q, want %q", gate.RetryContext.IdempotencyKey, key)
+	}
+
+	if err := client.MarkStepCompleted("wf_1", "step_1", &MarkStepCompletedRequest{
+		Output:         map[string]interface{}{"ok": true},
+		IdempotencyKey: key,
+	}); err != nil {
+		t.Fatalf("Unexpected complete error: %v", err)
+	}
+	if gotCompleteKey != key {
+		t.Errorf("Complete request idempotency_key = %q, want %q", gotCompleteKey, key)
+	}
+}
+
+// Test f: 409 IDEMPOTENCY_KEY_MISMATCH maps to typed *IdempotencyKeyMismatchError.
+func TestMarkStepCompleted_IdempotencyMismatch_TypedError(t *testing.T) {
+	body := `{
+      "error": {
+        "code": "IDEMPOTENCY_KEY_MISMATCH",
+        "message": "idempotency_key on complete does not match the key recorded on gate",
+        "details": {
+          "workflow_id": "wf_41231a72",
+          "step_id": "step-2",
+          "expected_idempotency_key": "payment:wire:acct4471:invoice-7721",
+          "received_idempotency_key": "payment:wire:acct4471:invoice-9999"
+        }
+      }
+    }`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL, ClientID: "t"})
+
+	err := client.MarkStepCompleted("wf_41231a72", "step-2", &MarkStepCompletedRequest{
+		IdempotencyKey: "payment:wire:acct4471:invoice-9999",
+	})
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	var idemErr *IdempotencyKeyMismatchError
+	if !errors.As(err, &idemErr) {
+		t.Fatalf("Expected *IdempotencyKeyMismatchError, got %T: %v", err, err)
+	}
+	if idemErr.WorkflowID != "wf_41231a72" {
+		t.Errorf("WorkflowID = %q, want wf_41231a72", idemErr.WorkflowID)
+	}
+	if idemErr.StepID != "step-2" {
+		t.Errorf("StepID = %q, want step-2", idemErr.StepID)
+	}
+	if idemErr.ExpectedIdempotencyKey != "payment:wire:acct4471:invoice-7721" {
+		t.Errorf("ExpectedIdempotencyKey = %q", idemErr.ExpectedIdempotencyKey)
+	}
+	if idemErr.ReceivedIdempotencyKey != "payment:wire:acct4471:invoice-9999" {
+		t.Errorf("ReceivedIdempotencyKey = %q", idemErr.ReceivedIdempotencyKey)
+	}
+}
+
+// Also surface 409 on the gate call path.
+func TestStepGate_IdempotencyMismatch_TypedError(t *testing.T) {
+	body := `{"error":{"code":"IDEMPOTENCY_KEY_MISMATCH","message":"mismatch","details":{"workflow_id":"wf_1","step_id":"s1","expected_idempotency_key":"a","received_idempotency_key":"b"}}}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL, ClientID: "t"})
+	_, err := client.StepGate("wf_1", "s1", StepGateRequest{
+		StepType:       StepTypeLLMCall,
+		IdempotencyKey: "b",
+	})
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+	var idemErr *IdempotencyKeyMismatchError
+	if !errors.As(err, &idemErr) {
+		t.Fatalf("Expected *IdempotencyKeyMismatchError, got %T: %v", err, err)
+	}
+	if idemErr.ExpectedIdempotencyKey != "a" || idemErr.ReceivedIdempotencyKey != "b" {
+		t.Errorf("unexpected keys: expected=%q received=%q", idemErr.ExpectedIdempotencyKey, idemErr.ReceivedIdempotencyKey)
+	}
+}
+
+// Sanity: ensure timestamps round-trip to time.Time as expected.
+func TestRetryContext_TimestampsDecodeToTime(t *testing.T) {
+	raw := `{
+      "gate_count": 1,
+      "completion_count": 0,
+      "prior_completion_status": "none",
+      "prior_output_available": false,
+      "prior_output": null,
+      "prior_completion_at": null,
+      "first_attempt_at": "2026-04-21T15:30:45.123Z",
+      "last_attempt_at": "2026-04-21T15:30:45.123Z",
+      "last_decision": "allow",
+      "idempotency_key": ""
+    }`
+	var rc RetryContext
+	if err := json.Unmarshal([]byte(raw), &rc); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	want, _ := time.Parse(time.RFC3339Nano, "2026-04-21T15:30:45.123Z")
+	if !rc.FirstAttemptAt.Equal(want) {
+		t.Errorf("FirstAttemptAt = %v, want %v", rc.FirstAttemptAt, want)
+	}
+}

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package axonflow
 
 // Version is the SDK version.
-const Version = "5.4.0"
+const Version = "5.5.0"

--- a/workflows.go
+++ b/workflows.go
@@ -170,6 +170,20 @@ type StepGateRequest struct {
 	// RetryPolicy controls behavior on repeated calls for the same (workflow_id, step_id).
 	// Default (empty or "idempotent"): return cached decision. "reevaluate": force fresh evaluation.
 	RetryPolicy RetryPolicy `json:"retry_policy,omitempty"`
+
+	// IdempotencyKey is a caller-supplied opaque business-level key (max 255 chars).
+	// Once set on the first gate call for a (workflow_id, step_id), it is immutable —
+	// subsequent gate/complete calls must pass the same key or receive IdempotencyKeyMismatchError.
+	// The key is echoed on RetryContext.IdempotencyKey in every subsequent gate response.
+	IdempotencyKey string `json:"idempotency_key,omitempty"`
+}
+
+// StepGateOptions controls gate-call behavior that lives outside the request body.
+type StepGateOptions struct {
+	// IncludePriorOutput opts into populating RetryContext.PriorOutput on the
+	// response when a prior /complete exists. Default false because prior output
+	// may be large and/or contain sensitive data. Sent as ?include_prior_output=true.
+	IncludePriorOutput bool
 }
 
 // StepGateResponse is the response from a step gate check.
@@ -197,10 +211,19 @@ type StepGateResponse struct {
 
 	// Cached indicates whether this response was served from a prior decision
 	// rather than a fresh policy evaluation.
+	//
+	// Deprecated: use RetryContext.GateCount > 1 instead. Will be removed in a future major version.
 	Cached bool `json:"cached"`
 
 	// DecisionSource indicates how the decision was produced: "fresh" or "cached".
+	//
+	// Deprecated: use RetryContext.PriorCompletionStatus instead. Will be removed in a future major version.
 	DecisionSource string `json:"decision_source"`
+
+	// RetryContext is the first-class state signal for (workflow_id, step_id). Always
+	// present on every gate response, including the first call. See RetryContext for
+	// field semantics.
+	RetryContext RetryContext `json:"retry_context"`
 }
 
 // IsAllowed returns true if the step is allowed to proceed.
@@ -341,6 +364,10 @@ type MarkStepCompletedRequest struct {
 
 	// CostUSD is the estimated cost in USD for this step's LLM usage
 	CostUSD *float64 `json:"cost_usd,omitempty"`
+
+	// IdempotencyKey must match the key passed on the corresponding gate call, if any.
+	// Mismatch (including empty vs set on either side) yields IdempotencyKeyMismatchError.
+	IdempotencyKey string `json:"idempotency_key,omitempty"`
 }
 
 // CreateWorkflow creates a new workflow for governance tracking.
@@ -421,6 +448,30 @@ func (c *AxonFlowClient) GetWorkflow(workflowID string) (*WorkflowStatusResponse
 //	}
 //	// Step is allowed, proceed with execution
 func (c *AxonFlowClient) StepGate(workflowID, stepID string, req StepGateRequest) (*StepGateResponse, error) {
+	return c.StepGateWithOptions(workflowID, stepID, req, StepGateOptions{})
+}
+
+// StepGateWithOptions is StepGate with explicit call-level options (e.g. IncludePriorOutput).
+//
+// Use this variant when you need RetryContext.PriorOutput populated for retry/replay flows.
+// The opts.IncludePriorOutput flag is sent as the ?include_prior_output=true query param.
+//
+// Example:
+//
+//	gate, err := client.StepGateWithOptions("wf_123", "step-1",
+//	    StepGateRequest{StepType: StepTypeLLMCall, IdempotencyKey: "payment:wire:acct4471:invoice-7721"},
+//	    StepGateOptions{IncludePriorOutput: true})
+//	if err != nil {
+//	    var idemErr *IdempotencyKeyMismatchError
+//	    if errors.As(err, &idemErr) {
+//	        // expected_idempotency_key / received_idempotency_key available on idemErr
+//	    }
+//	    return err
+//	}
+//	if gate.RetryContext.PriorCompletionStatus == PriorCompletionStatusCompleted {
+//	    // prior result is in gate.RetryContext.PriorOutput
+//	}
+func (c *AxonFlowClient) StepGateWithOptions(workflowID, stepID string, req StepGateRequest, opts StepGateOptions) (*StepGateResponse, error) {
 	if workflowID == "" {
 		return nil, fmt.Errorf("workflow ID is required")
 	}
@@ -429,9 +480,15 @@ func (c *AxonFlowClient) StepGate(workflowID, stepID string, req StepGateRequest
 	}
 
 	fullURL := fmt.Sprintf("%s/api/v1/workflows/%s/steps/%s/gate", c.config.Endpoint, workflowID, stepID)
+	if opts.IncludePriorOutput {
+		fullURL += "?include_prior_output=true"
+	}
 	var result StepGateResponse
 
 	if err := c.makeJSONRequest(context.Background(), "POST", fullURL, req, &result); err != nil {
+		if idemErr := parseIdempotencyKeyMismatch(err); idemErr != nil {
+			return nil, idemErr
+		}
 		return nil, fmt.Errorf("failed to check step gate: %w", err)
 	}
 
@@ -632,15 +689,15 @@ func (c *AxonFlowClient) MarkStepCompleted(workflowID, stepID string, req *MarkS
 
 	fullURL := fmt.Sprintf("%s/api/v1/workflows/%s/steps/%s/complete", c.config.Endpoint, workflowID, stepID)
 
-	body := struct{}{}
+	var payload interface{} = struct{}{}
 	if req != nil {
-		if err := c.makeJSONRequest(context.Background(), "POST", fullURL, req, nil); err != nil {
-			return fmt.Errorf("failed to mark step completed: %w", err)
+		payload = req
+	}
+	if err := c.makeJSONRequest(context.Background(), "POST", fullURL, payload, nil); err != nil {
+		if idemErr := parseIdempotencyKeyMismatch(err); idemErr != nil {
+			return idemErr
 		}
-	} else {
-		if err := c.makeJSONRequest(context.Background(), "POST", fullURL, body, nil); err != nil {
-			return fmt.Errorf("failed to mark step completed: %w", err)
-		}
+		return fmt.Errorf("failed to mark step completed: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Implements the Go SDK side of the WCP retry_context + idempotency_key wire contract for [axonflow-enterprise#1673](https://github.com/getaxonflow/axonflow-enterprise/issues/1673) (Phase 1 + Phase 2). Contract: [WCP_RETRY_IDEMPOTENCY_WIRE_CONTRACT.md](https://github.com/getaxonflow/axonflow-enterprise/blob/feat/1673-retry-context-and-idempotency-key/technical-docs/WCP_RETRY_IDEMPOTENCY_WIRE_CONTRACT.md) on branch `feat/1673-retry-context-and-idempotency-key`.

- `RetryContext` type mirroring §3 (always present on `StepGateResponse`, full lifecycle fields).
- `Cached` / `DecisionSource` preserved, marked Deprecated.
- `StepGateWithOptions(StepGateOptions{IncludePriorOutput: true})` sends `?include_prior_output=true`; existing `StepGate(...)` keeps its signature.
- `IdempotencyKey` field on `StepGateRequest` and `MarkStepCompletedRequest`.
- Typed `*IdempotencyKeyMismatchError` unwraps `409 IDEMPOTENCY_KEY_MISMATCH` from either call path.
- Unit tests for all six shapes from §6.8.
- `[Unreleased]` CHANGELOG entry. **No version bump** until platform v7.3.0 tag is cut.

## Coordination

- **Do not merge before** [getaxonflow/axonflow-enterprise#1673](https://github.com/getaxonflow/axonflow-enterprise/issues/1673) platform PR merges.
- After platform merges, reconcile against final response shape (§3), build locally, and run full E2E per `E2E_EXAMPLES_TESTING_WORKFLOW.md` (CLAUDE.md hard rule #6).
- Version bump lands in this PR once platform tag is cut.

## Test plan

- [x] `go test ./...` — all existing tests still green
- [x] 8 new unit tests green (`TestStepGate_RetryContext_FirstCall`, `_SecondCallAfterCompletion`, `_SecondCallWithoutCompletion`, `TestStepGate_IncludePriorOutput_QueryParamAndPayload`, `TestStepGate_IdempotencyKey_RoundTrip`, `TestMarkStepCompleted_IdempotencyMismatch_TypedError`, `TestStepGate_IdempotencyMismatch_TypedError`, `TestRetryContext_TimestampsDecodeToTime`)
- [x] `go vet ./...` clean
- [ ] E2E against merged platform — deferred until platform PR merges
- [ ] Version bump commit — deferred until platform release tag is cut