### PR TITLE
feat(types): wire-shape alignment sweep (Cat B + RENAME_SAFE + UNRECOVERABLE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`WebhookSubscription.Secret`** — HMAC-SHA256 signing key now exposed on the response from `CreateWebhook`. Required to verify the `X-AxonFlow-Signature` header on inbound webhook deliveries; without it, callers couldn't validate payload authenticity. Also adds `OrgID` and `TenantID` (ownership scoping).
+- **`StepGateRequest`** carries `TokensIn`, `TokensOut`, `CostUSD` so budget-based policies can evaluate gate-time cost estimates.
+- **`StepGateResponse.DecisionID`** — unique audit correlator that links a gate response to its audit row (previously absent on the SDK, present on the wire).
+- **`ListWorkflowsResponse.Limit` / `Offset`** — pagination echo, surfaced on the response.
+- **`StaticPolicy.PolicyID` / `Priority`** — wire-canonical fields surfaced.
+- **`CreateStaticPolicyRequest.Priority` / `Tags`** and **`UpdateStaticPolicyRequest.Priority` / `Tags`** — match the spec.
+- **`UpdatePlanRequest.Metadata`** — accept arbitrary plan metadata, opaque to the platform.
+- **`UsageBreakdownItem.GroupBy`** — dimension name (provider/model/agent/etc.) is now exposed on each item.
+- **`BudgetAlert.Acknowledged`** — alert dismissal flag.
+- **`Budget.OrgID` / `TenantID`** — ownership scoping.
+- **`UsageRecord`** gains `CreatedAt`, `Success`, `ErrorMessage`, `LatencyMS`, `TeamID`, `TenantID`, `UserID`, `WorkflowID` to match the wire. The legacy `Timestamp` field is `Deprecated`; the wire emits `created_at`, so `Timestamp` has always read empty.
+- **`WorkflowStatusResponse.Metadata`** — arbitrary workflow metadata.
+- **`CreateWorkflowResponse.StartedAt`** — wire-canonical timestamp. Legacy `CreatedAt` and `Source` are `Deprecated`; they have always read zero/empty (wire emits neither).
+- **`ExecutionSnapshot.RetryCount`** — number of retry attempts on a step.
+- **`Finding.Article`** — regulatory article reference (e.g. MAS FEAT principle number).
+- **`PolicyOverride.ID` / `EnabledOverride`** — wire-canonical fields. `Active` is `Deprecated`; the wire emits `enabled_override`, so `Active` has always read false.
+- **`PolicyVersion.ID` / `PolicyID` / `ChangeSummary` / `Snapshot`** — match the wire shape (versions are immutable snapshots, not before/after diffs). `ChangeDescription`, `PreviousValues`, `NewValues` are `Deprecated` orphan-reads.
+- **`DynamicPolicyMatch.Message`** — wire-canonical name. `Reason` is `Deprecated` (read empty today).
+- **`ExfiltrationCheckInfo.Exceeded` / `LimitType`** — match the wire. `WithinLimits` is `Deprecated`.
+- **`CancelPlanResponse.Success`** — wire-canonical boolean. `Message` is `Deprecated` (orphan read).
+- **`PlanResponse`** gains the wire top-level fields `Success`, `Version`, `Result`, `Error`, `WorkflowExecutionID`, `PolicyInfo`. The decoder is JSON.Decode passthrough, so consumers can now read these directly.
+- **`ResumePlanResponse.Result`** — final aggregated result (canonical wire field). The 6 fields `WorkflowID`, `Message`, `StepResult`, `NextStep`, `NextStepName`, `TotalSteps` are now `Deprecated`; none of them were populated by the resume decoder against the actual server response.
+- **`HealthResponse.Components` / `Features`** — match the wire health shape.
+
+### Notes
+
+The above is an audit-driven sweep against the wire-shape contract gate. All changes are additive (new fields are pointer or `,omitempty`-tagged so existing user code keeps compiling) or `Deprecated`-marked alias fields kept for source-compat. Removal scheduled for v6.
+
+Two platform-side spec corrections filed alongside this work, for issues the audit surfaced where the spec was wrong (server emits the SDK's name): `AISystemRegistry.materiality_classification` (axonflow-enterprise#1708), `DynamicPolicyInfo` schema completely wrong shape (axonflow-enterprise#1709). No SDK change for those — the SDK is correct.
+
 ## [5.6.1] - 2026-04-25
 
 ### Changed

--- a/axonflow.go
+++ b/axonflow.go
@@ -222,8 +222,15 @@ type ExfiltrationCheckInfo struct {
 	BytesReturned int64 `json:"bytes_returned"`
 	// ByteLimit is the configured maximum bytes per response
 	ByteLimit int64 `json:"byte_limit"`
-	// WithinLimits indicates whether the response is within configured limits
-	WithinLimits bool `json:"within_limits"`
+	// Exceeded indicates whether any exfiltration limit was exceeded
+	// (canonical wire field; logical negation of WithinLimits).
+	Exceeded bool `json:"exceeded,omitempty"`
+	// LimitType identifies which limit was exceeded ("rows", "bytes", "none").
+	LimitType string `json:"limit_type,omitempty"`
+	// Deprecated: the wire emits Exceeded + LimitType, not WithinLimits.
+	// This field has always read false against JSON-decoded responses.
+	// Removed in v6.
+	WithinLimits bool `json:"within_limits,omitempty"`
 }
 
 // DynamicPolicyInfo contains information about dynamic policy evaluation (Issue #968).
@@ -250,7 +257,11 @@ type DynamicPolicyMatch struct {
 	PolicyType string `json:"policy_type"`
 	// Action is the action taken (allow, block, log, etc.)
 	Action string `json:"action"`
-	// Reason provides context for the policy match
+	// Message is the policy evaluation message (canonical wire field).
+	Message string `json:"message,omitempty"`
+	// Deprecated: the wire emits `message`, not `reason`. This field
+	// has always read empty against JSON-decoded responses. Removed
+	// in v6.
 	Reason string `json:"reason,omitempty"`
 }
 
@@ -298,6 +309,18 @@ type PlanResponse struct {
 	Parallel          bool                   `json:"parallel"`           // Whether steps can run in parallel
 	EstimatedDuration string                 `json:"estimated_duration"` // Estimated execution time
 	Metadata          map[string]interface{} `json:"metadata"`
+	// Success indicates whether the plan was created successfully (wire top-level field).
+	Success bool `json:"success,omitempty"`
+	// Version is the plan version number for optimistic locking.
+	Version int `json:"version,omitempty"`
+	// Result is the final aggregated result if the plan executed inline.
+	Result interface{} `json:"result,omitempty"`
+	// Error is the error message if creation failed.
+	Error string `json:"error,omitempty"`
+	// WorkflowExecutionID is set when the plan was auto-executed.
+	WorkflowExecutionID string `json:"workflow_execution_id,omitempty"`
+	// PolicyInfo is the policy evaluation summary for this plan creation.
+	PolicyInfo *PolicyEvaluationResult `json:"policy_info,omitempty"`
 }
 
 // PlanStep represents a single step in a multi-agent plan
@@ -376,10 +399,19 @@ type GeneratePlanOptions struct {
 }
 
 // CancelPlanResponse represents the response from cancelling a plan.
+//
+// The wire shape is `{success, plan_id, status}`. The legacy
+// `Message` field reads `data.message` which the server doesn't emit;
+// use `Success` and the `Status` enum to detect outcome.
 type CancelPlanResponse struct {
-	PlanID  string `json:"plan_id"`
-	Status  string `json:"status"`
-	Message string `json:"message"`
+	PlanID string `json:"plan_id"`
+	Status string `json:"status"`
+	// Success signals whether the cancel succeeded (canonical wire field).
+	Success bool `json:"success,omitempty"`
+	// Deprecated: the wire emits success+status, not message. This
+	// field has always read empty against JSON-decoded responses.
+	// Removed in v6.
+	Message string `json:"message,omitempty"`
 }
 
 // UpdatePlanRequest represents a request to update a plan's configuration.
@@ -387,6 +419,8 @@ type UpdatePlanRequest struct {
 	ExpectedVersion int           `json:"version"`
 	ExecutionMode   ExecutionMode `json:"execution_mode,omitempty"`
 	Domain          string        `json:"domain,omitempty"`
+	// Metadata is arbitrary plan metadata, opaque to the platform.
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // UpdatePlanResponse represents the response from updating a plan.
@@ -413,16 +447,32 @@ type PlanVersionsResponse struct {
 }
 
 // ResumePlanResponse represents the response from resuming a paused plan.
+//
+// Wire shape: {plan_id, status, result}. The Approved/Message/StepResult/
+// NextStep/NextStepName/TotalSteps/WorkflowID fields are kept for
+// source-compat — none of them are populated by the resume decoder
+// against the actual server response. New code should read Result.
 type ResumePlanResponse struct {
-	PlanID       string      `json:"plan_id"`
-	WorkflowID   string      `json:"workflow_id,omitempty"`
-	Status       string      `json:"status"`
-	Approved     bool        `json:"approved,omitempty"`
-	Message      string      `json:"message,omitempty"`
-	StepResult   interface{} `json:"step_result,omitempty"`
-	NextStep     int         `json:"next_step,omitempty"`
-	NextStepName string      `json:"next_step_name,omitempty"`
-	TotalSteps   int         `json:"total_steps,omitempty"`
+	PlanID string `json:"plan_id"`
+	Status string `json:"status"`
+	// Result is the final aggregated result if the resume completed
+	// (canonical wire field).
+	Result interface{} `json:"result,omitempty"`
+	// Approved is sometimes populated (legacy). Prefer Status enum.
+	Approved bool `json:"approved,omitempty"`
+	// Deprecated: never populated; the wire emits result, not message.
+	// Removed in v6.
+	Message string `json:"message,omitempty"`
+	// Deprecated: never populated; use Result. Removed in v6.
+	StepResult interface{} `json:"step_result,omitempty"`
+	// Deprecated: not on the wire; never populated. Removed in v6.
+	NextStep int `json:"next_step,omitempty"`
+	// Deprecated: not on the wire; never populated. Removed in v6.
+	NextStepName string `json:"next_step_name,omitempty"`
+	// Deprecated: not on the wire; never populated. Removed in v6.
+	TotalSteps int `json:"total_steps,omitempty"`
+	// Deprecated: not on the wire; never populated. Removed in v6.
+	WorkflowID string `json:"workflow_id,omitempty"`
 }
 
 // RollbackPlanRequest represents a request to rollback a plan to a previous version.
@@ -1030,6 +1080,11 @@ type HealthResponse struct {
 	Timestamp    string               `json:"timestamp"`
 	Capabilities []PlatformCapability `json:"capabilities,omitempty"`
 	SDKCompat    *SDKCompatibility    `json:"sdk_compatibility,omitempty"`
+	// Components reports the health status of individual platform
+	// components (database, redis, orchestrator, etc).
+	Components map[string]string `json:"components,omitempty"`
+	// Features reports enabled feature flags relevant to the SDK.
+	Features map[string]interface{} `json:"features,omitempty"`
 }
 
 // PlatformCapability describes a feature supported by the platform.

--- a/cost_controls.go
+++ b/cost_controls.go
@@ -50,8 +50,12 @@ type Budget struct {
 	AlertThresholds []int   `json:"alert_thresholds"`
 	Enabled         bool    `json:"enabled"`
 	ScopeID         string  `json:"scope_id,omitempty"`
-	CreatedAt       string  `json:"created_at,omitempty"`
-	UpdatedAt       string  `json:"updated_at,omitempty"`
+	// TenantID is the tenant that owns this budget.
+	TenantID string `json:"tenant_id,omitempty"`
+	// OrgID is the organization that owns this budget.
+	OrgID     string `json:"org_id,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
 }
 
 // BudgetsResponse represents a list of budgets response
@@ -90,6 +94,8 @@ type BudgetAlert struct {
 	AmountUSD         float64 `json:"amount_usd"`
 	Message           string  `json:"message"`
 	CreatedAt         string  `json:"created_at"`
+	// Acknowledged signals whether an operator has dismissed the alert.
+	Acknowledged bool `json:"acknowledged,omitempty"`
 }
 
 // BudgetAlertsResponse represents a list of budget alerts
@@ -146,6 +152,8 @@ type UsageSummary struct {
 
 // UsageBreakdownItem represents a single item in usage breakdown
 type UsageBreakdownItem struct {
+	// GroupBy is the dimension name (provider, model, agent, etc).
+	GroupBy      string  `json:"group_by,omitempty"`
 	GroupValue   string  `json:"group_value"`
 	CostUSD      float64 `json:"cost_usd"`
 	Percentage   float64 `json:"percentage"`
@@ -175,7 +183,27 @@ type UsageRecord struct {
 	RequestID string  `json:"request_id,omitempty"`
 	OrgID     string  `json:"org_id,omitempty"`
 	AgentID   string  `json:"agent_id,omitempty"`
-	Timestamp string  `json:"timestamp,omitempty"`
+	// CreatedAt is the canonical wire timestamp; the server emits
+	// `created_at`, not `timestamp`.
+	CreatedAt string `json:"created_at,omitempty"`
+	// Success signals whether the underlying request succeeded.
+	Success bool `json:"success,omitempty"`
+	// ErrorMessage carries the failure reason when Success is false.
+	ErrorMessage string `json:"error_message,omitempty"`
+	// LatencyMS is request latency in milliseconds.
+	LatencyMS int `json:"latency_ms,omitempty"`
+	// TeamID associates the record with a team scope.
+	TeamID string `json:"team_id,omitempty"`
+	// TenantID is the tenant that owns this record.
+	TenantID string `json:"tenant_id,omitempty"`
+	// UserID is the user that initiated the request.
+	UserID string `json:"user_id,omitempty"`
+	// WorkflowID is set when the record came from a workflow execution.
+	WorkflowID string `json:"workflow_id,omitempty"`
+	// Deprecated: the wire field is `created_at`; `Timestamp` has
+	// always read empty against JSON-decoded server responses. Use
+	// CreatedAt. Removed in v6.
+	Timestamp string `json:"timestamp,omitempty"`
 }
 
 // UsageRecordsResponse represents a list of usage records

--- a/execution_replay.go
+++ b/execution_replay.go
@@ -60,6 +60,8 @@ type ExecutionSnapshot struct {
 	ApprovalRequired  bool     `json:"approval_required,omitempty"`
 	ApprovedBy        string   `json:"approved_by,omitempty"`
 	ApprovedAt        string   `json:"approved_at,omitempty"`
+	// RetryCount is the number of retry attempts on this step.
+	RetryCount int `json:"retry_count,omitempty"`
 }
 
 // TimelineEntry represents an entry in the execution timeline

--- a/masfeat.go
+++ b/masfeat.go
@@ -105,7 +105,10 @@ type Finding struct {
 	Description string          `json:"description"`
 	Status      FindingStatus   `json:"status"`
 	Remediation string          `json:"remediation,omitempty"`
-	DueDate     *time.Time      `json:"due_date,omitempty"`
+	// Article is the regulatory article reference (e.g. MAS FEAT
+	// principle number).
+	Article string     `json:"article,omitempty"`
+	DueDate *time.Time `json:"due_date,omitempty"`
 }
 
 // ===========================================================================

--- a/policies.go
+++ b/policies.go
@@ -112,15 +112,20 @@ const (
 
 // StaticPolicy represents a static policy definition
 type StaticPolicy struct {
-	ID             string          `json:"id"`
-	Name           string          `json:"name"`
-	Description    string          `json:"description,omitempty"`
-	Category       PolicyCategory  `json:"category"`
-	Tier           PolicyTier      `json:"tier"`
-	Pattern        string          `json:"pattern"`
-	Severity       PolicySeverity  `json:"severity"`
-	Enabled        bool            `json:"enabled"`
-	Action         PolicyAction    `json:"action"`
+	ID string `json:"id"`
+	// PolicyID is the human-readable policy identifier (e.g.
+	// "sys_sqli_union_select"). Distinct from ID (the UUID).
+	PolicyID       string         `json:"policy_id,omitempty"`
+	Name           string         `json:"name"`
+	Description    string         `json:"description,omitempty"`
+	Category       PolicyCategory `json:"category"`
+	Tier           PolicyTier     `json:"tier"`
+	Pattern        string         `json:"pattern"`
+	Severity       PolicySeverity `json:"severity"`
+	Enabled        bool           `json:"enabled"`
+	Action         PolicyAction   `json:"action"`
+	// Priority is the evaluation order — lower values run first.
+	Priority       int             `json:"priority,omitempty"`
 	OrganizationID *string         `json:"organization_id,omitempty"`
 	TenantID       *string         `json:"tenant_id,omitempty"`
 	CreatedAt      time.Time       `json:"created_at"`
@@ -132,13 +137,23 @@ type StaticPolicy struct {
 
 // PolicyOverride represents an override for a static policy
 type PolicyOverride struct {
+	// ID is the override identifier (required to revoke a specific
+	// override).
+	ID        string         `json:"id,omitempty"`
 	PolicyID  string         `json:"policy_id"`
 	Action    OverrideAction `json:"action_override"`
 	Reason    string         `json:"override_reason"`
 	CreatedBy string         `json:"created_by,omitempty"`
 	CreatedAt time.Time      `json:"created_at"`
 	ExpiresAt *time.Time     `json:"expires_at,omitempty"`
-	Active    bool           `json:"active"`
+	// EnabledOverride is the canonical wire field for override enabled
+	// state. The legacy `Active` field reads the same wire key as
+	// `active`, but the server actually emits `enabled_override`.
+	EnabledOverride bool `json:"enabled_override,omitempty"`
+	// Deprecated: use EnabledOverride. The wire field is
+	// `enabled_override`, so `Active` has always read false against
+	// JSON-decoded server responses. Removed in v6.
+	Active bool `json:"active,omitempty"`
 }
 
 // ListStaticPoliciesOptions represents options for listing static policies
@@ -168,6 +183,10 @@ type CreateStaticPolicyRequest struct {
 	Severity       PolicySeverity `json:"severity,omitempty"`
 	Enabled        bool           `json:"enabled"`
 	Action         PolicyAction   `json:"action,omitempty"`
+	// Priority is the evaluation order — lower values run first.
+	Priority int `json:"priority,omitempty"`
+	// Tags are free-form labels for grouping and filtering.
+	Tags []string `json:"tags,omitempty"`
 }
 
 // UpdateStaticPolicyRequest represents a request to update an existing static policy
@@ -179,6 +198,10 @@ type UpdateStaticPolicyRequest struct {
 	Severity    *PolicySeverity `json:"severity,omitempty"`
 	Enabled     *bool           `json:"enabled,omitempty"`
 	Action      *PolicyAction   `json:"action,omitempty"`
+	// Priority updates the evaluation order.
+	Priority *int `json:"priority,omitempty"`
+	// Tags replaces the policy's tag set.
+	Tags []string `json:"tags,omitempty"`
 }
 
 // CreatePolicyOverrideRequest represents a request to create a policy override
@@ -311,15 +334,33 @@ type TestPatternMatch struct {
 // Policy Version Types
 // ============================================================================
 
-// PolicyVersion represents a policy version history entry
+// PolicyVersion represents a policy version history entry.
+//
+// The wire shape is an immutable snapshot, not a before/after diff.
+// The fields ChangeDescription, PreviousValues, and NewValues are
+// kept for source-compat only — the server actually emits
+// ChangeSummary and Snapshot.
 type PolicyVersion struct {
-	Version           int                    `json:"version"`
-	ChangedBy         string                 `json:"changed_by,omitempty"`
-	ChangedAt         time.Time              `json:"changed_at"`
-	ChangeType        string                 `json:"change_type"`
-	ChangeDescription string                 `json:"change_description,omitempty"`
-	PreviousValues    map[string]interface{} `json:"previous_values,omitempty"`
-	NewValues         map[string]interface{} `json:"new_values,omitempty"`
+	// ID is the snapshot identifier.
+	ID string `json:"id,omitempty"`
+	// PolicyID is the policy this snapshot belongs to.
+	PolicyID  string    `json:"policy_id,omitempty"`
+	Version   int       `json:"version"`
+	ChangedBy string    `json:"changed_by,omitempty"`
+	ChangedAt time.Time `json:"changed_at"`
+	ChangeType string `json:"change_type"`
+	// ChangeSummary is the canonical wire field summarising the change.
+	ChangeSummary string `json:"change_summary,omitempty"`
+	// Snapshot is the complete policy state at this version.
+	Snapshot map[string]interface{} `json:"snapshot,omitempty"`
+	// Deprecated: the wire field is `change_summary`. ChangeDescription
+	// has always read empty against JSON-decoded responses. Removed in v6.
+	ChangeDescription string `json:"change_description,omitempty"`
+	// Deprecated: the wire emits a single `snapshot`, not before/after
+	// diffs. Use Snapshot. Removed in v6.
+	PreviousValues map[string]interface{} `json:"previous_values,omitempty"`
+	// Deprecated: same as PreviousValues. Use Snapshot. Removed in v6.
+	NewValues map[string]interface{} `json:"new_values,omitempty"`
 }
 
 // EffectivePoliciesOptions represents options for getting effective policies

--- a/policies.go
+++ b/policies.go
@@ -115,15 +115,15 @@ type StaticPolicy struct {
 	ID string `json:"id"`
 	// PolicyID is the human-readable policy identifier (e.g.
 	// "sys_sqli_union_select"). Distinct from ID (the UUID).
-	PolicyID       string         `json:"policy_id,omitempty"`
-	Name           string         `json:"name"`
-	Description    string         `json:"description,omitempty"`
-	Category       PolicyCategory `json:"category"`
-	Tier           PolicyTier     `json:"tier"`
-	Pattern        string         `json:"pattern"`
-	Severity       PolicySeverity `json:"severity"`
-	Enabled        bool           `json:"enabled"`
-	Action         PolicyAction   `json:"action"`
+	PolicyID    string         `json:"policy_id,omitempty"`
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Category    PolicyCategory `json:"category"`
+	Tier        PolicyTier     `json:"tier"`
+	Pattern     string         `json:"pattern"`
+	Severity    PolicySeverity `json:"severity"`
+	Enabled     bool           `json:"enabled"`
+	Action      PolicyAction   `json:"action"`
 	// Priority is the evaluation order — lower values run first.
 	Priority       int             `json:"priority,omitempty"`
 	OrganizationID *string         `json:"organization_id,omitempty"`
@@ -344,11 +344,11 @@ type PolicyVersion struct {
 	// ID is the snapshot identifier.
 	ID string `json:"id,omitempty"`
 	// PolicyID is the policy this snapshot belongs to.
-	PolicyID  string    `json:"policy_id,omitempty"`
-	Version   int       `json:"version"`
-	ChangedBy string    `json:"changed_by,omitempty"`
-	ChangedAt time.Time `json:"changed_at"`
-	ChangeType string `json:"change_type"`
+	PolicyID   string    `json:"policy_id,omitempty"`
+	Version    int       `json:"version"`
+	ChangedBy  string    `json:"changed_by,omitempty"`
+	ChangedAt  time.Time `json:"changed_at"`
+	ChangeType string    `json:"change_type"`
 	// ChangeSummary is the canonical wire field summarising the change.
 	ChangeSummary string `json:"change_summary,omitempty"`
 	// Snapshot is the complete policy state at this version.

--- a/testdata/wire_shape_baseline.json
+++ b/testdata/wire_shape_baseline.json
@@ -307,24 +307,13 @@
       "sdk_only": [
         "enabled"
       ],
-      "spec_only": [
-        "org_id",
-        "tenant_id"
-      ]
-    },
-    "BudgetAlert": {
-      "sdk_only": [],
-      "spec_only": [
-        "acknowledged"
-      ]
+      "spec_only": []
     },
     "CancelPlanResponse": {
       "sdk_only": [
         "message"
       ],
-      "spec_only": [
-        "success"
-      ]
+      "spec_only": []
     },
     "ClientRequest": {
       "sdk_only": [
@@ -346,19 +335,14 @@
       "sdk_only": [
         "organization_id"
       ],
-      "spec_only": [
-        "priority",
-        "tags"
-      ]
+      "spec_only": []
     },
     "CreateWorkflowResponse": {
       "sdk_only": [
         "created_at",
         "source"
       ],
-      "spec_only": [
-        "started_at"
-      ]
+      "spec_only": []
     },
     "DynamicPolicy": {
       "sdk_only": [
@@ -395,9 +379,7 @@
       "sdk_only": [
         "reason"
       ],
-      "spec_only": [
-        "message"
-      ]
+      "spec_only": []
     },
     "ExecutionSnapshot": {
       "sdk_only": [
@@ -405,9 +387,7 @@
         "approved_at",
         "approved_by"
       ],
-      "spec_only": [
-        "retry_count"
-      ]
+      "spec_only": []
     },
     "ExecutionSummary": {
       "sdk_only": [
@@ -420,33 +400,14 @@
       "sdk_only": [
         "within_limits"
       ],
-      "spec_only": [
-        "exceeded",
-        "limit_type"
-      ]
+      "spec_only": []
     },
     "Finding": {
       "sdk_only": [
         "due_date",
         "pillar"
       ],
-      "spec_only": [
-        "article"
-      ]
-    },
-    "HealthResponse": {
-      "sdk_only": [],
-      "spec_only": [
-        "components",
-        "features"
-      ]
-    },
-    "ListWorkflowsResponse": {
-      "sdk_only": [],
-      "spec_only": [
-        "limit",
-        "offset"
-      ]
+      "spec_only": []
     },
     "MCPCheckInputRequest": {
       "sdk_only": [],
@@ -518,14 +479,7 @@
         "parallel",
         "status"
       ],
-      "spec_only": [
-        "error",
-        "policy_info",
-        "result",
-        "success",
-        "version",
-        "workflow_execution_id"
-      ]
+      "spec_only": []
     },
     "PolicyEvaluationInfo": {
       "sdk_only": [
@@ -537,10 +491,7 @@
       "sdk_only": [
         "active"
       ],
-      "spec_only": [
-        "enabled_override",
-        "id"
-      ]
+      "spec_only": []
     },
     "PolicyVersion": {
       "sdk_only": [
@@ -548,12 +499,7 @@
         "new_values",
         "previous_values"
       ],
-      "spec_only": [
-        "change_summary",
-        "id",
-        "policy_id",
-        "snapshot"
-      ]
+      "spec_only": []
     },
     "RegisterSystemRequest": {
       "sdk_only": [
@@ -579,45 +525,13 @@
         "total_steps",
         "workflow_id"
       ],
-      "spec_only": [
-        "result"
-      ]
-    },
-    "StaticPolicy": {
-      "sdk_only": [],
-      "spec_only": [
-        "policy_id",
-        "priority"
-      ]
-    },
-    "StepGateRequest": {
-      "sdk_only": [],
-      "spec_only": [
-        "cost_usd",
-        "tokens_in",
-        "tokens_out"
-      ]
-    },
-    "StepGateResponse": {
-      "sdk_only": [],
-      "spec_only": [
-        "decision_id"
-      ]
-    },
-    "UpdatePlanRequest": {
-      "sdk_only": [],
-      "spec_only": [
-        "metadata"
-      ]
+      "spec_only": []
     },
     "UpdateStaticPolicyRequest": {
       "sdk_only": [
         "category"
       ],
-      "spec_only": [
-        "priority",
-        "tags"
-      ]
+      "spec_only": []
     },
     "UpdateSystemRequest": {
       "sdk_only": [
@@ -642,46 +556,17 @@
       ],
       "spec_only": []
     },
-    "UsageBreakdownItem": {
-      "sdk_only": [],
-      "spec_only": [
-        "group_by"
-      ]
-    },
     "UsageRecord": {
       "sdk_only": [
         "timestamp"
       ],
-      "spec_only": [
-        "created_at",
-        "error_message",
-        "latency_ms",
-        "success",
-        "team_id",
-        "tenant_id",
-        "user_id",
-        "workflow_id"
-      ]
+      "spec_only": []
     },
     "UsageSummary": {
       "sdk_only": [
         "period"
       ],
       "spec_only": []
-    },
-    "WebhookSubscription": {
-      "sdk_only": [],
-      "spec_only": [
-        "org_id",
-        "secret",
-        "tenant_id"
-      ]
-    },
-    "WorkflowStatusResponse": {
-      "sdk_only": [],
-      "spec_only": [
-        "metadata"
-      ]
     },
     "WorkflowStepInfo": {
       "sdk_only": [

--- a/webhooks.go
+++ b/webhooks.go
@@ -52,6 +52,18 @@ type WebhookSubscription struct {
 	// Active indicates whether the webhook is active
 	Active bool `json:"active"`
 
+	// TenantID is the tenant that owns this subscription.
+	TenantID string `json:"tenant_id,omitempty"`
+
+	// OrgID is the organization that owns this subscription.
+	OrgID string `json:"org_id,omitempty"`
+
+	// Secret is the HMAC-SHA256 signing key for verifying inbound
+	// webhook payload signatures (X-AxonFlow-Signature header).
+	// Returned by CreateWebhook on initial creation; required for
+	// callers to validate payload authenticity.
+	Secret string `json:"secret,omitempty"`
+
 	// CreatedAt is when the webhook was created
 	CreatedAt string `json:"created_at"`
 

--- a/workflows.go
+++ b/workflows.go
@@ -120,17 +120,25 @@ type CreateWorkflowResponse struct {
 	// WorkflowName is the name of the workflow
 	WorkflowName string `json:"workflow_name"`
 
-	// Source is the source orchestrator
-	Source WorkflowSource `json:"source"`
-
 	// Status is the current status (always "in_progress" for new workflows)
 	Status WorkflowStatus `json:"status"`
 
-	// CreatedAt is when the workflow was created
-	CreatedAt time.Time `json:"created_at"`
+	// StartedAt is when the workflow started executing (canonical wire field).
+	StartedAt time.Time `json:"started_at"`
 
 	// TraceID is the trace ID for correlating with external tracing systems
 	TraceID string `json:"trace_id,omitempty"`
+
+	// Deprecated: the wire emits started_at, not created_at. This field
+	// has always read zero against JSON-decoded server responses. Use
+	// StartedAt. Removed in v6.
+	CreatedAt time.Time `json:"created_at,omitempty"`
+
+	// Deprecated: not emitted on the create response. The wire shape
+	// for CreateWorkflowResponse does not include `source`; this
+	// field has always read empty. Read Source from a subsequent
+	// GetWorkflow() call instead. Removed in v6.
+	Source WorkflowSource `json:"source,omitempty"`
 }
 
 // RetryPolicy controls how step gate decisions behave on repeated calls for the
@@ -176,6 +184,16 @@ type StepGateRequest struct {
 	// subsequent gate/complete calls must pass the same key or receive IdempotencyKeyMismatchError.
 	// The key is echoed on RetryContext.IdempotencyKey in every subsequent gate response.
 	IdempotencyKey string `json:"idempotency_key,omitempty"`
+
+	// TokensIn is the estimated input tokens for the step at gate time
+	// (used by budget-based policies).
+	TokensIn int `json:"tokens_in,omitempty"`
+
+	// TokensOut is the estimated output tokens for the step at gate time.
+	TokensOut int `json:"tokens_out,omitempty"`
+
+	// CostUSD is the estimated cost in USD for the step at gate time.
+	CostUSD float64 `json:"cost_usd,omitempty"`
 }
 
 // StepGateOptions controls gate-call behavior that lives outside the request body.
@@ -202,6 +220,9 @@ type StepGateResponse struct {
 
 	// ApprovalURL is the URL to the approval portal (if decision is require_approval)
 	ApprovalURL string `json:"approval_url,omitempty"`
+
+	// DecisionID is the unique audit correlator for this gate decision.
+	DecisionID string `json:"decision_id,omitempty"`
 
 	// PoliciesEvaluated contains all policies that were evaluated for this step (Issue #1021)
 	PoliciesEvaluated []PolicyMatch `json:"policies_evaluated,omitempty"`
@@ -303,6 +324,9 @@ type WorkflowStatusResponse struct {
 	// TraceID is the trace ID for correlating with external tracing systems
 	TraceID string `json:"trace_id,omitempty"`
 
+	// Metadata is arbitrary workflow metadata, opaque to the platform.
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+
 	// Steps contains the list of steps in the workflow
 	Steps []WorkflowStepInfo `json:"steps,omitempty"`
 }
@@ -337,6 +361,12 @@ type ListWorkflowsResponse struct {
 
 	// Total is the total count for pagination
 	Total int `json:"total"`
+
+	// Limit echoes the limit query parameter (for pagination clients).
+	Limit int `json:"limit,omitempty"`
+
+	// Offset echoes the offset query parameter (for pagination clients).
+	Offset int `json:"offset,omitempty"`
 }
 
 // AbortWorkflowRequest is the request to abort a workflow.


### PR DESCRIPTION
## Summary

Audit-driven cleanup against the wire-shape contract gate (43 → 33 drift entries). Mirrors the equivalent sweep on the TS SDK (axonflow-sdk-typescript#185). All changes are additive or marked \`Deprecated\` for source-compat — no breaking renames, no version bump trigger.

## Categorization (mirrors TS sweep)

- **Cat B (Pure additions, 14 types resolved)** — SDK was missing wire fields the spec declares. Added as optional/omitempty fields. Includes \`WebhookSubscription.Secret\` (security-critical: HMAC verification), \`StepGateRequest.{TokensIn,TokensOut,CostUSD}\` (budget policies), \`StepGateResponse.DecisionID\` (audit trail), pagination echo, etc.
- **RENAME_SAFE (audit-confirmed broken transformer reads)** — fields that read empty/zero today because the SDK was unmarshalling a wire key the server doesn't emit. Wire-canonical names added; legacy fields kept as \`Deprecated\` so existing source compiles.
- **UNRECOVERABLE realignments** — types where no decoder was present; wire shape added straight.

## Per-type RESOLVED ✓

\`BudgetAlert\`, \`ListWorkflowsResponse\`, \`StaticPolicy\`, \`StepGateRequest\`, \`StepGateResponse\`, \`UpdatePlanRequest\`, \`UsageBreakdownItem\`, \`WebhookSubscription\`, \`WorkflowStatusResponse\`, \`HealthResponse\` (10 types fully resolved).

## Remaining drift (33 entries)

Mostly:
1. \`Deprecated\` aliases I added (kept for source-compat, removed in v6)
2. Plugin Batch 1 SDK fields not yet in spec (file platform-side issue separately)
3. Cat C entries (SDK has fields the spec doesn't document — needs per-type platform decision)
4. Already-filed platform issues: \`AISystemRegistry.materiality_classification\` (axonflow-enterprise#1708), \`DynamicPolicyInfo\` schema (axonflow-enterprise#1709)

## Hard rules followed

- No SDK property renames where the transformer works correctly (per the rule established for the TS sweep: only rename when runtime-broken, semantically wrong, or collision)
- Every BROKEN transformer read found by the audit gets fixed (added wire-canonical field; legacy field marked \`Deprecated\`)
- All user-visible additions documented in CHANGELOG \`[Unreleased]\`
- No version bump (held until release time)

## Verification

- \`go build ./...\`: ✅
- \`go test ./...\`: ✅ all pass
- \`go vet ./...\`: ✅ clean
- Wire-shape baseline regenerated: 43 → 33 drift entries
- Cross-spec / intra-file unchanged (8 / 1 — same platform-side issues)

## Test plan

- [x] All tests pass locally
- [x] Vet clean
- [x] Baseline regenerated and committed
- [ ] CI on this PR is green