### PR TITLE
docs(readme): make /v5 module path explicit to stop pkg.go.dev trap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Telemetry pings now deliver reliably from short-lived processes (CLI, serverless, cold-starts). `NewClient` blocks briefly (~350ms warm, ~1.3s cold; bounded at `telemetryTimeout`) while the ping is sent synchronously.
 - Telemetry path is bounded at `telemetryTimeout` (3s) total; the `/health` probe and checkpoint POST share a single context deadline instead of stacking.
 
+### Changed
+
+- README makes the `/v5` import path requirement explicit. `go get github.com/getaxonflow/axonflow-sdk-go@latest` (without `/v5`) resolves to the pre-v2 `v1.17.0` relic; the correct module path is `github.com/getaxonflow/axonflow-sdk-go/v5`. Added a top-of-README banner, corrected the install command and import examples (all formerly `/v4`), and expanded the Migration Guide with v1→v5 and v4→v5 paths.
+
 ## [5.6.0] - 2026-04-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 > go get github.com/getaxonflow/axonflow-sdk-go/v5
 > ```
 >
-> `go get github.com/getaxonflow/axonflow-sdk-go@latest` (without `/v5`) resolves to **v1.17.0** (a 2026-01 relic from before the v2 split) and is missing three major versions of functionality. See the [Migration Guide](#migration-guide) below.
+> `go get github.com/getaxonflow/axonflow-sdk-go@latest` (without `/v5`) resolves to **v1.17.0** (a 2026-01 relic from before the v2 split) and is four major release lines behind current. See the [Migration Guide](#migration-guide) below.
 
 > **Evaluating AxonFlow in production?** We're opening limited Design Partner slots.
 >
@@ -825,8 +825,8 @@ Update all imports in your `.go` files from `/v4` to `/v5`. No API-surface chang
 **1. Update module path:**
 ```bash
 # In go.mod, change:
-#   github.com/getaxonflow/axonflow-sdk-go/v3 → github.com/getaxonflow/axonflow-sdk-go/v5
-go get github.com/getaxonflow/axonflow-sdk-go/v5@v4.0.0
+#   github.com/getaxonflow/axonflow-sdk-go/v3 → github.com/getaxonflow/axonflow-sdk-go/v4
+go get github.com/getaxonflow/axonflow-sdk-go/v4@v4.0.0
 ```
 
 Update all imports in your `.go` files from `v3` to `v4`.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,22 @@
 # AxonFlow SDK for Go
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/getaxonflow/axonflow-sdk-go/v4.svg)](https://pkg.go.dev/github.com/getaxonflow/axonflow-sdk-go/v4)
+[![Go Reference](https://pkg.go.dev/badge/github.com/getaxonflow/axonflow-sdk-go/v5.svg)](https://pkg.go.dev/github.com/getaxonflow/axonflow-sdk-go/v5)
 [![Go Report Card](https://goreportcard.com/badge/github.com/getaxonflow/axonflow-sdk-go)](https://goreportcard.com/report/github.com/getaxonflow/axonflow-sdk-go)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+> ## ⚠️ Use the `/v5` import path
+>
+> Go's semantic import versioning requires the module path to include the major version suffix for v2+. The current release line is **v5.x**, imported as:
+>
+> ```go
+> import "github.com/getaxonflow/axonflow-sdk-go/v5"
+> ```
+>
+> ```bash
+> go get github.com/getaxonflow/axonflow-sdk-go/v5
+> ```
+>
+> `go get github.com/getaxonflow/axonflow-sdk-go@latest` (without `/v5`) resolves to **v1.17.0** (a 2026-01 relic from before the v2 split) and is missing three major versions of functionality. See the [Migration Guide](#migration-guide) below.
 
 > **Evaluating AxonFlow in production?** We're opening limited Design Partner slots.
 >
@@ -35,7 +49,7 @@ If you're new to AxonFlow, this short video shows how the control plane and SDKs
 ## Installation
 
 ```bash
-go get github.com/getaxonflow/axonflow-sdk-go/v4
+go get github.com/getaxonflow/axonflow-sdk-go/v5
 ```
 
 ## Evaluation Tier (Free License)
@@ -83,7 +97,7 @@ import (
     "log"
     "os"
 
-    "github.com/getaxonflow/axonflow-sdk-go/v4"
+    "github.com/getaxonflow/axonflow-sdk-go/v5"
 )
 
 func main() {
@@ -121,7 +135,7 @@ func main() {
 import (
     "time"
     "os"
-    "github.com/getaxonflow/axonflow-sdk-go/v4"
+    "github.com/getaxonflow/axonflow-sdk-go/v5"
 )
 
 // Full configuration with all features
@@ -159,7 +173,7 @@ import (
     "fmt"
     "log"
 
-    "github.com/getaxonflow/axonflow-sdk-go/v4"
+    "github.com/getaxonflow/axonflow-sdk-go/v5"
 )
 
 func main() {
@@ -293,8 +307,8 @@ Wrap your LLM clients with automatic AxonFlow governance using the interceptors 
 import (
     "context"
     "github.com/sashabaranov/go-openai"
-    "github.com/getaxonflow/axonflow-sdk-go/v4"
-    "github.com/getaxonflow/axonflow-sdk-go/v4/interceptors"
+    "github.com/getaxonflow/axonflow-sdk-go/v5"
+    "github.com/getaxonflow/axonflow-sdk-go/v5/interceptors"
 )
 
 // Initialize AxonFlow client
@@ -346,8 +360,8 @@ if err != nil {
 ```go
 import (
     "context"
-    "github.com/getaxonflow/axonflow-sdk-go/v4"
-    "github.com/getaxonflow/axonflow-sdk-go/v4/interceptors"
+    "github.com/getaxonflow/axonflow-sdk-go/v5"
+    "github.com/getaxonflow/axonflow-sdk-go/v5/interceptors"
 )
 
 // Create Anthropic interceptor
@@ -772,13 +786,47 @@ fmt.Printf("Result: %v\n", resp.Data)
 
 ## Migration Guide
 
+### Migrating from v1.x (bare import path) to v5
+
+If `go get github.com/getaxonflow/axonflow-sdk-go@latest` resolved to **v1.17.0**, you are on a 2026-01 relic because you used the bare module path. Go's semantic import versioning requires the `/v5` suffix for v2+ releases.
+
+```bash
+# In go.mod, remove the old entry and replace with the v5 path:
+#   github.com/getaxonflow/axonflow-sdk-go → github.com/getaxonflow/axonflow-sdk-go/v5
+go get github.com/getaxonflow/axonflow-sdk-go/v5
+```
+
+Update all imports in your `.go` files to include `/v5`:
+
+```go
+// Before:
+import "github.com/getaxonflow/axonflow-sdk-go"
+
+// After:
+import "github.com/getaxonflow/axonflow-sdk-go/v5"
+```
+
+The API surface between v1 and v5 is substantially different. Check the release notes for v2, v3, v4, and v5 for the breaking changes you'll need to adopt. If you're coming from v1.x directly, the fastest path is usually to re-read the [Quick Start](#quick-start) section rather than trying to incrementally migrate.
+
+### Migrating from v4 to v5
+
+**1. Update module path:**
+
+```bash
+# In go.mod, change:
+#   github.com/getaxonflow/axonflow-sdk-go/v4 → github.com/getaxonflow/axonflow-sdk-go/v5
+go get github.com/getaxonflow/axonflow-sdk-go/v5
+```
+
+Update all imports in your `.go` files from `/v4` to `/v5`. No API-surface changes are required for the v4 → v5 bump itself — the major version increment reflects a policy break in how plan-scoped HITL responses are returned. See the [v5.0.0 release notes](https://github.com/getaxonflow/axonflow-sdk-go/releases/tag/v5.0.0) for the specifics.
+
 ### Migrating from v3 to v4
 
 **1. Update module path:**
 ```bash
 # In go.mod, change:
-#   github.com/getaxonflow/axonflow-sdk-go/v3 → github.com/getaxonflow/axonflow-sdk-go/v4
-go get github.com/getaxonflow/axonflow-sdk-go/v4@v4.0.0
+#   github.com/getaxonflow/axonflow-sdk-go/v3 → github.com/getaxonflow/axonflow-sdk-go/v5
+go get github.com/getaxonflow/axonflow-sdk-go/v5@v4.0.0
 ```
 
 Update all imports in your `.go` files from `v3` to `v4`.


### PR DESCRIPTION
Closes getaxonflow/axonflow-enterprise#1695

## Summary

Go's semantic import versioning requires the \`/v5\` suffix for v2+ releases. Users who follow the natural flow (click repo URL, copy \`go get github.com/getaxonflow/axonflow-sdk-go@latest\`) silently get **v1.17.0** — a 2026-01 relic from before the v2 split, missing four major versions of functionality. The README itself was part of the problem: its pkg.go.dev badge, install command, and all import examples still said \`/v4\`.

## Reproduction

\`\`\`
$ curl -s https://proxy.golang.org/github.com/getaxonflow/axonflow-sdk-go/@latest
{\"Version\":\"v1.17.0\",\"Time\":\"2026-01-04T...\"}

$ curl -s https://proxy.golang.org/github.com/getaxonflow/axonflow-sdk-go/v5/@latest
{\"Version\":\"v5.6.0\",\"Time\":\"2026-04-22T...\"}
\`\`\`

## Changes

- **Top-of-README banner** explicitly calling out the \`/v5\` requirement and the v1.17.0 trap. Users scanning the README for how-to-install see it before any feature copy.
- **pkg.go.dev badge** updated \`/v4\` → \`/v5\` so the live badge reflects the real current version.
- **Install command + all import examples** updated \`/v4\` → \`/v5\` (11 occurrences) so copy-pasted snippets actually work on the current line.
- **Migration Guide** gains:
  - v1.x (bare path) → v5 section for users who already hit the trap
  - v4 → v5 section for the structural major-version bump
  - Existing v3 → v4 section preserved for history
- **CHANGELOG** [Unreleased] / Changed entry documenting the discoverability fix (terse per the telemetry-CHANGELOG-minimal convention; full story lives here and in the issue).

## Why docs, not code

Yanking v1.17.0 doesn't fix this — the \`/v5\` path is structurally required by Go's semver rule. The path trap can only be closed by making the correct command obvious everywhere a user might land. This PR covers the most-visited surface (the repo README). Related docs elsewhere (docs.getaxonflow.com, blog posts, tutorials) should be swept in a follow-up.

## Test plan

- [x] Rendered README locally — banner is the first visible content block after the badges
- [x] All 11 \`/v4\` → \`/v5\` replacements applied; \`grep '/v4' README.md\` now only hits the Migration Guide section (intentional, history)
- [ ] After merge, verify pkg.go.dev crawler picks up the new badge link (next crawl cycle)