### PR TITLE
fix(script): version-alignment grep-no-match silent abort

### DIFF
--- a/.github/scripts/validate-version-alignment.sh
+++ b/.github/scripts/validate-version-alignment.sh
@@ -23,7 +23,13 @@ ERRORS=0
 # accumulates in-flight changes between tags and must not be used as
 # the expected-version target — the manifest only gets bumped when we
 # actually cut a tag.
-LATEST_VERSION=$(grep -m1 -E '^## \[[0-9]' CHANGELOG.md | sed 's/## \[\(.*\)\].*/\1/' | sed 's/^v//')
+#
+# `{ grep || true; }` is deliberate: under `set -euo pipefail`, a
+# failing grep (no match) aborts the whole command substitution
+# before the `-z` check can produce the friendly error below. The
+# wrapper lets the -z branch fire with a readable message instead of
+# a silent exit.
+LATEST_VERSION=$({ grep -m1 -E '^## \[[0-9]' CHANGELOG.md || true; } | sed 's/## \[\(.*\)\].*/\1/' | sed 's/^v//')
 
 if [ -z "${LATEST_VERSION:-}" ]; then
     echo "❌ Could not extract a released version (## [X.Y.Z]) from CHANGELOG.md"


### PR DESCRIPTION
## Summary

One-line hardening on the version-alignment script that landed in #130. Under \`set -euo pipefail\`, a \`grep\`-no-match on the \`LATEST_VERSION\` pipeline aborts the whole command substitution before the \`-z\` check runs, so a CHANGELOG with no released section produces a silent exit instead of the friendly error the code clearly intends.

Wrapping the grep in \`{ ... || true; }\` lets the -z branch fire with its message.

Discovered during deep-review of the same pattern in PR #153 (Python) and PR #182 (TypeScript); applying the fix here on Go for parity.

## Before

```
before extraction
exit=1
# silent abort, no message
```

## After

```
before extraction
after extraction: LATEST_VERSION=[]
❌ Could not extract a released version (## [X.Y.Z]) from CHANGELOG.md
exit=1
```

## Test plan

- [x] Direct test of the pipeline pattern with a no-match input reaches the -z branch
- [x] Validator still passes on the current aligned state (CHANGELOG [5.6.1] + version.go 5.6.1)
- [ ] CI green on this PR