### PR TITLE
fix: Sandbox() and examples target localhost; staging-eu was decommissioned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Breaking type change in `SDKCompatibility`.** `MinSDKVersion` and `RecommendedSDKVersion` are now `map[string]string` (per-language) instead of `string`, matching the actual on-the-wire shape returned by the platform `/health` endpoint since v4.8.0. The previous `string` type silently unmarshalled the JSON object to an empty string, making the SDK version-mismatch warning a no-op. New helpers `(*SDKCompatibility).MinSDKVersionFor("go")` / `RecommendedSDKVersionFor("go")` return the per-language entry. Aligns Go with Java + TypeScript SDKs.
+- **`Sandbox()`** now targets `http://localhost:8080` (was the decommissioned `https://staging-eu.getaxonflow.com`). Override via `NewClient` with an explicit `Endpoint` if you need to point sandbox at a hosted environment. The staging-eu environment was torn down 2026-04-09.
+- **`examples/basic/`, `examples/connectors/`, `examples/planning/`, `examples/README.md`** — replaced the decommissioned `staging-eu.getaxonflow.com` default endpoint with `http://localhost:8080` (the local docker-compose default).
+- **`README.md`, `SECURITY.md`, `CONTRIBUTING.md`** — bulk-replaced staging-eu URL references with `http://localhost:8080` in code samples and env-var instructions.
 
 ## [5.8.0] - 2026-04-25 — Plugin Batch 1 explainability fields on MCP responses
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ scrutinise the SHA move.
 Set up your environment variables:
 
 ```bash
-export AXONFLOW_AGENT_URL="https://staging-eu.getaxonflow.com"
+export AXONFLOW_AGENT_URL="http://localhost:8080"  # Local docker-compose default
 export AXONFLOW_CLIENT_ID="your-client-id"
 export AXONFLOW_CLIENT_SECRET="your-client-secret"
 ```

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ import (
 func main() {
     // Simple initialization with OAuth2 credentials
     client := axonflow.NewClient(axonflow.AxonFlowConfig{
-        Endpoint:     "https://staging-eu.getaxonflow.com",
+        Endpoint:     "http://localhost:8080",
         ClientID:     os.Getenv("AXONFLOW_CLIENT_ID"),
         ClientSecret: os.Getenv("AXONFLOW_CLIENT_SECRET"),
     })
@@ -144,7 +144,7 @@ import (
 
 // Full configuration with all features
 client := axonflow.NewClient(axonflow.AxonFlowConfig{
-    Endpoint:     "https://staging-eu.getaxonflow.com",
+    Endpoint:     "http://localhost:8080",
     ClientID:     os.Getenv("AXONFLOW_CLIENT_ID"),
     ClientSecret: os.Getenv("AXONFLOW_CLIENT_SECRET"),
     Mode:         "production",  // or "sandbox"
@@ -247,7 +247,7 @@ Automatic retry on transient failures with exponential backoff:
 
 ```go
 client := axonflow.NewClient(axonflow.AxonFlowConfig{
-    Endpoint: "https://staging-eu.getaxonflow.com",
+    Endpoint: "http://localhost:8080",
     ClientID: "your-client-id",
     ClientSecret: "your-secret",
     Retry: axonflow.RetryConfig{
@@ -267,7 +267,7 @@ Reduce latency and load with intelligent caching:
 
 ```go
 client := axonflow.NewClient(axonflow.AxonFlowConfig{
-    Endpoint: "https://staging-eu.getaxonflow.com",
+    Endpoint: "http://localhost:8080",
     ClientID: "your-client-id",
     ClientSecret: "your-secret",
     Cache: axonflow.CacheConfig{
@@ -289,7 +289,7 @@ Never block your users if AxonFlow is unavailable:
 
 ```go
 client := axonflow.NewClient(axonflow.AxonFlowConfig{
-    Endpoint: "https://staging-eu.getaxonflow.com",
+    Endpoint: "http://localhost:8080",
     ClientID: "your-client-id",
     ClientSecret: "your-secret",
     Mode:     "production",  // Fail-open in production
@@ -317,7 +317,7 @@ import (
 
 // Initialize AxonFlow client
 axonflowClient := axonflow.NewClient(axonflow.AxonFlowConfig{
-    Endpoint:     "https://staging-eu.getaxonflow.com",
+    Endpoint:     "http://localhost:8080",
     ClientID:     os.Getenv("AXONFLOW_CLIENT_ID"),
     ClientSecret: os.Getenv("AXONFLOW_CLIENT_SECRET"),
 })
@@ -867,7 +867,7 @@ If you're using older authentication methods (`LicenseKey` or API keys), migrate
 **Before (v2.x):**
 ```go
 client := axonflow.NewClient(axonflow.AxonFlowConfig{
-    Endpoint:   "https://staging-eu.getaxonflow.com",
+    Endpoint:   "http://localhost:8080",
     LicenseKey: os.Getenv("AXONFLOW_LICENSE_KEY"),
 })
 ```
@@ -875,7 +875,7 @@ client := axonflow.NewClient(axonflow.AxonFlowConfig{
 **After (v3.x):**
 ```go
 client := axonflow.NewClient(axonflow.AxonFlowConfig{
-    Endpoint:     "https://staging-eu.getaxonflow.com",
+    Endpoint:     "http://localhost:8080",
     ClientID:     os.Getenv("AXONFLOW_CLIENT_ID"),
     ClientSecret: os.Getenv("AXONFLOW_CLIENT_SECRET"),
 })

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,7 +62,7 @@ When using the AxonFlow Go SDK:
 ```go
 // ❌ BAD - Credentials in code
 client := axonflow.NewClientSimple(
-    "https://staging-eu.getaxonflow.com",
+    "http://localhost:8080",
     "client-id-here",
     "secret-here",
 )

--- a/axonflow.go
+++ b/axonflow.go
@@ -695,14 +695,19 @@ func NewClientSimple(endpoint, clientID, clientSecret string) *AxonFlowClient {
 	})
 }
 
-// Sandbox creates a client in sandbox mode for testing
+// Sandbox creates a client in sandbox mode for testing.
+//
+// Defaults to http://localhost:8080 (the local docker-compose default).
+// The previous staging-eu.getaxonflow.com endpoint was decommissioned
+// 2026-04-09. To point sandbox at a hosted environment, construct the
+// client directly with NewClient and an explicit Endpoint.
 func Sandbox(apiKey string) *AxonFlowClient {
 	if apiKey == "" {
 		apiKey = "demo-key"
 	}
 
 	return NewClient(AxonFlowConfig{
-		Endpoint:     "https://staging-eu.getaxonflow.com",
+		Endpoint:     "http://localhost:8080",
 		ClientID:     apiKey,
 		ClientSecret: apiKey,
 		Mode:         "sandbox",

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ go get github.com/getaxonflow/axonflow-go
 Set environment variables:
 
 ```bash
-export AXONFLOW_AGENT_URL="https://staging-eu.getaxonflow.com"
+export AXONFLOW_AGENT_URL="http://localhost:8080"  # Default for local docker-compose
 export AXONFLOW_CLIENT_ID="your-client-id"
 export AXONFLOW_CLIENT_SECRET="AXON-PLUS-yourorg-20351025-signature"  # Your license key
 ```

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	// Load configuration from environment variables
-	agentURL := getEnv("AXONFLOW_AGENT_URL", "https://staging-eu.getaxonflow.com")
+	agentURL := getEnv("AXONFLOW_AGENT_URL", "http://localhost:8080")
 	clientID := getEnv("AXONFLOW_CLIENT_ID", "")
 	clientSecret := getEnv("AXONFLOW_CLIENT_SECRET", "")
 

--- a/examples/connectors/main.go
+++ b/examples/connectors/main.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	// Load configuration from environment variables
-	agentURL := getEnv("AXONFLOW_AGENT_URL", "https://staging-eu.getaxonflow.com")
+	agentURL := getEnv("AXONFLOW_AGENT_URL", "http://localhost:8080")
 	clientID := getEnv("AXONFLOW_CLIENT_ID", "")
 	clientSecret := getEnv("AXONFLOW_CLIENT_SECRET", "")
 

--- a/examples/planning/main.go
+++ b/examples/planning/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	// Load configuration from environment variables
-	agentURL := getEnv("AXONFLOW_AGENT_URL", "https://staging-eu.getaxonflow.com")
+	agentURL := getEnv("AXONFLOW_AGENT_URL", "http://localhost:8080")
 	clientID := getEnv("AXONFLOW_CLIENT_ID", "")
 	clientSecret := getEnv("AXONFLOW_CLIENT_SECRET", "")
 


### PR DESCRIPTION
## Summary

Cross-SDK audit prompted by your question \"why TS and Java only — what about Python and Go?\" caught the same staging-eu URL drift in Go that the TS deep review fixed.

## The bug

\`axonflow.go:705\` — \`Sandbox()\` hard-coded \`https://staging-eu.getaxonflow.com\`, a host that was decommissioned 2026-04-09. Anyone calling \`axonflow.Sandbox(...)\` hit a dead host.

Same pattern + fix as the TS SDK PR #203. Java SDK already defaulted to localhost (via \`AxonFlowConfig.DEFAULT_ENDPOINT\`); Python SDK defaults to localhost or try.getaxonflow.com depending on mode.

## Changes

### SDK source (real bug)

- **\`axonflow.go:705\`** — \`Sandbox()\` endpoint changed from \`staging-eu.getaxonflow.com\` → \`http://localhost:8080\`. Doc-comment added explaining why and how to override for hosted environments.

### Examples + docs (cosmetic)

- **\`examples/basic/main.go\`, \`examples/connectors/main.go\`, \`examples/planning/main.go\`** — default \`agentURL\` env-var fallback pointed at staging-eu; now localhost.
- **\`examples/README.md\`** — env-var instructions repointed.
- **\`README.md\`** (9 staging-eu refs in code samples), **\`SECURITY.md\`** (1 ref), **\`CONTRIBUTING.md\`** (1 ref) — bulk-replaced.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` passes (all packages, no failures)
- [ ] CI green on PR
- [ ] CI: integration green on push to main

## CHANGELOG

User-facing entries under \`[Unreleased] / Fixed\` for Sandbox + example + docs changes.

## Why the deep review missed this

I greped staging-eu in TS \`examples/\` (which caught the example-side defaults in PR #196) but didn't grep the SDK source. The cross-SDK question prompted the right grep across all 4 SDK repos and surfaced both the Go and TS SDK-source instances.