### PR TITLE
chore(release): promote [Unreleased] to [5.6.1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [5.6.1] - 2026-04-25
 
 ### Changed
 

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package axonflow
 
 // Version is the SDK version.
-const Version = "5.6.0"
+const Version = "5.6.1"


### PR DESCRIPTION
## Summary

Release-prep for Go SDK v5.6.1. Two line changes:

- `CHANGELOG.md`: `## [Unreleased]` → `## [5.6.1] - 2026-04-25`
- `version.go`: `const Version = \"5.6.0\"` → `\"5.6.1\"`

Both moves happen in the same commit so the new \`validate-version-alignment\` gate (merged with #130) stays green across the transition.

## What ships in v5.6.1

User-facing fixes accumulated since v5.6.0:

- **README makes the `/v5` import path requirement explicit.** Users running `go get github.com/getaxonflow/axonflow-sdk-go@latest` without `/v5` were resolving to the pre-v2 `v1.17.0` relic. The README now has a top-of-page banner, corrected install command, import examples with `/v5`, and an expanded Migration Guide covering v1→v5 and v4→v5 paths. (#129)
- **Telemetry pings deliver reliably from short-lived processes.** CLI, serverless, and cold-start invocations were dropping their ping because the daemon goroutine was being terminated before the HTTP POST completed. Fix: synchronous send from `NewClient` bounded at `telemetryTimeout` (~350ms warm, ~1.3s cold). (#128)
- **Telemetry path time-bounded at `telemetryTimeout` (3s) total.** `/health` probe and checkpoint POST now share a single context deadline instead of stacking. (#128)

## Not in the user-facing CHANGELOG

The wire-shape contract CI (#130) and the new version-alignment gate that landed in the same Unreleased window are internal tooling per the `feedback_changelog_no_internal_entries.md` policy. One exception: `go.mod` gained `gopkg.in/yaml.v3` as a test-only dep, which IS observable to anyone running `go mod tidy` on a consuming project, so there's a one-line Notes entry for that.

## Release flow after merge

1. Merge this PR
2. Tag `v5.6.1` at the merge commit
3. `release.yml` preflight validates CHANGELOG section matches tag
4. pkg.go.dev index auto-refreshes

## Test plan

- [x] `validate-version-alignment.sh` passes locally (5.6.1 on both sides)
- [x] Release workflow's awk extracts the right section (`awk -v ver=5.6.1 ...` yields the renamed content)
- [ ] CI green on this PR