### PR TITLE
fix(client): close review gaps on ListProviders — full shape, pagination, ctx, warning test

### DIFF
--- a/axonflow.go
+++ b/axonflow.go
@@ -1228,41 +1228,84 @@ type LLMProviderHealth struct {
 }
 
 // LLMProvider is a registered LLM provider as returned by ListProviders.
+//
+// Mirrors the platform's LLMProviderResource schema. Optional fields are
+// populated when the underlying provider config has them set; Settings is
+// a free-form provider-specific map (e.g. Bedrock inference-profile id,
+// Azure OpenAI deployment name).
 type LLMProvider struct {
-	Name      string             `json:"name"`
-	Type      string             `json:"type"`
-	Enabled   bool               `json:"enabled"`
-	Priority  int                `json:"priority,omitempty"`
-	Weight    int                `json:"weight,omitempty"`
-	HasAPIKey bool               `json:"has_api_key"`
-	Health    *LLMProviderHealth `json:"health,omitempty"`
+	Name           string             `json:"name"`
+	Type           string             `json:"type"`
+	Enabled        bool               `json:"enabled"`
+	Priority       int                `json:"priority,omitempty"`
+	Weight         int                `json:"weight,omitempty"`
+	HasAPIKey      bool               `json:"has_api_key"`
+	Health         *LLMProviderHealth `json:"health,omitempty"`
+	Endpoint       string             `json:"endpoint,omitempty"`
+	Model          string             `json:"model,omitempty"`
+	Region         string             `json:"region,omitempty"`
+	RateLimit      int                `json:"rate_limit,omitempty"`
+	TimeoutSeconds int                `json:"timeout_seconds,omitempty"`
+	Settings       map[string]any     `json:"settings,omitempty"`
+}
+
+// PaginationMeta is the pagination block returned alongside paginated list
+// responses from the platform.
+type PaginationMeta struct {
+	Page       int `json:"page"`
+	PageSize   int `json:"page_size"`
+	TotalItems int `json:"total_items"`
+	TotalPages int `json:"total_pages"`
+}
+
+// LLMProviderListResponse is the paginated response wrapper returned by
+// ListProvidersPaged.
+type LLMProviderListResponse struct {
+	Providers  []LLMProvider  `json:"providers"`
+	Pagination PaginationMeta `json:"pagination"`
 }
 
 // ListProvidersOptions narrows the result set returned by ListProviders.
 //
-// Either field is optional — leaving both at the zero value returns every
-// configured provider regardless of type or enabled status.
+// All fields are optional — leaving them at zero values returns the first
+// page with the server's default page size.
 type ListProvidersOptions struct {
 	// Type filters by provider type (e.g. "openai", "anthropic", "azure-openai").
 	Type string
 	// Enabled filters on the boolean flag. Use a pointer to distinguish
 	// "no filter" (nil) from "only enabled=false" (pointer to false).
 	Enabled *bool
+	// Page is the 1-indexed page number (zero or negative means "use server default").
+	Page int
+	// PageSize is the items per page (zero or negative means "use server default";
+	// platform-side cap is 100).
+	PageSize int
 }
 
-// ListProviders returns the configured LLM providers and their health status,
+// ListProviders returns the providers from a SINGLE page of results,
 // optionally filtered by type and/or enabled flag.
 //
 // Calls GET /api/v1/llm-providers. Mirrors the Java SDK's listLLMProviders()
-// and the Python SDK's list_providers().
+// and the Python SDK's list_providers(). For multi-page traversal use
+// ListAllProviders; for pagination metadata use ListProvidersPaged.
 //
 // Example:
 //
-//	providers, err := client.ListProviders(nil)
+//	providers, err := client.ListProviders(ctx, nil)
 //	for _, p := range providers {
 //	    log.Printf("%s (%s) — %s", p.Name, p.Type, p.Health.Status)
 //	}
-func (c *AxonFlowClient) ListProviders(opts *ListProvidersOptions) ([]LLMProvider, error) {
+func (c *AxonFlowClient) ListProviders(ctx context.Context, opts *ListProvidersOptions) ([]LLMProvider, error) {
+	resp, err := c.ListProvidersPaged(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Providers, nil
+}
+
+// ListProvidersPaged returns one page of providers along with pagination
+// metadata so callers can paginate manually.
+func (c *AxonFlowClient) ListProvidersPaged(ctx context.Context, opts *ListProvidersOptions) (*LLMProviderListResponse, error) {
 	reqURL := c.config.Endpoint + "/api/v1/llm-providers"
 	if opts != nil {
 		q := url.Values{}
@@ -1276,12 +1319,18 @@ func (c *AxonFlowClient) ListProviders(opts *ListProvidersOptions) ([]LLMProvide
 				q.Set("enabled", "false")
 			}
 		}
+		if opts.Page > 0 {
+			q.Set("page", strconv.Itoa(opts.Page))
+		}
+		if opts.PageSize > 0 {
+			q.Set("page_size", strconv.Itoa(opts.PageSize))
+		}
 		if encoded := q.Encode(); encoded != "" {
 			reqURL = reqURL + "?" + encoded
 		}
 	}
 
-	req, err := http.NewRequest("GET", reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list providers request: %w", err)
 	}
@@ -1298,18 +1347,48 @@ func (c *AxonFlowClient) ListProviders(opts *ListProvidersOptions) ([]LLMProvide
 		return nil, fmt.Errorf("list providers failed: HTTP %d: %s", resp.StatusCode, string(body))
 	}
 
-	var response struct {
-		Providers []LLMProvider `json:"providers"`
-	}
+	var response LLMProviderListResponse
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		return nil, fmt.Errorf("failed to decode providers response: %w", err)
 	}
 
 	if c.config.Debug {
-		log.Printf("[AxonFlow] Listed %d LLM providers", len(response.Providers))
+		log.Printf("[AxonFlow] Listed %d LLM providers (page %d/%d)",
+			len(response.Providers), response.Pagination.Page, response.Pagination.TotalPages)
 	}
 
-	return response.Providers, nil
+	return &response, nil
+}
+
+// ListAllProviders walks every page of providers and returns the combined
+// list. Defaults to PageSize=100 (the server-side max) to minimise round
+// trips. Per-page Type and Enabled filters from opts are honoured on every
+// page; opts.Page and opts.PageSize are overridden by the walker.
+func (c *AxonFlowClient) ListAllProviders(ctx context.Context, opts *ListProvidersOptions) ([]LLMProvider, error) {
+	pageSize := 100
+	walker := ListProvidersOptions{}
+	if opts != nil {
+		walker.Type = opts.Type
+		walker.Enabled = opts.Enabled
+		if opts.PageSize > 0 {
+			pageSize = opts.PageSize
+		}
+	}
+
+	var all []LLMProvider
+	for page := 1; ; page++ {
+		walker.Page = page
+		walker.PageSize = pageSize
+		resp, err := c.ListProvidersPaged(ctx, &walker)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, resp.Providers...)
+		if resp.Pagination.TotalPages <= page || len(resp.Providers) == 0 {
+			break
+		}
+	}
+	return all, nil
 }
 
 // ListConnectors returns all available MCP connectors from the marketplace

--- a/list_providers_review_fixes_test.go
+++ b/list_providers_review_fixes_test.go
@@ -1,0 +1,301 @@
+// Regression tests for the review-feedback fixes on ListProviders:
+//
+//  1. Wire-shape: LLMProvider surfaces Endpoint, Model, Region, RateLimit,
+//     TimeoutSeconds, and Settings.
+//  2. Pagination: ListProvidersPaged returns LLMProviderListResponse with
+//     PaginationMeta; ListAllProviders walks every page.
+//  3. context.Context propagation: cancelled context surfaces as a
+//     request error, not a hang.
+//  4. SDK version-mismatch warning actually fires when min_sdk_version
+//     declares the local Version as out-of-date.
+package axonflow
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestLLMProvider_FullShapeRoundTrip(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"providers": []map[string]interface{}{
+				{
+					"name":            "anthropic",
+					"type":            "anthropic",
+					"enabled":         true,
+					"priority":        0,
+					"weight":          100,
+					"has_api_key":     true,
+					"endpoint":        "https://api.anthropic.com",
+					"model":           "claude-haiku-4-5",
+					"region":          "us-east-1",
+					"rate_limit":      60,
+					"timeout_seconds": 30,
+					"settings": map[string]interface{}{
+						"temperature_default": 0.2,
+					},
+					"health": map[string]interface{}{"status": "healthy"},
+				},
+			},
+			"pagination": map[string]interface{}{
+				"page": 1, "page_size": 20, "total_items": 1, "total_pages": 1,
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL})
+	providers, err := client.ListProviders(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListProviders: %v", err)
+	}
+	if len(providers) != 1 {
+		t.Fatalf("got %d providers, want 1", len(providers))
+	}
+	p := providers[0]
+	if p.Endpoint != "https://api.anthropic.com" {
+		t.Errorf("Endpoint = %q, want https://api.anthropic.com", p.Endpoint)
+	}
+	if p.Model != "claude-haiku-4-5" {
+		t.Errorf("Model = %q, want claude-haiku-4-5", p.Model)
+	}
+	if p.Region != "us-east-1" {
+		t.Errorf("Region = %q, want us-east-1", p.Region)
+	}
+	if p.RateLimit != 60 {
+		t.Errorf("RateLimit = %d, want 60", p.RateLimit)
+	}
+	if p.TimeoutSeconds != 30 {
+		t.Errorf("TimeoutSeconds = %d, want 30", p.TimeoutSeconds)
+	}
+	if p.Settings == nil || p.Settings["temperature_default"] != 0.2 {
+		t.Errorf("Settings = %+v, want map with temperature_default=0.2", p.Settings)
+	}
+}
+
+func TestListProvidersPaged_ReturnsPaginationMeta(t *testing.T) {
+	t.Parallel()
+	var seenQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"providers": []map[string]interface{}{
+				{"name": "p1", "type": "openai", "enabled": true, "has_api_key": true},
+			},
+			"pagination": map[string]interface{}{
+				"page": 2, "page_size": 5, "total_items": 7, "total_pages": 2,
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL})
+	resp, err := client.ListProvidersPaged(context.Background(), &ListProvidersOptions{
+		Page:     2,
+		PageSize: 5,
+	})
+	if err != nil {
+		t.Fatalf("ListProvidersPaged: %v", err)
+	}
+	if resp.Pagination.Page != 2 || resp.Pagination.PageSize != 5 ||
+		resp.Pagination.TotalItems != 7 || resp.Pagination.TotalPages != 2 {
+		t.Errorf("Pagination = %+v, want page=2 size=5 items=7 pages=2", resp.Pagination)
+	}
+	for _, p := range []string{"page=2", "page_size=5"} {
+		if !strings.Contains(seenQuery, p) {
+			t.Errorf("query %q missing %q", seenQuery, p)
+		}
+	}
+}
+
+func TestListAllProviders_WalksEveryPage(t *testing.T) {
+	t.Parallel()
+	var pageSeen int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := atomic.AddInt32(&pageSeen, 1)
+		w.Header().Set("Content-Type", "application/json")
+		switch page {
+		case 1:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"providers": []map[string]interface{}{
+					{"name": "a", "type": "openai", "enabled": true, "has_api_key": true},
+					{"name": "b", "type": "openai", "enabled": true, "has_api_key": true},
+				},
+				"pagination": map[string]interface{}{
+					"page": 1, "page_size": 2, "total_items": 3, "total_pages": 2,
+				},
+			})
+		case 2:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"providers": []map[string]interface{}{
+					{"name": "c", "type": "anthropic", "enabled": true, "has_api_key": true},
+				},
+				"pagination": map[string]interface{}{
+					"page": 2, "page_size": 2, "total_items": 3, "total_pages": 2,
+				},
+			})
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL})
+	all, err := client.ListAllProviders(context.Background(), &ListProvidersOptions{PageSize: 2})
+	if err != nil {
+		t.Fatalf("ListAllProviders: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("got %d providers across pages, want 3", len(all))
+	}
+	wantNames := []string{"a", "b", "c"}
+	for i, p := range all {
+		if p.Name != wantNames[i] {
+			t.Errorf("provider[%d].Name = %q, want %q", i, p.Name, wantNames[i])
+		}
+	}
+}
+
+func TestListProviders_RespectsContextCancellation(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL})
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := client.ListProviders(ctx, nil)
+	if err == nil {
+		t.Fatal("expected context cancellation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "context") &&
+		!strings.Contains(err.Error(), "deadline") &&
+		!strings.Contains(err.Error(), "canceled") {
+		t.Errorf("error %q does not mention context/deadline/canceled", err.Error())
+	}
+}
+
+func TestListProviders_EmptyProvidersArray(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"providers":[],"pagination":{"page":1,"page_size":20,"total_items":0,"total_pages":1}}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL})
+	providers, err := client.ListProviders(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListProviders: %v", err)
+	}
+	if len(providers) != 0 {
+		t.Errorf("expected empty providers slice, got %+v", providers)
+	}
+}
+
+func TestListProviders_MalformedJSON(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"providers": [garbage`))
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL})
+	_, err := client.ListProviders(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected decode error, got nil")
+	}
+	if !strings.Contains(err.Error(), "decode") {
+		t.Errorf("error %q does not mention decoding", err.Error())
+	}
+}
+
+func TestHealthCheckDetailed_FiresWarningWhenSDKBelowMinimum(t *testing.T) {
+	// NOT t.Parallel() — captures global log.SetOutput which races with the
+	// "no warning when empty min version" test below.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"service":      "axonflow-agent",
+			"status":       "healthy",
+			"version":      "7.4.4",
+			"capabilities": []map[string]interface{}{},
+			"sdk_compatibility": map[string]interface{}{
+				"min_sdk_version":         map[string]string{"go": "99.0.0"},
+				"recommended_sdk_version": map[string]string{"go": "99.0.0"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	defaultOut := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(defaultOut)
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL, Debug: true})
+	if _, err := client.HealthCheckDetailed(); err != nil {
+		t.Fatalf("HealthCheckDetailed: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "below minimum supported version") {
+		t.Errorf("expected upgrade warning in log output, got: %s", out)
+	}
+}
+
+func TestHealthCheckDetailed_NoWarningWhenEmptyMinVersion(t *testing.T) {
+	// NOT t.Parallel() — captures global log.SetOutput which races with the
+	// "fires warning" test above.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"service":      "axonflow-agent",
+			"status":       "healthy",
+			"version":      "7.4.4",
+			"capabilities": []map[string]interface{}{},
+			"sdk_compatibility": map[string]interface{}{
+				"min_sdk_version":         map[string]string{"go": ""},
+				"recommended_sdk_version": map[string]string{"go": ""},
+			},
+		})
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	defaultOut := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(defaultOut)
+
+	client := NewClient(AxonFlowConfig{Endpoint: server.URL})
+	if _, err := client.HealthCheckDetailed(); err != nil {
+		t.Fatalf("HealthCheckDetailed: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "below minimum supported version") {
+		t.Errorf("upgrade warning fired on empty min version: %s", out)
+	}
+}

--- a/list_providers_test.go
+++ b/list_providers_test.go
@@ -5,6 +5,7 @@
 package axonflow
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -51,7 +52,7 @@ func TestListProviders_DecodesProvidersAndHealth(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(AxonFlowConfig{Endpoint: server.URL})
-	providers, err := client.ListProviders(nil)
+	providers, err := client.ListProviders(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("ListProviders returned error: %v", err)
 	}
@@ -83,7 +84,7 @@ func TestListProviders_FiltersAreQueryParams(t *testing.T) {
 
 	client := NewClient(AxonFlowConfig{Endpoint: server.URL})
 	enabledFalse := false
-	if _, err := client.ListProviders(&ListProvidersOptions{
+	if _, err := client.ListProviders(context.Background(), &ListProvidersOptions{
 		Type:    "anthropic",
 		Enabled: &enabledFalse,
 	}); err != nil {
@@ -111,7 +112,7 @@ func TestListProviders_ProviderWithoutHealth(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(AxonFlowConfig{Endpoint: server.URL})
-	providers, err := client.ListProviders(nil)
+	providers, err := client.ListProviders(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("ListProviders returned error: %v", err)
 	}
@@ -131,7 +132,7 @@ func TestListProviders_HTTPError(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(AxonFlowConfig{Endpoint: server.URL})
-	_, err := client.ListProviders(nil)
+	_, err := client.ListProviders(context.Background(), nil)
 	if err == nil {
 		t.Fatal("expected error from 403, got nil")
 	}


### PR DESCRIPTION
## Summary

Six review-driven fixes on the just-shipped \`ListProviders()\` (PR #141). All flagged by the post-merge deep code review.

## What changed

| # | Issue | Fix |
|---|---|---|
| 1 | \`LLMProvider\` was silently dropping six platform-emitted fields | Added \`Endpoint\`, \`Model\`, \`Region\`, \`RateLimit\`, \`TimeoutSeconds\`, \`Settings (map[string]any)\` to the struct |
| 2 | Pagination was ignored — silent truncation at 20 providers | Extended \`ListProvidersOptions\` with \`Page\` + \`PageSize\`. Added \`ListProvidersPaged()\` (single page + meta) and \`ListAllProviders()\` (walks every page, default \`PageSize=100\`) |
| 3 | \`ListProviders\` had no \`context.Context\` parameter | Added \`ctx context.Context\` as first param. **Pre-release breaking change** to the unreleased PR #141 — no published tag yet, so no consumers have pinned the old signature |
| 4 | The previous test never verified the SDK-version-mismatch warning actually fires | Added \`TestHealthCheckDetailed_FiresWarningWhenSDKBelowMinimum\` (mocks min=99.0.0 against local \`Version\`) and \`TestHealthCheckDetailed_NoWarningWhenEmptyMinVersion\` (empty-string edge case) |
| 5 | Missing tests for empty list + malformed JSON | \`TestListProviders_EmptyProvidersArray\` and \`TestListProviders_MalformedJSON\` |
| 6 | No test for ctx cancellation propagation | \`TestListProviders_RespectsContextCancellation\` (50ms timeout against a 2s-stalled server) |

## New types

- \`PaginationMeta{Page, PageSize, TotalItems, TotalPages}\`
- \`LLMProviderListResponse{Providers, Pagination}\`

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` clean (existing + 7 new tests)
- [x] Wire-shape contract gate green
- [x] No regressions in the existing \`SDKCompatibility\` / \`HealthCheckDetailed\` tests
- [x] Ran with \`-race\` — no flakes (had to remove \`t.Parallel()\` from the two tests that capture global \`log.SetOutput\` since they race on stdlib state)

## Cross-SDK note

The same review surfaced equivalent gaps in Python / TS / Java SDKs — sibling PRs landing in the same window: axonflow-sdk-python#165, plus TS + Java in flight.