### PR TITLE
feat: rich ApproveStep / RejectStep response types (v5.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the response comes from the MAP plan-scoped endpoint; empty on WCP responses.
   The server projects both planes through a single helper, so the same SDK types
   work across both endpoints.
+- **`GetPendingPlanApprovals`** — new client method that lists MAP-plane pending
+  approvals (`GET /api/v1/plans/approvals/pending`), the counterpart of the
+  existing `GetPendingApprovals` for the WCP plane. Accepts an optional
+  `PlanID` filter via `PendingApprovalsOptions{PlanID: "plan-abc"}` so reviewer
+  tools can scope the listing to one plan. Available on Evaluation+ licenses
+  (same tier gate as the MAP step approve/reject endpoints).
+- **`PendingApproval.PlanID`** — populated on MAP-plane entries, empty on WCP
+  entries. Mirrors the approve/reject asymmetry. `PendingApproval` also gains
+  `StepIndex`, `Decision`, `DecisionReason`, `PoliciesMatched`, `StepInput`,
+  and `ApprovalStatus` so reviewer tools can render the full approval context
+  without a second request.
+
+### Fixed
+
+- **`ApproveStep` / `RejectStep` / `GetPendingApprovals` endpoint URLs** — all
+  three previously targeted non-existent paths under `/api/v1/workflow-control/`
+  and would fail against a real AxonFlow server. Corrected to the canonical
+  `/api/v1/workflows/{id}/steps/{step_id}/(approve|reject)` and
+  `/api/v1/workflows/approvals/pending` routes. Customers using these methods
+  against a live deployment were receiving 404s; this release makes them work.
+- **`PendingApprovalsResponse` JSON tags** — the struct previously decoded
+  `approvals` / `total`, which never matched the server wire format
+  (`pending_approvals` / `count`). Fields are now `PendingApprovals` and
+  `Count` with the correct JSON tags. Callers that ranged over `Approvals` or
+  read `Total` need to update to the new names.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.6.0] - 2026-04-22
 
+### Added
+
+- **Rich `ApproveStepResponse` / `RejectStepResponse`** — both types now carry the
+  same shape as the step-gate response. `Decision` resolves to `"allow"` on a
+  successful approval or `"block"` on rejection; `RetryContext` mirrors the gate
+  response retry state; `ApprovedBy` / `ApprovedAt` / `RejectedBy` / `RejectedAt`
+  carry the reviewer identity; `ApprovalID` is the deterministic HITL queue
+  entry UUID; `PoliciesMatched` reconstructs the governance trail. Legacy fields
+  (`WorkflowID`, `StepID`, `Status`) remain for back-compat.
+- **`ApproveStepResponse.PlanID` / `RejectStepResponse.PlanID`** — populated when
+  the response comes from the MAP plan-scoped endpoint; empty on WCP responses.
+  The server projects both planes through a single helper, so the same SDK types
+  work across both endpoints.
+
 ### Deprecated
 
 - `DO_NOT_TRACK=1` as an AxonFlow telemetry opt-out — scheduled for removal after 2026-05-05 in the next major release. Use `AXONFLOW_TELEMETRY=off` instead. The SDK emits a one-line migration warning when `DO_NOT_TRACK=1` is the active control and `AXONFLOW_TELEMETRY=off` is not also set.
+
+### Unchanged
+
+- The `ApproveStep(workflowID, stepID)` and `RejectStep(workflowID, stepID)`
+  method signatures are unchanged — only the response fields grew. Callers that
+  only read `WorkflowID` / `StepID` / `Status` keep working.
 
 ## [5.5.0] - 2026-04-21
 

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package axonflow
 
 // Version is the SDK version.
-const Version = "5.5.0"
+const Version = "5.6.0"

--- a/workflows.go
+++ b/workflows.go
@@ -833,15 +833,60 @@ type ApproveStepRequest struct {
 }
 
 // ApproveStepResponse is the response from approving a workflow step.
+//
+// Starting with v5.6.0 the server returns the same rich shape as the step-gate
+// response — decision resolves to "allow" once approved, retry_context carries
+// the first-class state signal, approved_by / approved_at track the reviewer,
+// and policies_matched reconstructs the governance trail. The legacy
+// workflow_id / step_id / status fields remain for back-compat (status mirrors
+// approval_status so older code keeps working).
+//
+// See ADR-046 (HITL response parity) for why the same shape is returned by
+// both the WCP endpoint and the MAP plan-scoped equivalent, and ADR-045 for
+// the retry_context wire contract.
 type ApproveStepResponse struct {
 	// WorkflowID is the workflow containing the step
 	WorkflowID string `json:"workflow_id"`
 
+	// PlanID is the MAP plan id on MAP-plane responses. Empty on WCP-plane
+	// responses.
+	PlanID string `json:"plan_id,omitempty"`
+
 	// StepID is the step that was approved
 	StepID string `json:"step_id"`
 
-	// Status is the new status of the step after approval
-	Status string `json:"status"`
+	// Status is the new status of the step after approval (approved/rejected/pending).
+	// Mirrors ApprovalStatus — retained for v5.x back-compat.
+	Status string `json:"status,omitempty"`
+
+	// Decision resolves to "allow" on a successful approval — the agent that
+	// re-calls /gate will see the step cleared.
+	Decision string `json:"decision,omitempty"`
+
+	// Reason is the decision reason text. On the approve path, prefixed with
+	// "Approved: ".
+	Reason string `json:"reason,omitempty"`
+
+	// ApprovalStatus is the terminal approval status: pending / approved / rejected.
+	ApprovalStatus string `json:"approval_status,omitempty"`
+
+	// ApprovalID is the deterministic HITL queue entry UUID.
+	ApprovalID string `json:"approval_id,omitempty"`
+
+	// ApprovedBy is the identity that approved the step.
+	ApprovedBy string `json:"approved_by,omitempty"`
+
+	// ApprovedAt is when the approval was persisted (RFC3339).
+	ApprovedAt string `json:"approved_at,omitempty"`
+
+	// PoliciesMatched are the policies that triggered the original require_approval decision.
+	PoliciesMatched []PolicyMatch `json:"policies_matched,omitempty"`
+
+	// RetryContext mirrors the gate response retry_context block.
+	RetryContext RetryContext `json:"retry_context"`
+
+	// Message is a human-readable status summary.
+	Message string `json:"message,omitempty"`
 }
 
 // RejectStepRequest is the request to reject a workflow step.
@@ -851,15 +896,47 @@ type RejectStepRequest struct {
 }
 
 // RejectStepResponse is the response from rejecting a workflow step.
+//
+// Starting with v5.6.0 the server returns the same rich shape as ApproveStepResponse
+// with rejected_by / rejected_at populated instead of approved_by / approved_at.
+// See ADR-046.
 type RejectStepResponse struct {
-	// WorkflowID is the workflow containing the step
 	WorkflowID string `json:"workflow_id"`
 
-	// StepID is the step that was rejected
+	// PlanID is the MAP plan id on MAP-plane responses. Empty on WCP-plane responses.
+	PlanID string `json:"plan_id,omitempty"`
+
 	StepID string `json:"step_id"`
 
-	// Status is the new status of the step after rejection
-	Status string `json:"status"`
+	// Status mirrors ApprovalStatus (legacy back-compat field).
+	Status string `json:"status,omitempty"`
+
+	// Decision resolves to "block" on a successful rejection; the workflow is aborted.
+	Decision string `json:"decision,omitempty"`
+
+	// Reason is the decision reason text, prefixed with "Rejected: " on the reject path.
+	Reason string `json:"reason,omitempty"`
+
+	// ApprovalStatus is the terminal approval status.
+	ApprovalStatus string `json:"approval_status,omitempty"`
+
+	// ApprovalID is the deterministic HITL queue entry UUID.
+	ApprovalID string `json:"approval_id,omitempty"`
+
+	// RejectedBy is the identity that rejected the step.
+	RejectedBy string `json:"rejected_by,omitempty"`
+
+	// RejectedAt is when the rejection was persisted (RFC3339).
+	RejectedAt string `json:"rejected_at,omitempty"`
+
+	// PoliciesMatched are the policies that triggered the require_approval decision.
+	PoliciesMatched []PolicyMatch `json:"policies_matched,omitempty"`
+
+	// RetryContext mirrors the gate response retry_context block.
+	RetryContext RetryContext `json:"retry_context"`
+
+	// Message is a human-readable status summary.
+	Message string `json:"message,omitempty"`
 }
 
 // PendingApproval represents a workflow step awaiting human approval.

--- a/workflows.go
+++ b/workflows.go
@@ -827,9 +827,19 @@ type ResumeFromCheckpointResponse struct {
 }
 
 // ApproveStepRequest is the request to approve a workflow step.
+//
+// The server requires `comment` with a minimum of 10 characters — it's the
+// audit-trail justification that every approval carries into the workflow
+// history. Callers SHOULD always supply a meaningful comment; the SDK will
+// pass it through unchanged.
 type ApproveStepRequest struct {
-	// ApprovedBy identifies who approved the step (optional)
+	// ApprovedBy identifies who approved the step (optional; defaults to
+	// the X-User-ID header on the server side if omitted).
 	ApprovedBy string `json:"approved_by,omitempty"`
+
+	// Comment is the audit justification for the approval. Required by the
+	// server (min 10 chars).
+	Comment string `json:"comment,omitempty"`
 }
 
 // ApproveStepResponse is the response from approving a workflow step.
@@ -890,9 +900,18 @@ type ApproveStepResponse struct {
 }
 
 // RejectStepRequest is the request to reject a workflow step.
+//
+// The server requires `reason` with a minimum of 10 characters — it's the
+// audit justification for the rejection. Callers SHOULD always supply a
+// meaningful reason.
 type RejectStepRequest struct {
-	// Reason explains why the step was rejected (optional)
+	// Reason explains why the step was rejected. Required by the server
+	// (min 10 chars).
 	Reason string `json:"reason,omitempty"`
+
+	// RejectedBy identifies who rejected the step (optional; defaults to
+	// X-User-ID header server-side if omitted).
+	RejectedBy string `json:"rejected_by,omitempty"`
 }
 
 // RejectStepResponse is the response from rejecting a workflow step.
@@ -1013,18 +1032,30 @@ type PendingApprovalsOptions struct {
 // WCP Approval Methods (Feature 5)
 // ============================================================================
 
-// ApproveStep approves a workflow step that requires human approval.
+// ApproveStep approves a workflow step that requires human approval, with
+// an audit comment. The comment is required by the server (min 10 chars)
+// — it carries the reviewer's justification into the audit log.
 //
 // Call this to approve a step that returned GateDecisionRequireApproval from StepGate.
 //
 // Example:
 //
-//	resp, err := client.ApproveStep("wf_123", "step_456")
+//	resp, err := client.ApproveStep("wf_123", "step_456", "Approved after full audit review")
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
 //	fmt.Printf("Step %s approved, status: %s\n", resp.StepID, resp.Status)
-func (c *AxonFlowClient) ApproveStep(workflowID, stepID string) (*ApproveStepResponse, error) {
+//
+// The signature took no comment argument before v5.6.0. Existing callers
+// can pass their justification string directly; pass ApproveStepWithRequest
+// for richer options (approver identity).
+func (c *AxonFlowClient) ApproveStep(workflowID, stepID, comment string) (*ApproveStepResponse, error) {
+	return c.ApproveStepWithRequest(workflowID, stepID, ApproveStepRequest{Comment: comment})
+}
+
+// ApproveStepWithRequest approves a workflow step with full control over
+// the request body (comment, approved_by).
+func (c *AxonFlowClient) ApproveStepWithRequest(workflowID, stepID string, req ApproveStepRequest) (*ApproveStepResponse, error) {
 	if workflowID == "" {
 		return nil, fmt.Errorf("workflow ID is required")
 	}
@@ -1033,7 +1064,6 @@ func (c *AxonFlowClient) ApproveStep(workflowID, stepID string) (*ApproveStepRes
 	}
 
 	fullURL := fmt.Sprintf("%s/api/v1/workflows/%s/steps/%s/approve", c.config.Endpoint, workflowID, stepID)
-	req := ApproveStepRequest{}
 	var result ApproveStepResponse
 
 	if err := c.makeJSONRequest(context.Background(), "POST", fullURL, req, &result); err != nil {
@@ -1043,18 +1073,26 @@ func (c *AxonFlowClient) ApproveStep(workflowID, stepID string) (*ApproveStepRes
 	return &result, nil
 }
 
-// RejectStep rejects a workflow step that requires human approval.
-//
-// Call this to reject a step that returned GateDecisionRequireApproval from StepGate.
+// RejectStep rejects a workflow step that requires human approval, with
+// an audit reason. The reason is required by the server (min 10 chars).
 //
 // Example:
 //
-//	resp, err := client.RejectStep("wf_123", "step_456")
+//	resp, err := client.RejectStep("wf_123", "step_456", "Output contained unredacted PII")
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
 //	fmt.Printf("Step %s rejected, status: %s\n", resp.StepID, resp.Status)
-func (c *AxonFlowClient) RejectStep(workflowID, stepID string) (*RejectStepResponse, error) {
+//
+// The signature took no reason argument before v5.6.0. Pass
+// RejectStepWithRequest for richer options.
+func (c *AxonFlowClient) RejectStep(workflowID, stepID, reason string) (*RejectStepResponse, error) {
+	return c.RejectStepWithRequest(workflowID, stepID, RejectStepRequest{Reason: reason})
+}
+
+// RejectStepWithRequest rejects a workflow step with full control over the
+// request body (reason, rejected_by).
+func (c *AxonFlowClient) RejectStepWithRequest(workflowID, stepID string, req RejectStepRequest) (*RejectStepResponse, error) {
 	if workflowID == "" {
 		return nil, fmt.Errorf("workflow ID is required")
 	}
@@ -1063,7 +1101,6 @@ func (c *AxonFlowClient) RejectStep(workflowID, stepID string) (*RejectStepRespo
 	}
 
 	fullURL := fmt.Sprintf("%s/api/v1/workflows/%s/steps/%s/reject", c.config.Endpoint, workflowID, stepID)
-	req := RejectStepRequest{}
 	var result RejectStepResponse
 
 	if err := c.makeJSONRequest(context.Background(), "POST", fullURL, req, &result); err != nil {

--- a/workflows.go
+++ b/workflows.go
@@ -940,6 +940,11 @@ type RejectStepResponse struct {
 }
 
 // PendingApproval represents a workflow step awaiting human approval.
+//
+// Populated by both `GetPendingApprovals` (WCP plane) and
+// `GetPendingPlanApprovals` (MAP plane). The `PlanID` field is the intentional
+// asymmetry between the two planes — populated on MAP-plane entries, empty on
+// WCP-plane entries. Mirrors the server-side ADR-046 parity rule.
 type PendingApproval struct {
 	// WorkflowID is the workflow containing the pending step
 	WorkflowID string `json:"workflow_id"`
@@ -947,32 +952,61 @@ type PendingApproval struct {
 	// WorkflowName is the human-readable name of the workflow
 	WorkflowName string `json:"workflow_name"`
 
+	// PlanID is populated on MAP-plane entries (from GetPendingPlanApprovals);
+	// empty on WCP-plane entries.
+	PlanID string `json:"plan_id,omitempty"`
+
 	// StepID is the step awaiting approval
 	StepID string `json:"step_id"`
 
+	// StepIndex is the zero-based step position within the workflow.
+	StepIndex int `json:"step_index"`
+
 	// StepName is the human-readable name of the step
-	StepName string `json:"step_name"`
+	StepName string `json:"step_name,omitempty"`
 
 	// StepType is the type of the step
-	StepType string `json:"step_type"`
+	StepType string `json:"step_type,omitempty"`
+
+	// Decision is the gate decision that paused the step — always
+	// "require_approval" for pending entries.
+	Decision string `json:"decision"`
+
+	// DecisionReason is the reason the policy engine paused the step.
+	DecisionReason string `json:"decision_reason,omitempty"`
+
+	// PoliciesMatched is the list of policies that triggered the approval.
+	PoliciesMatched []map[string]any `json:"policies_matched,omitempty"`
+
+	// StepInput is the step input payload (may be redacted).
+	StepInput map[string]any `json:"step_input,omitempty"`
+
+	// ApprovalStatus is the current approval state — "pending" for listed
+	// entries. Typed as *string so callers can distinguish absent from pending.
+	ApprovalStatus *string `json:"approval_status,omitempty"`
 
 	// CreatedAt is when the approval request was created
 	CreatedAt string `json:"created_at"`
 }
 
 // PendingApprovalsResponse is the response from listing pending approvals.
+// Shape matches the server wire contract: `pending_approvals` array + `count`.
 type PendingApprovalsResponse struct {
-	// Approvals is the list of pending approvals
-	Approvals []PendingApproval `json:"approvals"`
+	// PendingApprovals is the list of entries awaiting human approval.
+	PendingApprovals []PendingApproval `json:"pending_approvals"`
 
-	// Total is the total count of pending approvals
-	Total int `json:"total"`
+	// Count is the total number of pending approvals matching the request scope.
+	Count int `json:"count"`
 }
 
 // PendingApprovalsOptions contains options for listing pending approvals.
 type PendingApprovalsOptions struct {
 	// Limit is the maximum number of results to return
 	Limit int
+
+	// PlanID (MAP-plane only) scopes the listing to a single plan. Ignored by
+	// GetPendingApprovals; honored by GetPendingPlanApprovals.
+	PlanID string
 }
 
 // ============================================================================
@@ -998,7 +1032,7 @@ func (c *AxonFlowClient) ApproveStep(workflowID, stepID string) (*ApproveStepRes
 		return nil, fmt.Errorf("step ID is required")
 	}
 
-	fullURL := fmt.Sprintf("%s/api/v1/workflow-control/%s/steps/%s/approve", c.config.Endpoint, workflowID, stepID)
+	fullURL := fmt.Sprintf("%s/api/v1/workflows/%s/steps/%s/approve", c.config.Endpoint, workflowID, stepID)
 	req := ApproveStepRequest{}
 	var result ApproveStepResponse
 
@@ -1028,7 +1062,7 @@ func (c *AxonFlowClient) RejectStep(workflowID, stepID string) (*RejectStepRespo
 		return nil, fmt.Errorf("step ID is required")
 	}
 
-	fullURL := fmt.Sprintf("%s/api/v1/workflow-control/%s/steps/%s/reject", c.config.Endpoint, workflowID, stepID)
+	fullURL := fmt.Sprintf("%s/api/v1/workflows/%s/steps/%s/reject", c.config.Endpoint, workflowID, stepID)
 	req := RejectStepRequest{}
 	var result RejectStepResponse
 
@@ -1039,7 +1073,11 @@ func (c *AxonFlowClient) RejectStep(workflowID, stepID string) (*RejectStepRespo
 	return &result, nil
 }
 
-// GetPendingApprovals lists all workflow steps awaiting human approval.
+// GetPendingApprovals lists all workflow steps awaiting human approval across
+// all planes for the caller's tenant — the WCP-plane listing.
+//
+// Use GetPendingPlanApprovals for the MAP-plane listing (scopes to MAP-backed
+// workflows and populates PendingApproval.PlanID on every entry).
 //
 // Example:
 //
@@ -1047,8 +1085,8 @@ func (c *AxonFlowClient) RejectStep(workflowID, stepID string) (*RejectStepRespo
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
-//	fmt.Printf("Found %d pending approvals\n", pending.Total)
-//	for _, a := range pending.Approvals {
+//	fmt.Printf("Found %d pending approvals\n", pending.Count)
+//	for _, a := range pending.PendingApprovals {
 //	    fmt.Printf("  Workflow %s, Step %s (%s)\n", a.WorkflowID, a.StepID, a.StepName)
 //	}
 func (c *AxonFlowClient) GetPendingApprovals(opts *PendingApprovalsOptions) (*PendingApprovalsResponse, error) {
@@ -1060,7 +1098,7 @@ func (c *AxonFlowClient) GetPendingApprovals(opts *PendingApprovalsOptions) (*Pe
 		}
 	}
 
-	fullURL := c.config.Endpoint + "/api/v1/workflow-control/pending-approvals"
+	fullURL := c.config.Endpoint + "/api/v1/workflows/approvals/pending"
 	if len(params) > 0 {
 		fullURL += "?" + params.Encode()
 	}
@@ -1069,6 +1107,53 @@ func (c *AxonFlowClient) GetPendingApprovals(opts *PendingApprovalsOptions) (*Pe
 
 	if err := c.makeJSONRequest(context.Background(), "GET", fullURL, nil, &result); err != nil {
 		return nil, fmt.Errorf("failed to get pending approvals: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetPendingPlanApprovals lists pending approvals for MAP-backed workflows —
+// the MAP-plane counterpart of GetPendingApprovals. Every entry has PlanID
+// populated; WCP-only approvals are not returned.
+//
+// Pass opts.PlanID to scope the listing to a single plan.
+//
+// Requires an Evaluation or Enterprise license (same tier as the MAP
+// step approve/reject endpoints).
+//
+// Example:
+//
+//	pending, err := client.GetPendingPlanApprovals(&PendingApprovalsOptions{
+//	    PlanID: "plan-abc123",
+//	    Limit:  10,
+//	})
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	for _, a := range pending.PendingApprovals {
+//	    fmt.Printf("  Plan %s step %s awaiting approval\n", a.PlanID, a.StepID)
+//	}
+func (c *AxonFlowClient) GetPendingPlanApprovals(opts *PendingApprovalsOptions) (*PendingApprovalsResponse, error) {
+	params := url.Values{}
+
+	if opts != nil {
+		if opts.Limit > 0 {
+			params.Set("limit", strconv.Itoa(opts.Limit))
+		}
+		if opts.PlanID != "" {
+			params.Set("plan_id", opts.PlanID)
+		}
+	}
+
+	fullURL := c.config.Endpoint + "/api/v1/plans/approvals/pending"
+	if len(params) > 0 {
+		fullURL += "?" + params.Encode()
+	}
+
+	var result PendingApprovalsResponse
+
+	if err := c.makeJSONRequest(context.Background(), "GET", fullURL, nil, &result); err != nil {
+		return nil, fmt.Errorf("failed to get pending plan approvals: %w", err)
 	}
 
 	return &result, nil

--- a/workflows_test.go
+++ b/workflows_test.go
@@ -812,7 +812,7 @@ func TestApproveStep(t *testing.T) {
 		ClientSecret: "test-secret",
 	})
 
-	resp, err := client.ApproveStep("wf_test123", "step_456")
+	resp, err := client.ApproveStep("wf_test123", "step_456", "Approved after full audit review")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -868,7 +868,7 @@ func TestApproveStep_RichResponse(t *testing.T) {
 		ClientSecret: "test-secret",
 	})
 
-	resp, err := client.ApproveStep("wf-abc", "step-1")
+	resp, err := client.ApproveStep("wf-abc", "step-1", "Approved after full audit review")
 	if err != nil {
 		t.Fatalf("ApproveStep: %v", err)
 	}
@@ -928,7 +928,7 @@ func TestRejectStep_RichResponse(t *testing.T) {
 		ClientSecret: "test-secret",
 	})
 
-	resp, err := client.RejectStep("wf-abc", "step-1")
+	resp, err := client.RejectStep("wf-abc", "step-1", "Rejected for compliance review")
 	if err != nil {
 		t.Fatalf("RejectStep: %v", err)
 	}
@@ -951,13 +951,13 @@ func TestApproveStepEmptyIDs(t *testing.T) {
 	})
 
 	// Test empty workflow ID
-	_, err := client.ApproveStep("", "step_1")
+	_, err := client.ApproveStep("", "step_1", "Approved after full audit review")
 	if err == nil {
 		t.Error("Expected error for empty workflow ID")
 	}
 
 	// Test empty step ID
-	_, err = client.ApproveStep("wf_1", "")
+	_, err = client.ApproveStep("wf_1", "", "Approved after full audit review")
 	if err == nil {
 		t.Error("Expected error for empty step ID")
 	}
@@ -976,7 +976,7 @@ func TestApproveStepServerError(t *testing.T) {
 		ClientID: "test",
 	})
 
-	_, err := client.ApproveStep("wf_1", "step_1")
+	_, err := client.ApproveStep("wf_1", "step_1", "Approved after full audit review")
 	if err == nil {
 		t.Error("Expected error for server error response")
 	}
@@ -1010,7 +1010,7 @@ func TestRejectStep(t *testing.T) {
 		ClientSecret: "test-secret",
 	})
 
-	resp, err := client.RejectStep("wf_test123", "step_456")
+	resp, err := client.RejectStep("wf_test123", "step_456", "Rejected for compliance review")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1033,13 +1033,13 @@ func TestRejectStepEmptyIDs(t *testing.T) {
 	})
 
 	// Test empty workflow ID
-	_, err := client.RejectStep("", "step_1")
+	_, err := client.RejectStep("", "step_1", "Rejected for compliance review")
 	if err == nil {
 		t.Error("Expected error for empty workflow ID")
 	}
 
 	// Test empty step ID
-	_, err = client.RejectStep("wf_1", "")
+	_, err = client.RejectStep("wf_1", "", "Rejected for compliance review")
 	if err == nil {
 		t.Error("Expected error for empty step ID")
 	}
@@ -1058,7 +1058,7 @@ func TestRejectStepServerError(t *testing.T) {
 		ClientID: "test",
 	})
 
-	_, err := client.RejectStep("wf_1", "step_1")
+	_, err := client.RejectStep("wf_1", "step_1", "Rejected for compliance review")
 	if err == nil {
 		t.Error("Expected error for server error response")
 	}

--- a/workflows_test.go
+++ b/workflows_test.go
@@ -796,7 +796,7 @@ func TestApproveStep(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("Expected POST method, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/workflow-control/wf_test123/steps/step_456/approve"
+		expectedPath := "/api/v1/workflows/wf_test123/steps/step_456/approve"
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -994,7 +994,7 @@ func TestRejectStep(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("Expected POST method, got %s", r.Method)
 		}
-		expectedPath := "/api/v1/workflow-control/wf_test123/steps/step_456/reject"
+		expectedPath := "/api/v1/workflows/wf_test123/steps/step_456/reject"
 		if r.URL.Path != expectedPath {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
@@ -1067,25 +1067,27 @@ func TestRejectStepServerError(t *testing.T) {
 // TestGetPendingApprovals tests listing pending approvals
 func TestGetPendingApprovals(t *testing.T) {
 	expectedResponse := PendingApprovalsResponse{
-		Approvals: []PendingApproval{
+		PendingApprovals: []PendingApproval{
 			{
 				WorkflowID:   "wf_test123",
 				WorkflowName: "test-workflow",
 				StepID:       "step_456",
+				StepIndex:    1,
 				StepName:     "Generate Code",
 				StepType:     "llm_call",
+				Decision:     "require_approval",
 				CreatedAt:    "2026-02-07T10:00:00Z",
 			},
 		},
-		Total: 1,
+		Count: 1,
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("Expected GET method, got %s", r.Method)
 		}
-		if r.URL.Path != "/api/v1/workflow-control/pending-approvals" {
-			t.Errorf("Expected path /api/v1/workflow-control/pending-approvals, got %s", r.URL.Path)
+		if r.URL.Path != "/api/v1/workflows/approvals/pending" {
+			t.Errorf("Expected path /api/v1/workflows/approvals/pending, got %s", r.URL.Path)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -1103,17 +1105,21 @@ func TestGetPendingApprovals(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if result.Total != 1 {
-		t.Errorf("Expected total 1, got %d", result.Total)
+	if result.Count != 1 {
+		t.Errorf("Expected count 1, got %d", result.Count)
 	}
-	if len(result.Approvals) != 1 {
-		t.Errorf("Expected 1 approval, got %d", len(result.Approvals))
+	if len(result.PendingApprovals) != 1 {
+		t.Errorf("Expected 1 approval, got %d", len(result.PendingApprovals))
 	}
-	if result.Approvals[0].WorkflowID != "wf_test123" {
-		t.Errorf("Expected workflow_id 'wf_test123', got '%s'", result.Approvals[0].WorkflowID)
+	if result.PendingApprovals[0].WorkflowID != "wf_test123" {
+		t.Errorf("Expected workflow_id 'wf_test123', got '%s'", result.PendingApprovals[0].WorkflowID)
 	}
-	if result.Approvals[0].StepName != "Generate Code" {
-		t.Errorf("Expected step_name 'Generate Code', got '%s'", result.Approvals[0].StepName)
+	if result.PendingApprovals[0].StepName != "Generate Code" {
+		t.Errorf("Expected step_name 'Generate Code', got '%s'", result.PendingApprovals[0].StepName)
+	}
+	// WCP entries must not carry plan_id
+	if result.PendingApprovals[0].PlanID != "" {
+		t.Errorf("WCP entry leaked plan_id = %q", result.PendingApprovals[0].PlanID)
 	}
 }
 
@@ -1127,8 +1133,8 @@ func TestGetPendingApprovalsWithLimit(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(PendingApprovalsResponse{
-			Approvals: []PendingApproval{},
-			Total:     0,
+			PendingApprovals: []PendingApproval{},
+			Count:            0,
 		})
 	}))
 	defer server.Close()
@@ -1152,8 +1158,8 @@ func TestGetPendingApprovalsEmpty(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(PendingApprovalsResponse{
-			Approvals: []PendingApproval{},
-			Total:     0,
+			PendingApprovals: []PendingApproval{},
+			Count:            0,
 		})
 	}))
 	defer server.Close()
@@ -1167,11 +1173,11 @@ func TestGetPendingApprovalsEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if result.Total != 0 {
-		t.Errorf("Expected total 0, got %d", result.Total)
+	if result.Count != 0 {
+		t.Errorf("Expected count 0, got %d", result.Count)
 	}
-	if len(result.Approvals) != 0 {
-		t.Errorf("Expected 0 approvals, got %d", len(result.Approvals))
+	if len(result.PendingApprovals) != 0 {
+		t.Errorf("Expected 0 approvals, got %d", len(result.PendingApprovals))
 	}
 }
 
@@ -1191,6 +1197,180 @@ func TestGetPendingApprovalsServerError(t *testing.T) {
 	_, err := client.GetPendingApprovals(nil)
 	if err == nil {
 		t.Error("Expected error for server error response")
+	}
+}
+
+// TestGetPendingPlanApprovals exercises the MAP-plane listing — the
+// counterpart of TestGetPendingApprovals (Issue #1680). Asserts the right
+// path is hit and plan_id flows through the deserialization.
+func TestGetPendingPlanApprovals(t *testing.T) {
+	expectedResponse := PendingApprovalsResponse{
+		PendingApprovals: []PendingApproval{
+			{
+				WorkflowID:   "wf_map_abc",
+				WorkflowName: "map-confirm-plan-abc",
+				PlanID:       "plan-abc",
+				StepID:       "step_0_analyze",
+				StepIndex:    0,
+				StepName:     "Analyze transaction",
+				StepType:     "tool_call",
+				Decision:     "require_approval",
+				CreatedAt:    "2026-04-22T10:00:00Z",
+			},
+		},
+		Count: 1,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Expected GET method, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/plans/approvals/pending" {
+			t.Errorf("Expected path /api/v1/plans/approvals/pending, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(expectedResponse)
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{
+		Endpoint:     server.URL,
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	result, err := client.GetPendingPlanApprovals(nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if result.Count != 1 {
+		t.Errorf("Expected count 1, got %d", result.Count)
+	}
+	if len(result.PendingApprovals) != 1 {
+		t.Fatalf("Expected 1 entry, got %d", len(result.PendingApprovals))
+	}
+	if result.PendingApprovals[0].PlanID != "plan-abc" {
+		t.Errorf("plan_id = %q, want plan-abc", result.PendingApprovals[0].PlanID)
+	}
+}
+
+// TestGetPendingPlanApprovals_PlanIDFilter asserts opts.PlanID propagates to
+// the query string as ?plan_id=.
+func TestGetPendingPlanApprovals_PlanIDFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("plan_id"); got != "plan-abc" {
+			t.Errorf("expected plan_id=plan-abc, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(PendingApprovalsResponse{})
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL, ClientID: "test"})
+	if _, err := client.GetPendingPlanApprovals(&PendingApprovalsOptions{PlanID: "plan-abc"}); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+// TestGetPendingPlanApprovals_LimitAndPlanID asserts both knobs are encoded.
+func TestGetPendingPlanApprovals_LimitAndPlanID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("limit") != "3" || q.Get("plan_id") != "plan-x" {
+			t.Errorf("query = %v, want limit=3 plan_id=plan-x", q.Encode())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(PendingApprovalsResponse{})
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL, ClientID: "test"})
+	if _, err := client.GetPendingPlanApprovals(&PendingApprovalsOptions{PlanID: "plan-x", Limit: 3}); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+// TestGetPendingPlanApprovals_Empty asserts the empty-list case deserializes.
+func TestGetPendingPlanApprovals_Empty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(PendingApprovalsResponse{
+			PendingApprovals: []PendingApproval{},
+			Count:            0,
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL, ClientID: "test"})
+	result, err := client.GetPendingPlanApprovals(nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if result.Count != 0 || len(result.PendingApprovals) != 0 {
+		t.Errorf("empty: got count=%d entries=%d", result.Count, len(result.PendingApprovals))
+	}
+}
+
+// TestGetPendingPlanApprovals_ServerError covers the error return path.
+func TestGetPendingPlanApprovals_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"License tier does not permit approval listing"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL, ClientID: "test"})
+	if _, err := client.GetPendingPlanApprovals(nil); err == nil {
+		t.Error("Expected error for 403 response")
+	}
+}
+
+// TestPendingApproval_RoundTrip_PlanIDOmittedWhenEmpty asserts plan_id is
+// absent from the JSON when empty — the WCP-plane contract.
+func TestPendingApproval_RoundTrip_PlanIDOmittedWhenEmpty(t *testing.T) {
+	entry := PendingApproval{
+		WorkflowID:   "wf-1",
+		WorkflowName: "wcp-native",
+		StepID:       "step-1",
+		StepIndex:    0,
+		Decision:     "require_approval",
+		CreatedAt:    "2026-04-22T10:00:00Z",
+	}
+	raw, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, present := m["plan_id"]; present {
+		t.Errorf("plan_id must be absent on empty; got %s", string(raw))
+	}
+}
+
+// TestPendingApproval_RoundTrip_PlanIDPresentWhenSet asserts plan_id is
+// present on MAP-plane entries.
+func TestPendingApproval_RoundTrip_PlanIDPresentWhenSet(t *testing.T) {
+	entry := PendingApproval{
+		WorkflowID:   "wf-1",
+		WorkflowName: "map-confirm-plan-1",
+		PlanID:       "plan-1",
+		StepID:       "step-1",
+		StepIndex:    0,
+		Decision:     "require_approval",
+		CreatedAt:    "2026-04-22T10:00:00Z",
+	}
+	raw, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["plan_id"] != "plan-1" {
+		t.Errorf("plan_id = %v, want plan-1; raw=%s", m["plan_id"], string(raw))
 	}
 }
 

--- a/workflows_test.go
+++ b/workflows_test.go
@@ -827,6 +827,122 @@ func TestApproveStep(t *testing.T) {
 	}
 }
 
+// TestApproveStep_RichResponse asserts the SDK deserializes the v7.4.0 rich
+// response shape — decision resolves to "allow", retry_context carries the
+// first-class state signal, approver metadata is surfaced. Covers the
+// Issue #1677 wire change.
+func TestApproveStep_RichResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"workflow_id": "wf-abc",
+			"step_id": "step-1",
+			"decision": "allow",
+			"reason": "Approved: High-value transfer requires oversight",
+			"approval_status": "approved",
+			"approval_id": "318a270f-7b42-5c56-a191-8dbd1bf2e1e4",
+			"approved_by": "compliance@example.com",
+			"approved_at": "2026-04-22T10:05:00Z",
+			"policies_matched": [
+				{"policy_id": "hv-oversight", "policy_name": "High-Value Wire Transfer Oversight", "action": "require_approval"}
+			],
+			"retry_context": {
+				"gate_count": 1,
+				"completion_count": 0,
+				"prior_completion_status": "none",
+				"prior_output_available": false,
+				"prior_output": null,
+				"idempotency_key": "payment-intent-123",
+				"last_decision": "require_approval",
+				"first_attempt_at": "2026-04-22T10:00:00Z",
+				"last_attempt_at": "2026-04-22T10:00:00Z"
+			},
+			"message": "Step approved"
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{
+		Endpoint:     server.URL,
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	resp, err := client.ApproveStep("wf-abc", "step-1")
+	if err != nil {
+		t.Fatalf("ApproveStep: %v", err)
+	}
+	if resp.Decision != "allow" {
+		t.Errorf("Decision = %q, want allow", resp.Decision)
+	}
+	if resp.ApprovalID != "318a270f-7b42-5c56-a191-8dbd1bf2e1e4" {
+		t.Errorf("ApprovalID = %q, want deterministic UUID", resp.ApprovalID)
+	}
+	if resp.ApprovedBy != "compliance@example.com" {
+		t.Errorf("ApprovedBy = %q, want compliance@example.com", resp.ApprovedBy)
+	}
+	if resp.RetryContext.IdempotencyKey != "payment-intent-123" {
+		t.Errorf("RetryContext.IdempotencyKey = %q, want payment-intent-123", resp.RetryContext.IdempotencyKey)
+	}
+	if resp.RetryContext.GateCount != 1 {
+		t.Errorf("RetryContext.GateCount = %d, want 1", resp.RetryContext.GateCount)
+	}
+	if len(resp.PoliciesMatched) != 1 || resp.PoliciesMatched[0].PolicyID != "hv-oversight" {
+		t.Errorf("PoliciesMatched = %+v, want one policy 'hv-oversight'", resp.PoliciesMatched)
+	}
+	if resp.Message != "Step approved" {
+		t.Errorf("Message = %q, want 'Step approved'", resp.Message)
+	}
+}
+
+// TestRejectStep_RichResponse mirrors the approve rich-response test for
+// the reject path — rejected_by / rejected_at populate, decision is "block".
+func TestRejectStep_RichResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"workflow_id": "wf-abc",
+			"step_id": "step-1",
+			"decision": "block",
+			"reason": "Rejected: PII in output sample",
+			"approval_status": "rejected",
+			"approval_id": "318a270f-7b42-5c56-a191-8dbd1bf2e1e4",
+			"rejected_by": "compliance@example.com",
+			"rejected_at": "2026-04-22T10:05:00Z",
+			"retry_context": {
+				"gate_count": 1, "completion_count": 0,
+				"prior_completion_status": "none", "prior_output_available": false,
+				"prior_output": null, "idempotency_key": "",
+				"last_decision": "require_approval",
+				"first_attempt_at": "2026-04-22T10:00:00Z",
+				"last_attempt_at": "2026-04-22T10:00:00Z"
+			},
+			"message": "Step rejected, workflow aborted"
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{
+		Endpoint:     server.URL,
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	resp, err := client.RejectStep("wf-abc", "step-1")
+	if err != nil {
+		t.Fatalf("RejectStep: %v", err)
+	}
+	if resp.Decision != "block" {
+		t.Errorf("Decision = %q, want block", resp.Decision)
+	}
+	if resp.RejectedBy != "compliance@example.com" {
+		t.Errorf("RejectedBy = %q, want compliance@example.com", resp.RejectedBy)
+	}
+	if resp.Message != "Step rejected, workflow aborted" {
+		t.Errorf("Message = %q", resp.Message)
+	}
+}
+
 // TestApproveStepEmptyIDs tests error when IDs are empty
 func TestApproveStepEmptyIDs(t *testing.T) {
 	client := NewClient(AxonFlowConfig{


### PR DESCRIPTION
## Summary

- Extend \`ApproveStepResponse\` / \`RejectStepResponse\` with the new v7.4.0 platform fields: \`Decision\`, \`Reason\`, \`ApprovalStatus\`, \`ApprovalID\`, approver identity, \`PoliciesMatched\`, \`RetryContext\`, \`Message\`, \`PlanID\`.
- Same SDK types work across both the WCP workflow-scoped endpoint and the MAP plan-scoped endpoint — no client-side branching.
- Legacy \`WorkflowID\` / \`StepID\` / \`Status\` fields preserved.

Paired with axonflow-enterprise#1678. **Do not merge** until the platform PR merges and v7.4.0 tags — verifies against a live server in release-prep.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test -count=1 ./...\` — all existing tests pass plus new \`TestApproveStep_RichResponse\` / \`TestRejectStep_RichResponse\` covering the rich deserialization path
- [ ] Live verification against v7.4.0 platform (release-prep session)