### PR TITLE
fix(types): SDKCompatibility map[string]string for per-language version compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Breaking type change in `SDKCompatibility`.** `MinSDKVersion` and `RecommendedSDKVersion` are now `map[string]string` (per-language) instead of `string`, matching the actual on-the-wire shape returned by the platform `/health` endpoint since v4.8.0. The previous `string` type silently unmarshalled the JSON object to an empty string, making the SDK version-mismatch warning a no-op. New helpers `(*SDKCompatibility).MinSDKVersionFor("go")` / `RecommendedSDKVersionFor("go")` return the per-language entry. Aligns Go with Java + TypeScript SDKs.
+
 ## [5.8.0] - 2026-04-25 — Plugin Batch 1 explainability fields on MCP responses
 
 Minor release. Surfaces fields the AxonFlow agent has emitted since v7.1.0 (Plugin Batch 1) but the SDK didn't declare. Pure field-additions on existing methods — `,omitempty`-tagged so existing user code keeps compiling. Documented in OpenAPI via platform v7.4.3.

--- a/axonflow.go
+++ b/axonflow.go
@@ -1094,10 +1094,38 @@ type PlatformCapability struct {
 	Description string `json:"description"`
 }
 
-// SDKCompatibility describes SDK version compatibility.
+// SDKCompatibility describes per-language SDK version compatibility returned
+// by the platform `/health` endpoint.
+//
+// The platform emits these as per-language maps, e.g.
+//
+//	{"go": "5.0.0", "java": "5.0.0", "python": "6.0.0", "typescript": "5.0.0"}
+//
+// Older SDK builds typed both fields as a single string; the dict shape would
+// then unmarshal into an empty string and the SDK version-mismatch warning
+// silently no-op'd. Keeping the fields as maps aligns Go with Java + TypeScript.
 type SDKCompatibility struct {
-	MinSDKVersion         string `json:"min_sdk_version"`
-	RecommendedSDKVersion string `json:"recommended_sdk_version"`
+	MinSDKVersion         map[string]string `json:"min_sdk_version"`
+	RecommendedSDKVersion map[string]string `json:"recommended_sdk_version"`
+}
+
+// MinSDKVersionFor returns the minimum required SDK version for the given
+// language (e.g. "go"), or an empty string if the platform did not declare
+// one for that language.
+func (s *SDKCompatibility) MinSDKVersionFor(language string) string {
+	if s == nil || s.MinSDKVersion == nil {
+		return ""
+	}
+	return s.MinSDKVersion[language]
+}
+
+// RecommendedSDKVersionFor returns the recommended SDK version for the given
+// language, or an empty string if the platform did not declare one.
+func (s *SDKCompatibility) RecommendedSDKVersionFor(language string) string {
+	if s == nil || s.RecommendedSDKVersion == nil {
+		return ""
+	}
+	return s.RecommendedSDKVersion[language]
 }
 
 // HasCapability checks if the platform supports a named capability.
@@ -1140,9 +1168,10 @@ func (c *AxonFlowClient) HealthCheckDetailed() (*HealthResponse, error) {
 		log.Printf("[AxonFlow] Platform version: %s, SDK version: %s", health.Version, Version)
 	}
 
-	if health.SDKCompat != nil && health.SDKCompat.MinSDKVersion != "" {
-		if compareSemver(Version, health.SDKCompat.MinSDKVersion) < 0 {
-			log.Printf("[AxonFlow] WARNING: SDK version %s is below minimum supported version %s. Please upgrade.", Version, health.SDKCompat.MinSDKVersion)
+	if health.SDKCompat != nil {
+		minForGo := health.SDKCompat.MinSDKVersionFor("go")
+		if minForGo != "" && compareSemver(Version, minForGo) < 0 {
+			log.Printf("[AxonFlow] WARNING: SDK version %s is below minimum supported version %s. Please upgrade.", Version, minForGo)
 		}
 	}
 

--- a/health_check_detailed_test.go
+++ b/health_check_detailed_test.go
@@ -1,0 +1,107 @@
+// Regression tests for HealthCheckDetailed and SDKCompatibility.
+//
+// The platform /health endpoint returns sdk_compatibility.min_sdk_version
+// and recommended_sdk_version as per-language maps. An older SDK declared
+// both fields as plain strings, so JSON unmarshal silently produced empty
+// strings and the SDK version-mismatch warning logic became dead code.
+// These tests pin the dict-shape contract.
+package axonflow
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSDKCompatibility_MinSDKVersionFor(t *testing.T) {
+	t.Parallel()
+	c := &SDKCompatibility{
+		MinSDKVersion: map[string]string{
+			"go":         "5.0.0",
+			"java":       "5.0.0",
+			"python":     "6.0.0",
+			"typescript": "5.0.0",
+		},
+		RecommendedSDKVersion: map[string]string{
+			"go":         "5.8.0",
+			"java":       "6.1.0",
+			"python":     "6.8.0",
+			"typescript": "6.1.0",
+		},
+	}
+	if got := c.MinSDKVersionFor("go"); got != "5.0.0" {
+		t.Errorf("MinSDKVersionFor(go) = %q, want %q", got, "5.0.0")
+	}
+	if got := c.RecommendedSDKVersionFor("typescript"); got != "6.1.0" {
+		t.Errorf("RecommendedSDKVersionFor(typescript) = %q, want %q", got, "6.1.0")
+	}
+	if got := c.MinSDKVersionFor("rust"); got != "" {
+		t.Errorf("MinSDKVersionFor(rust) = %q, want \"\" (unknown language)", got)
+	}
+}
+
+func TestSDKCompatibility_NilSafe(t *testing.T) {
+	t.Parallel()
+	var c *SDKCompatibility
+	if got := c.MinSDKVersionFor("go"); got != "" {
+		t.Errorf("MinSDKVersionFor on nil receiver = %q, want \"\"", got)
+	}
+	if got := c.RecommendedSDKVersionFor("go"); got != "" {
+		t.Errorf("RecommendedSDKVersionFor on nil receiver = %q, want \"\"", got)
+	}
+
+	empty := &SDKCompatibility{}
+	if got := empty.MinSDKVersionFor("go"); got != "" {
+		t.Errorf("MinSDKVersionFor on empty struct = %q, want \"\"", got)
+	}
+}
+
+func TestHealthCheckDetailed_DictShapeMinSDKVersion(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"service": "axonflow-agent",
+			"status":  "healthy",
+			"version": "7.4.4",
+			"capabilities": []map[string]interface{}{
+				{"name": "health_check", "since": "1.0.0", "description": "Basic health endpoint"},
+			},
+			"sdk_compatibility": map[string]interface{}{
+				"min_sdk_version": map[string]string{
+					"go":         "5.0.0",
+					"java":       "5.0.0",
+					"python":     "6.0.0",
+					"typescript": "5.0.0",
+				},
+				"recommended_sdk_version": map[string]string{
+					"go":         "5.8.0",
+					"java":       "6.1.0",
+					"python":     "6.8.0",
+					"typescript": "6.1.0",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL})
+	health, err := client.HealthCheckDetailed()
+	if err != nil {
+		t.Fatalf("HealthCheckDetailed returned error: %v", err)
+	}
+	if health.SDKCompat == nil {
+		t.Fatal("SDKCompat is nil; expected populated dict")
+	}
+	if got := health.SDKCompat.MinSDKVersionFor("go"); got != "5.0.0" {
+		t.Errorf("MinSDKVersionFor(go) = %q, want %q", got, "5.0.0")
+	}
+	if got := health.SDKCompat.RecommendedSDKVersionFor("go"); got != "5.8.0" {
+		t.Errorf("RecommendedSDKVersionFor(go) = %q, want %q", got, "5.8.0")
+	}
+}


### PR DESCRIPTION
## Summary

The Go SDK typed \`SDKCompatibility.MinSDKVersion\` and \`RecommendedSDKVersion\` as \`string\`, but the platform \`/health\` endpoint has returned them as per-language JSON maps since v4.8.0:

\`\`\`json
{"go": "5.0.0", "java": "5.0.0", "python": "6.0.0", "typescript": "5.0.0"}
\`\`\`

Result: \`encoding/json\` silently unmarshalled the object into an empty string, and the SDK version-mismatch warning at \`HealthCheckDetailed\` became dead code (the \`MinSDKVersion != ""\` guard always failed).

Caught by Phase 1 quality-freeze sweep against \`examples/version-check\` after the parallel Python SDK fix shipped at axonflow-sdk-python#163.

## What changed

- \`MinSDKVersion\` and \`RecommendedSDKVersion\` retyped to \`map[string]string\`
- New \`(*SDKCompatibility).MinSDKVersionFor(language)\` / \`RecommendedSDKVersionFor(language)\` helpers
- \`HealthCheckDetailed\` updated to use \`MinSDKVersionFor("go")\`
- Aligns Go SDK with Java SDK's \`Map<String, String>\` + \`getMinSdkVersionFor()\` and TypeScript SDK's defensive shape handling

## Breaking change disclosure

This is a breaking type change for any caller that referenced \`MinSDKVersion\` / \`RecommendedSDKVersion\` directly as a string. \`grep\` across the SDK + examples found no such callers — the only consumer was the version-mismatch warning, which now uses the helper.

## Test plan

- [x] New \`health_check_detailed_test.go\` with 3 tests: dict shape, nil-receiver safety, live HealthCheckDetailed via httptest
- [x] \`go test ./...\` passes locally
- [x] \`go build ./...\` clean