### PR TITLE
feat(client): add ListProviders() — closes provider-listing parity gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`(*AxonFlowClient).ListProviders(opts *ListProvidersOptions)`** — list configured LLM providers and their per-provider health snapshot. Calls `GET /api/v1/llm-providers`. New `LLMProvider` and `LLMProviderHealth` types; `ListProvidersOptions{Type, Enabled}` for filtering. Closes the parity gap with the Java SDK's `listLLMProviders()` and the Python SDK's `list_providers()`.
+
 ### Fixed
 
 - **Breaking type change in `SDKCompatibility`.** `MinSDKVersion` and `RecommendedSDKVersion` are now `map[string]string` (per-language) instead of `string`, matching the actual on-the-wire shape returned by the platform `/health` endpoint since v4.8.0. The previous `string` type silently unmarshalled the JSON object to an empty string, making the SDK version-mismatch warning a no-op. New helpers `(*SDKCompatibility).MinSDKVersionFor("go")` / `RecommendedSDKVersionFor("go")` return the per-language entry. Aligns Go with Java + TypeScript SDKs.

--- a/axonflow.go
+++ b/axonflow.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"math"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -1217,6 +1218,98 @@ func getMetadataKeys(metadata map[string]interface{}) []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+// LLMProviderHealth is the health snapshot for a registered provider.
+type LLMProviderHealth struct {
+	Status      string `json:"status"`
+	Message     string `json:"message,omitempty"`
+	LastChecked string `json:"last_checked,omitempty"`
+}
+
+// LLMProvider is a registered LLM provider as returned by ListProviders.
+type LLMProvider struct {
+	Name       string             `json:"name"`
+	Type       string             `json:"type"`
+	Enabled    bool               `json:"enabled"`
+	Priority   int                `json:"priority,omitempty"`
+	Weight     int                `json:"weight,omitempty"`
+	HasAPIKey  bool               `json:"has_api_key"`
+	Health     *LLMProviderHealth `json:"health,omitempty"`
+}
+
+// ListProvidersOptions narrows the result set returned by ListProviders.
+//
+// Either field is optional — leaving both at the zero value returns every
+// configured provider regardless of type or enabled status.
+type ListProvidersOptions struct {
+	// Type filters by provider type (e.g. "openai", "anthropic", "azure-openai").
+	Type string
+	// Enabled filters on the boolean flag. Use a pointer to distinguish
+	// "no filter" (nil) from "only enabled=false" (pointer to false).
+	Enabled *bool
+}
+
+// ListProviders returns the configured LLM providers and their health status,
+// optionally filtered by type and/or enabled flag.
+//
+// Calls GET /api/v1/llm-providers. Mirrors the Java SDK's listLLMProviders()
+// and the Python SDK's list_providers().
+//
+// Example:
+//
+//	providers, err := client.ListProviders(nil)
+//	for _, p := range providers {
+//	    log.Printf("%s (%s) — %s", p.Name, p.Type, p.Health.Status)
+//	}
+func (c *AxonFlowClient) ListProviders(opts *ListProvidersOptions) ([]LLMProvider, error) {
+	reqURL := c.config.Endpoint + "/api/v1/llm-providers"
+	if opts != nil {
+		q := url.Values{}
+		if opts.Type != "" {
+			q.Set("type", opts.Type)
+		}
+		if opts.Enabled != nil {
+			if *opts.Enabled {
+				q.Set("enabled", "true")
+			} else {
+				q.Set("enabled", "false")
+			}
+		}
+		if encoded := q.Encode(); encoded != "" {
+			reqURL = reqURL + "?" + encoded
+		}
+	}
+
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create list providers request: %w", err)
+	}
+	c.addAuthHeaders(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list providers request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("list providers failed: HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var response struct {
+		Providers []LLMProvider `json:"providers"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, fmt.Errorf("failed to decode providers response: %w", err)
+	}
+
+	if c.config.Debug {
+		log.Printf("[AxonFlow] Listed %d LLM providers", len(response.Providers))
+	}
+
+	return response.Providers, nil
 }
 
 // ListConnectors returns all available MCP connectors from the marketplace

--- a/axonflow.go
+++ b/axonflow.go
@@ -1229,13 +1229,13 @@ type LLMProviderHealth struct {
 
 // LLMProvider is a registered LLM provider as returned by ListProviders.
 type LLMProvider struct {
-	Name       string             `json:"name"`
-	Type       string             `json:"type"`
-	Enabled    bool               `json:"enabled"`
-	Priority   int                `json:"priority,omitempty"`
-	Weight     int                `json:"weight,omitempty"`
-	HasAPIKey  bool               `json:"has_api_key"`
-	Health     *LLMProviderHealth `json:"health,omitempty"`
+	Name      string             `json:"name"`
+	Type      string             `json:"type"`
+	Enabled   bool               `json:"enabled"`
+	Priority  int                `json:"priority,omitempty"`
+	Weight    int                `json:"weight,omitempty"`
+	HasAPIKey bool               `json:"has_api_key"`
+	Health    *LLMProviderHealth `json:"health,omitempty"`
 }
 
 // ListProvidersOptions narrows the result set returned by ListProviders.

--- a/list_providers_test.go
+++ b/list_providers_test.go
@@ -1,0 +1,147 @@
+// Regression tests for ListProviders.
+//
+// Pins the wire-shape contract for GET /api/v1/llm-providers and confirms
+// the optional Type and Enabled filters get passed through as query strings.
+package axonflow
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListProviders_DecodesProvidersAndHealth(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/llm-providers" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"providers": []map[string]interface{}{
+				{
+					"name":        "anthropic",
+					"type":        "anthropic",
+					"enabled":     true,
+					"priority":    0,
+					"weight":      0,
+					"has_api_key": true,
+					"health": map[string]interface{}{
+						"status":       "healthy",
+						"message":      "provider is operational",
+						"last_checked": "2026-04-28T08:45:12Z",
+					},
+				},
+				{
+					"name":        "openai",
+					"type":        "openai",
+					"enabled":     true,
+					"has_api_key": true,
+					"health": map[string]interface{}{
+						"status":  "unhealthy",
+						"message": "billing exceeded",
+					},
+				},
+			},
+			"pagination": map[string]interface{}{"page": 1, "page_size": 20, "total": 2, "has_more": false},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL})
+	providers, err := client.ListProviders(nil)
+	if err != nil {
+		t.Fatalf("ListProviders returned error: %v", err)
+	}
+	if len(providers) != 2 {
+		t.Fatalf("got %d providers, want 2", len(providers))
+	}
+	if providers[0].Name != "anthropic" || providers[0].Type != "anthropic" {
+		t.Errorf("provider[0] = %+v, want anthropic/anthropic", providers[0])
+	}
+	if providers[0].Health == nil || providers[0].Health.Status != "healthy" {
+		t.Errorf("provider[0].Health = %+v, want healthy", providers[0].Health)
+	}
+	if providers[1].Health == nil || providers[1].Health.Status != "unhealthy" {
+		t.Errorf("provider[1].Health = %+v, want unhealthy", providers[1].Health)
+	}
+}
+
+func TestListProviders_FiltersAreQueryParams(t *testing.T) {
+	t.Parallel()
+	var seenQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"providers": []map[string]interface{}{},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL})
+	enabledFalse := false
+	if _, err := client.ListProviders(&ListProvidersOptions{
+		Type:    "anthropic",
+		Enabled: &enabledFalse,
+	}); err != nil {
+		t.Fatalf("ListProviders returned error: %v", err)
+	}
+	// Order of params is irrelevant — just check both are present.
+	wantPairs := []string{"type=anthropic", "enabled=false"}
+	for _, p := range wantPairs {
+		if !contains(seenQuery, p) {
+			t.Errorf("query %q missing %q", seenQuery, p)
+		}
+	}
+}
+
+func TestListProviders_ProviderWithoutHealth(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"providers": []map[string]interface{}{
+				{"name": "ollama", "type": "ollama", "enabled": true},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL})
+	providers, err := client.ListProviders(nil)
+	if err != nil {
+		t.Fatalf("ListProviders returned error: %v", err)
+	}
+	if len(providers) != 1 {
+		t.Fatalf("got %d providers, want 1", len(providers))
+	}
+	if providers[0].Health != nil {
+		t.Errorf("provider Health should be nil when omitted by server, got %+v", providers[0].Health)
+	}
+}
+
+func TestListProviders_HTTPError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"forbidden"}`, http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL})
+	_, err := client.ListProviders(nil)
+	if err == nil {
+		t.Fatal("expected error from 403, got nil")
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Adds \`ListProviders(opts)\` to the Go SDK, closing the parity gap with the Java SDK's \`listLLMProviders\` and the Python SDK's \`list_providers\`. Caught by the Phase 1 quality-freeze sweep against \`examples/llm-routing/e2e-tests/go\` (and the parallel Python work at axonflow-sdk-python#164).

## What changed

- New types: \`LLMProvider\`, \`LLMProviderHealth\`, \`ListProvidersOptions{Type, Enabled}\`
- New method: \`(*AxonFlowClient).ListProviders(opts *ListProvidersOptions) ([]LLMProvider, error)\`
- 4 regression tests in \`list_providers_test.go\` covering: dict shape with health, query-string filters, provider without health, HTTP 403 error path
- Wires through \`net/url\` import (newly needed for query encoding)

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` clean (existing + 4 new)
- [x] Wire-shape contract gate green