### PR TITLE
chore(telemetry): deprecate DO_NOT_TRACK env var (warn on use)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.6.0] - 2026-04-22
+
+### Deprecated
+
+- `DO_NOT_TRACK=1` as an AxonFlow telemetry opt-out — scheduled for removal after 2026-05-05 in the next major release. Use `AXONFLOW_TELEMETRY=off` instead. The SDK emits a one-line migration warning when `DO_NOT_TRACK=1` is the active control and `AXONFLOW_TELEMETRY=off` is not also set.
+
 ## [5.5.0] - 2026-04-21
 
 ### Added

--- a/telemetry.go
+++ b/telemetry.go
@@ -151,12 +151,22 @@ func generateInstanceID() string {
 // isTelemetryEnabled determines whether telemetry should be sent for this client.
 //
 // Priority order:
-//  1. Environment variables — DO_NOT_TRACK=1 or AXONFLOW_TELEMETRY=off disables (always wins).
+//  1. Environment variables — DO_NOT_TRACK=1 (deprecated) or AXONFLOW_TELEMETRY=off disables (always wins).
 //  2. Config override (TelemetryEnabled *bool) — if non-nil, use its value.
 //  3. Default — ON for all modes except sandbox.
+//
+// DO_NOT_TRACK is deprecated and will be removed after 2026-05-05 in the next
+// major release. Use AXONFLOW_TELEMETRY=off to opt out of AxonFlow telemetry.
+// When DO_NOT_TRACK=1 is the only thing disabling telemetry, a one-time
+// warning is logged so operators can migrate before the removal.
 func (c *AxonFlowClient) isTelemetryEnabled() bool {
 	// 1. Environment-level opt-out always wins (cannot be overridden by config).
 	if strings.TrimSpace(os.Getenv("DO_NOT_TRACK")) == "1" {
+		// Only warn when DO_NOT_TRACK is the active control. If the caller
+		// has also set AXONFLOW_TELEMETRY=off, they've already migrated.
+		if !strings.EqualFold(strings.TrimSpace(os.Getenv("AXONFLOW_TELEMETRY")), "off") {
+			log.Printf("[AxonFlow] DO_NOT_TRACK=1 is deprecated as an AxonFlow telemetry opt-out and will be removed after 2026-05-05 in the next major release. Set AXONFLOW_TELEMETRY=off to opt out going forward. See https://docs.getaxonflow.com/docs/telemetry for details.")
+		}
 		return false
 	}
 	if strings.EqualFold(strings.TrimSpace(os.Getenv("AXONFLOW_TELEMETRY")), "off") {


### PR DESCRIPTION
## Summary

- Starts a deprecation of `DO_NOT_TRACK=1` as an AxonFlow telemetry opt-out. Removal target: **after 2026-05-05 in the next major release**.
- `AXONFLOW_TELEMETRY=off` remains the canonical AxonFlow-specific opt-out. Its behavior is unchanged.
- When `DO_NOT_TRACK=1` is set AND `AXONFLOW_TELEMETRY=off` is NOT set, the SDK now emits a one-line warning at the point the opt-out takes effect, pointing operators at the canonical switch. If both are set, the caller has already migrated and no warning fires.
- Aligns with the v7.4.0 platform release train — other WCP / MAP fields are also being deprecated for removal after the 2026-05-05 cutoff.

## Why

`DO_NOT_TRACK=1` is a widely-understood privacy convention in dev tooling. It is set broadly across CI environments and corporate shells, often as a blanket policy, not as an intentional decision about AxonFlow specifically. When it silently disables AxonFlow telemetry the product operator learns nothing and the project loses the ability to see real usage.

This is the middle path between keep-honoring-DO_NOT_TRACK-forever (status quo — commercially blind) and ignore-DO_NOT_TRACK-overnight (trust-breaking). Announce the deprecation now, warn during the transition window, remove in the next major release. Users who genuinely want AxonFlow telemetry off can set the AxonFlow-specific switch; users whose DO_NOT_TRACK comes from a generic policy can opt in intentionally if they want the signal on.

## What changed

- Telemetry init: single code-path change that adds the warning emission.
- CHANGELOG: new `### Deprecated` section under the next version with the rationale and timeline.

## Test plan

- [x] Existing telemetry test suite still passes (no decision-logic change)
- [x] Warning fires only when `DO_NOT_TRACK=1` is the active control (`AXONFLOW_TELEMETRY=off` silences it)
- [ ] After merge, CI confirms the `release-notes-from-CHANGELOG` preflight picks up the `### Deprecated` entry verbatim for the release notes

## Related

- Sibling PRs in the other 3 SDK repos landing the same deprecation warning
- Companion platform v7.4.0 release train (#1678)
