### PR TITLE
fix(telemetry): synchronous send so short-lived processes deliver the ping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,23 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Telemetry delivery on short-lived processes.** `NewClient` spawned
-  `sendTelemetryPing` as a goroutine that was abandoned when `main()`
-  returned, so any short-lived Go binary — CLI tools, serverless handlers,
-  quickstart snippets, cold-start functions — exited before the HTTP POST
-  to the checkpoint completed and silently dropped telemetry. The ping is
-  now sent synchronously from `NewClient` under a single shared
-  `context.WithTimeout(telemetryTimeout)`. `NewClient` blocks briefly
-  (typically ~350ms warm, ~1.3s cold; worst case bounded at
-  `telemetryTimeout`) but telemetry delivery is now deterministic.
-- **Telemetry budget no longer stacks.** `detectPlatformVersion` previously
-  used its own 2-second `context.WithTimeout`, and the checkpoint POST
-  used its own 3-second timeout on top. In the unreachable-endpoint case
-  the two stacked, blocking `NewClient` for up to ~5s — defeating the
-  bounded-at-`telemetryTimeout` guarantee. Both operations now share the
-  same context deadline so the total blocking time on `NewClient` stays
-  within `telemetryTimeout`. `detectPlatformVersion` now takes a
-  `context.Context` parameter; internal-only, no user-visible API change.
+- Telemetry pings now deliver reliably from short-lived processes (CLI, serverless, cold-starts). `NewClient` blocks briefly (~350ms warm, ~1.3s cold; bounded at `telemetryTimeout`) while the ping is sent synchronously.
+- Telemetry path is bounded at `telemetryTimeout` (3s) total; the `/health` probe and checkpoint POST share a single context deadline instead of stacking.
 
 ## [5.6.0] - 2026-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Telemetry delivery on short-lived processes.** `NewClient` spawned
+  `sendTelemetryPing` as a goroutine that was abandoned when `main()`
+  returned, so any short-lived Go binary — CLI tools, serverless handlers,
+  quickstart snippets, cold-start functions — exited before the HTTP POST
+  to the checkpoint completed and silently dropped telemetry. The ping is
+  now sent synchronously from `NewClient` under a single shared
+  `context.WithTimeout(telemetryTimeout)`. `NewClient` blocks briefly
+  (typically ~350ms warm, ~1.3s cold; worst case bounded at
+  `telemetryTimeout`) but telemetry delivery is now deterministic.
+- **Telemetry budget no longer stacks.** `detectPlatformVersion` previously
+  used its own 2-second `context.WithTimeout`, and the checkpoint POST
+  used its own 3-second timeout on top. In the unreachable-endpoint case
+  the two stacked, blocking `NewClient` for up to ~5s — defeating the
+  bounded-at-`telemetryTimeout` guarantee. Both operations now share the
+  same context deadline so the total blocking time on `NewClient` stays
+  within `telemetryTimeout`. `detectPlatformVersion` now takes a
+  `context.Context` parameter; internal-only, no user-visible API change.
+
 ## [5.6.0] - 2026-04-22
 
 ### Added

--- a/axonflow.go
+++ b/axonflow.go
@@ -625,9 +625,11 @@ func NewClient(config AxonFlowConfig) *AxonFlowClient {
 	// cold-start function) returns from main() before the goroutine's HTTP
 	// POST completes, silently dropping the ping. See issue #1693.
 	//
-	// sendTelemetryPing is already bounded by context.WithTimeout(3s) and an
-	// http.Client timeout, so worst-case init latency is 3s when the
-	// checkpoint is unreachable; typical is ~350ms warm / ~1.3s cold.
+	// sendTelemetryPing runs the health probe and the checkpoint POST under a
+	// single shared context.WithTimeout(telemetryTimeout) so the total
+	// blocking time on NewClient is bounded at ~telemetryTimeout (3s),
+	// regardless of whether endpoints are reachable. Typical is ~350ms warm
+	// / ~1.3s cold.
 	client.sendTelemetryPing()
 
 	return client

--- a/axonflow.go
+++ b/axonflow.go
@@ -618,8 +618,17 @@ func NewClient(config AxonFlowConfig) *AxonFlowClient {
 		log.Printf("[AxonFlow] Client initialized - Mode: %s, Endpoint: %s, MapTimeout: %v", config.Mode, config.Endpoint, config.MapTimeout)
 	}
 
-	// Send telemetry ping (fire-and-forget).
-	go client.sendTelemetryPing()
+	// Send telemetry ping synchronously with a bounded timeout.
+	//
+	// A goroutine here would be fire-and-forget in theory, but in practice any
+	// short-lived process (CLI binary, serverless handler, quickstart snippet,
+	// cold-start function) returns from main() before the goroutine's HTTP
+	// POST completes, silently dropping the ping. See issue #1693.
+	//
+	// sendTelemetryPing is already bounded by context.WithTimeout(3s) and an
+	// http.Client timeout, so worst-case init latency is 3s when the
+	// checkpoint is unreachable; typical is ~350ms warm / ~1.3s cold.
+	client.sendTelemetryPing()
 
 	return client
 }

--- a/telemetry.go
+++ b/telemetry.go
@@ -102,15 +102,15 @@ type healthVersionResponse struct {
 	Version string `json:"version"`
 }
 
-// detectPlatformVersion calls the agent's /health endpoint to get the platform version.
-// Returns nil on any failure.
-func detectPlatformVersion(endpoint string) *string {
+// detectPlatformVersion calls the agent's /health endpoint to get the platform
+// version. Returns nil on any failure. The caller's context controls the
+// deadline so the health probe and the checkpoint POST share one budget —
+// preventing the two 3-second timeouts from stacking into ~6s of blocking on
+// unreachable endpoints (see issue #1693).
+func detectPlatformVersion(ctx context.Context, endpoint string) *string {
 	if endpoint == "" {
 		return nil
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"/health", nil)
 	if err != nil {
@@ -182,16 +182,19 @@ func (c *AxonFlowClient) isTelemetryEnabled() bool {
 	return c.config.Mode != "sandbox"
 }
 
-// sendTelemetryPing sends a synchronous, bounded-timeout telemetry ping to
-// the checkpoint service. It never returns an error — all failures are
+// sendTelemetryPing sends a synchronous telemetry ping to the checkpoint
+// service under a single shared context deadline covering both the /health
+// probe and the checkpoint POST. Never returns an error — all failures are
 // silently ignored. In debug mode, a version-outdated warning may be logged.
 //
 // Previously invoked as a goroutine (`go client.sendTelemetryPing()`), but
 // short-lived processes (CLI, serverless, quickstart scripts) returned from
 // main() before the goroutine's POST could complete, silently dropping the
-// ping. The function is now called synchronously from NewClient; the
-// context.WithTimeout + http.Client.Timeout below bound the worst case to
-// ~3s. See issue #1693.
+// ping. The function is now called synchronously from NewClient.
+//
+// Worst-case blocking time: telemetryTimeout (3s). Both detectPlatformVersion
+// and the checkpoint POST share the same context, so the individual
+// timeouts no longer stack. See issue #1693.
 func (c *AxonFlowClient) sendTelemetryPing() {
 	if !c.isTelemetryEnabled() {
 		return
@@ -211,8 +214,16 @@ func (c *AxonFlowClient) sendTelemetryPing() {
 		deploymentMode = "production"
 	}
 
-	// Detect platform version from health endpoint
-	platformVersion := detectPlatformVersion(c.config.Endpoint)
+	// Single shared deadline covering the ENTIRE telemetry path (health
+	// probe + checkpoint POST). Without this, the /health GET and the
+	// checkpoint POST each had their own timeout (2s + 3s), stacking into
+	// ~5s of potential blocking on NewClient when endpoints are
+	// unreachable — defeating the "bounded at telemetryTimeout" guarantee.
+	ctx, cancel := context.WithTimeout(context.Background(), telemetryTimeout)
+	defer cancel()
+
+	// Detect platform version from health endpoint (uses the shared deadline).
+	platformVersion := detectPlatformVersion(ctx, c.config.Endpoint)
 
 	payload := telemetryPayload{
 		SDK:             "go",
@@ -232,9 +243,7 @@ func (c *AxonFlowClient) sendTelemetryPing() {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), telemetryTimeout)
-	defer cancel()
-
+	// POST uses whatever budget remains after the health probe.
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, checkpointURL, bytes.NewReader(body))
 	if err != nil {
 		return

--- a/telemetry.go
+++ b/telemetry.go
@@ -182,9 +182,16 @@ func (c *AxonFlowClient) isTelemetryEnabled() bool {
 	return c.config.Mode != "sandbox"
 }
 
-// sendTelemetryPing sends a fire-and-forget telemetry ping to the checkpoint
-// service. It never returns an error — all failures are silently ignored.
-// In debug mode, a version-outdated warning may be logged.
+// sendTelemetryPing sends a synchronous, bounded-timeout telemetry ping to
+// the checkpoint service. It never returns an error — all failures are
+// silently ignored. In debug mode, a version-outdated warning may be logged.
+//
+// Previously invoked as a goroutine (`go client.sendTelemetryPing()`), but
+// short-lived processes (CLI, serverless, quickstart scripts) returned from
+// main() before the goroutine's POST could complete, silently dropping the
+// ping. The function is now called synchronously from NewClient; the
+// context.WithTimeout + http.Client.Timeout below bound the worst case to
+// ~3s. See issue #1693.
 func (c *AxonFlowClient) sendTelemetryPing() {
 	if !c.isTelemetryEnabled() {
 		return

--- a/telemetry_short_lived_test.go
+++ b/telemetry_short_lived_test.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -81,14 +82,12 @@ func TestTelemetryDeliveryOnShortLivedProcess(t *testing.T) {
 	}
 
 	// Run the binary, no wait, no sleep. Point telemetry at the mock server.
+	// Inherit parent env so the test works on any CI runner / shell, but
+	// scrub the two opt-out vars that might otherwise disable telemetry
+	// (e.g. a developer shell with DO_NOT_TRACK=1 exported globally).
 	runCmd := exec.Command(binPath)
-	runCmd.Env = append(runCmd.Env,
-		"PATH="+envPath(),
-		"HOME="+binDir,
+	runCmd.Env = append(filterOptOutEnv(os.Environ()),
 		"AXONFLOW_CHECKPOINT_URL="+server.URL+"/v1/ping",
-		// explicit: unset common opt-outs that might leak in from developer shells
-		"DO_NOT_TRACK=",
-		"AXONFLOW_TELEMETRY=",
 	)
 	if out, err := runCmd.CombinedOutput(); err != nil {
 		t.Fatalf("binary run failed: %v\n%s", err, out)
@@ -108,11 +107,19 @@ func TestTelemetryDeliveryOnShortLivedProcess(t *testing.T) {
 	}
 }
 
-// envPath returns a minimal PATH sufficient to find `go` in the subprocess's
-// build step (for transitive tooling if any). Kept narrow to avoid leaking
-// the test shell's developer env into the binary's runtime.
-func envPath() string {
-	return "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin"
+// filterOptOutEnv returns the parent environment with DO_NOT_TRACK and
+// AXONFLOW_TELEMETRY removed. Used so the regression test exercises the
+// telemetry-enabled code path even when the developer's shell has one of
+// those set globally.
+func filterOptOutEnv(env []string) []string {
+	out := make([]string, 0, len(env))
+	for _, e := range env {
+		if strings.HasPrefix(e, "DO_NOT_TRACK=") || strings.HasPrefix(e, "AXONFLOW_TELEMETRY=") {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
 }
 
 func writeShortLivedBinary(dir, modRoot string) error {

--- a/telemetry_short_lived_test.go
+++ b/telemetry_short_lived_test.go
@@ -1,0 +1,148 @@
+// Regression test for issue #1693: telemetry must be delivered even when a
+// Go binary exits immediately after client init.
+//
+// Root cause: `go client.sendTelemetryPing()` spawned a goroutine that was
+// abandoned when main() returned, silently dropping the HTTP POST to
+// checkpoint. The fix makes the call synchronous so the bounded-timeout
+// context.WithTimeout guarantees the POST either lands or times out before
+// main() returns.
+//
+// This test exercises a *compiled binary in a subprocess* — not in-process
+// goroutines — so it hits the real "main() returns immediately" path that
+// production users experience. In-process tests can't catch this regression
+// because the test binary keeps running long enough for the goroutine to
+// complete.
+
+package axonflow
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestTelemetryDeliveryOnShortLivedProcess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("subprocess telemetry test requires POSIX go build chain")
+	}
+
+	// Mock checkpoint server captures any POST it receives.
+	var received atomic.Int32
+	var mu sync.Mutex
+	var payloads []map[string]any
+
+	handler := http.NewServeMux()
+	handler.HandleFunc("/v1/ping", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload map[string]any
+		_ = json.Unmarshal(body, &payload)
+		mu.Lock()
+		payloads = append(payloads, payload)
+		mu.Unlock()
+		received.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"latest_version":"99.99.99","source":"external"}`))
+	})
+	handler.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","version":"mock-1.0"}`))
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// Locate the module root so we can build from an external cmd dir.
+	// The module under test is the current one (this _test.go lives at its root).
+	modRoot, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+
+	// Build a tiny binary that imports this module (via local replace) and
+	// exits immediately after NewClient — no sleep, no goroutine wait. This
+	// is the exact shape of a real short-lived caller.
+	binDir := t.TempDir()
+	srcDir := filepath.Join(binDir, "src")
+	if err := writeShortLivedBinary(srcDir, modRoot); err != nil {
+		t.Fatalf("writeShortLivedBinary: %v", err)
+	}
+	binPath := filepath.Join(binDir, "shortlived")
+	buildCmd := exec.Command("go", "build", "-o", binPath, ".")
+	buildCmd.Dir = srcDir
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, out)
+	}
+
+	// Run the binary, no wait, no sleep. Point telemetry at the mock server.
+	runCmd := exec.Command(binPath)
+	runCmd.Env = append(runCmd.Env,
+		"PATH="+envPath(),
+		"HOME="+binDir,
+		"AXONFLOW_CHECKPOINT_URL="+server.URL+"/v1/ping",
+		// explicit: unset common opt-outs that might leak in from developer shells
+		"DO_NOT_TRACK=",
+		"AXONFLOW_TELEMETRY=",
+	)
+	if out, err := runCmd.CombinedOutput(); err != nil {
+		t.Fatalf("binary run failed: %v\n%s", err, out)
+	}
+
+	if got := received.Load(); got != 1 {
+		t.Fatalf("expected 1 telemetry ping after immediate-exit binary, got %d", got)
+	}
+	mu.Lock()
+	payload := payloads[0]
+	mu.Unlock()
+	if sdk, _ := payload["sdk"].(string); sdk != "go" {
+		t.Errorf("ping sdk field: got %q, want %q", sdk, "go")
+	}
+	if _, ok := payload["instance_id"].(string); !ok {
+		t.Errorf("ping missing instance_id: %+v", payload)
+	}
+}
+
+// envPath returns a minimal PATH sufficient to find `go` in the subprocess's
+// build step (for transitive tooling if any). Kept narrow to avoid leaking
+// the test shell's developer env into the binary's runtime.
+func envPath() string {
+	return "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin"
+}
+
+func writeShortLivedBinary(dir, modRoot string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	// go.mod that replaces the upstream module with the local checkout.
+	goMod := `module shortlived
+
+go 1.21
+
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.0.0-00010101000000-000000000000
+
+replace github.com/getaxonflow/axonflow-sdk-go/v5 => ` + modRoot + `
+`
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o644); err != nil {
+		return err
+	}
+	main := `package main
+
+import (
+	axonflow "github.com/getaxonflow/axonflow-sdk-go/v5"
+)
+
+func main() {
+	_ = axonflow.NewClient(axonflow.AxonFlowConfig{
+		Endpoint: "http://127.0.0.1:1",
+	})
+	// no sleep, no goroutine wait — this is the regression case
+}
+`
+	return os.WriteFile(filepath.Join(dir, "main.go"), []byte(main), 0o644)
+}


### PR DESCRIPTION
Closes getaxonflow/axonflow-enterprise#1693

## Summary

\`NewClient\` spawned \`sendTelemetryPing\` as a goroutine. Short-lived Go binaries (CLI tools, serverless handlers, quickstart snippets, cold-start functions) return from \`main()\` before the goroutine's HTTP POST completes — silently dropping telemetry with no error visible to the caller.

## Investigation

Reproduced 2026-04-24 against a local mock checkpoint server using v5.6.0:
- 5× \`./testapp\` that calls \`NewClient\` and exits immediately → **0/5 pings arrived**
- Same binary + \`time.Sleep(5s)\` → **1/1 arrives**
- TypeScript SDK on identical setup → **5/5 arrives** (Node event loop refcounts pending fetches)
- Python SDK had identical bug (daemon thread) — fixed in axonflow-sdk-python PR that closes #1692

Full investigation: \`axonflow-business-docs/metrics/TELEMETRY_ADOPTION_BASELINE_2026-04-24.md\`.

## Fix (per review preference)

Call \`sendTelemetryPing\` synchronously from \`NewClient\`. The function already uses \`context.WithTimeout(3s)\` and \`http.Client.Timeout\`, so worst-case init latency is bounded to ~3s when checkpoint is unreachable; typical is ~350ms warm / ~1.3s cold.

Cleaner than \"goroutine + sleep-and-hope\" because:
1. Exit semantics are deterministic — ping either lands or times out before \`NewClient\` returns
2. No race with the caller's \`main()\` exit
3. \`context.WithTimeout\` is the idiomatic Go pattern for bounded-deadline work

## Regression test

\`telemetry_short_lived_test.go\` compiles a tiny binary in a temp directory (local \`replace\` directive pointing at the module under test), runs it, and asserts a local \`httptest\` server receives the ping. This is the invariant that catches the regression — in-process Go tests can't because the test binary keeps running long enough for goroutines to complete.

Verified:
- Test **FAILS** when the goroutine spawn is restored (explicit error: \`expected 1 telemetry ping after immediate-exit binary, got 0\`)
- Test **PASSES** with the synchronous call in place
- Full \`go test ./...\`: all packages green

## Impact

Closes one of three compounding silent-failure modes in the 2026-04-24 baseline. Separate tracks:
- axonflow-enterprise#1695 — bare-import-path trap resolving to v1.17.0 instead of v5.x

## Post-merge

Bump to **v5.7.0** (minor, user-visible delivery reliability change). Tag and publish; pkg.go.dev will pick up within ~10m.