### PR TITLE
review fixes: integration.yml gates + module-path traps + JWT-rejected demo tokens

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,10 +9,18 @@ on:
   workflow_dispatch:
   # Run weekly to catch API drift
   schedule:
-    - cron: '0 6 * * 1'  # Monday 6am UTC
+    # Tuesday 06:00 UTC — failures land in EU/IN working hours, not weekend
+    # handover. Aligns with the TS + Java SDK integration crons.
+    - cron: '0 6 * * 2'
 
 permissions:
   contents: read
+
+# Avoid spawning parallel docker-compose stacks on back-to-back pushes;
+# also cancels stale PR runs when a new commit lands.
+concurrency:
+  group: integration-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   DO_NOT_TRACK: '1'
@@ -173,10 +181,11 @@ jobs:
     - name: Start Community Stack
       run: |
         cd ../axonflow
-        docker compose up -d
+        docker compose up -d --wait --wait-timeout 120
 
-        # Wait for services to be healthy
-        echo "Waiting for services to be healthy..."
+        # Belt-and-suspenders: also poll /health since not every compose
+        # service has a healthcheck wired.
+        echo "Waiting for agent to be healthy..."
         timeout 120 bash -c 'until curl -sf http://localhost:8080/health; do sleep 2; done'
         echo "Agent is healthy"
 
@@ -194,26 +203,42 @@ jobs:
         AXONFLOW_CLIENT_SECRET: demo-secret
 
     - name: Run Basic Example
+      # `|| echo` was masking real failures (compile errors, panics,
+      # connection refused). Demo creds against the community stack should
+      # pass; if they don't, the smoke surfaces the regression.
       run: |
         cd examples/basic
-        timeout 30 go run main.go || echo "Example completed (may fail without LLM configured)"
+        timeout 30 go run main.go
       env:
         AXONFLOW_AGENT_URL: http://localhost:8080
         AXONFLOW_CLIENT_ID: demo-client
         AXONFLOW_CLIENT_SECRET: demo-secret
+
+    # Logs MUST be captured before `Stop Community Stack` runs — `compose
+    # down` destroys the containers and `compose logs` then returns
+    # nothing. `if: failure()` here, `if: always()` on teardown.
+    - name: Show Docker Logs on Failure
+      if: failure()
+      run: |
+        if [ -d "../axonflow" ]; then
+          cd ../axonflow
+          docker compose logs --tail=200 || true
+        fi
+
+    - name: Upload Docker Logs on Failure
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: docker-compose-logs
+        path: ../axonflow/docker-compose-logs.txt
+        if-no-files-found: ignore
 
     - name: Stop Community Stack
       if: always()
       run: |
         if [ -d "../axonflow" ]; then
           cd ../axonflow
+          # Persist logs to disk so the upload step can grab them post-teardown.
+          docker compose logs --tail=500 > docker-compose-logs.txt 2>/dev/null || true
           docker compose down --volumes --remove-orphans || true
-        fi
-
-    - name: Show Docker Logs on Failure
-      if: failure()
-      run: |
-        if [ -d "../axonflow" ]; then
-          cd ../axonflow
-          docker compose logs --tail=100 || true
         fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`Sandbox()`** now targets `http://localhost:8080` (was the decommissioned `https://staging-eu.getaxonflow.com`). Override via `NewClient` with an explicit `Endpoint` if you need to point sandbox at a hosted environment. The staging-eu environment was torn down 2026-04-09.
 - **`examples/basic/`, `examples/connectors/`, `examples/planning/`, `examples/README.md`** — replaced the decommissioned `staging-eu.getaxonflow.com` default endpoint with `http://localhost:8080` (the local docker-compose default).
 - **`README.md`, `SECURITY.md`, `CONTRIBUTING.md`** — bulk-replaced staging-eu URL references with `http://localhost:8080` in code samples and env-var instructions.
+- **Stale `axonflow-go` module path corrected to `axonflow-sdk-go/v5`** in `examples/README.md` (`go get` instruction + pkg.go.dev link), `SECURITY.md` (`go get -u` and pkg.go.dev advisory), and `CONTRIBUTING.md` (clone URL + cd target). The bare `axonflow-go` resolved to the v1.17.0 relic that the main README already warns about; the docs were sending readers straight into the trap.
+- **`examples/basic/`, `examples/connectors/`** — replaced hardcoded `"demo-user-token"` literal with empty string, letting the SDK auto-populate `user_token` (defaults to `"anonymous"` per `axonflow.go:734`). Stacks with JWT middleware enabled reject literal non-JWT strings outright; the same examples now work against community + JWT-validating deployments without modification.
+- **`README.md` VPC example** — replaced fictional `vpc-private-endpoint.getaxonflow.com:8443` hostname (does not resolve, doesn't follow the documented `{client}-{env}-{region}.getaxonflow.com` naming convention) with a clearly-placeholder `<your-vpc-endpoint>.example.com:8443`.
+- **`SECURITY.md` HTTPS example** — replaced fictional `https://api.getaxonflow.com` with a clearly-placeholder `https://your-axonflow-deployment.example.com`.
 
 ## [5.8.0] - 2026-04-25 — Plugin Batch 1 explainability fields on MCP responses
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for your interest in contributing to the AxonFlow Go SDK! We welcome c
 ## Getting Started
 
 1. Fork the repository
-2. Clone your fork: `git clone https://github.com/YOUR_USERNAME/axonflow-go.git`
+2. Clone your fork: `git clone https://github.com/YOUR_USERNAME/axonflow-sdk-go.git`
 3. Create a feature branch: `git checkout -b feature/your-feature-name`
 4. Make your changes
 5. Run tests: `go test ./...`
@@ -23,8 +23,8 @@ Thank you for your interest in contributing to the AxonFlow Go SDK! We welcome c
 ### Installation
 
 ```bash
-git clone https://github.com/getaxonflow/axonflow-go.git
-cd axonflow-go
+git clone https://github.com/getaxonflow/axonflow-sdk-go.git
+cd axonflow-sdk-go
 go mod download
 ```
 

--- a/README.md
+++ b/README.md
@@ -705,7 +705,7 @@ For applications running in AWS VPC, use the private endpoint for lower latency:
 
 ```go
 client := axonflow.NewClient(axonflow.AxonFlowConfig{
-    Endpoint:     "https://vpc-private-endpoint.getaxonflow.com:8443",  // VPC private endpoint
+    Endpoint:     "https://<your-vpc-endpoint>.example.com:8443",  // VPC private endpoint (replace with your deployment URL)
     ClientID:     "your-client-id",
     ClientSecret: "your-secret",
     Mode:         "production",

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -80,8 +80,8 @@ client := axonflow.NewClientSimple(
 Always use HTTPS endpoints for production:
 
 ```go
-// ✅ GOOD - HTTPS endpoint
-client := axonflow.NewClientSimple("https://api.getaxonflow.com", clientID, secret)
+// ✅ GOOD - HTTPS endpoint (replace with your AxonFlow deployment URL)
+client := axonflow.NewClientSimple("https://your-axonflow-deployment.example.com", clientID, secret)
 
 // ⚠️ WARNING - HTTP should only be used for local development
 client := axonflow.NewClientSimple("http://localhost:8080", clientID, secret)
@@ -145,7 +145,7 @@ Keep dependencies up to date:
 go list -m -u all
 
 # Update dependencies
-go get -u github.com/getaxonflow/axonflow-go
+go get -u github.com/getaxonflow/axonflow-sdk-go/v5
 go mod tidy
 ```
 
@@ -224,7 +224,7 @@ To receive security updates:
 
 - Watch this repository for releases
 - Subscribe to security advisories
-- Check https://pkg.go.dev/github.com/getaxonflow/axonflow-go regularly
+- Check https://pkg.go.dev/github.com/getaxonflow/axonflow-sdk-go/v5 regularly
 
 ## Questions?
 

--- a/axonflow_http_test.go
+++ b/axonflow_http_test.go
@@ -1204,7 +1204,7 @@ func TestNonLocalHostIncludesAuth(t *testing.T) {
 	// This tests that non-localhost URLs would include auth headers
 	// We verify this by checking the auth logic in the client configuration
 	client := NewClient(AxonFlowConfig{
-		Endpoint:     "https://api.getaxonflow.com",
+		Endpoint:     "https://example.test",
 		ClientID:     "test",
 		ClientSecret: "secret",
 		Cache:        CacheConfig{Enabled: false},
@@ -1214,7 +1214,7 @@ func TestNonLocalHostIncludesAuth(t *testing.T) {
 	if client.config.ClientSecret != "secret" {
 		t.Errorf("Expected ClientSecret 'secret', got '%s'", client.config.ClientSecret)
 	}
-	if client.config.Endpoint != "https://api.getaxonflow.com" {
+	if client.config.Endpoint != "https://example.test" {
 		t.Errorf("Expected non-localhost URL")
 	}
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ This directory contains working examples demonstrating how to use the AxonFlow G
 ## Prerequisites
 
 ```bash
-go get github.com/getaxonflow/axonflow-go
+go get github.com/getaxonflow/axonflow-sdk-go/v5
 ```
 
 Set environment variables:
@@ -92,5 +92,5 @@ Example license keys by tier:
 ## Learn More
 
 - [Main Documentation](../README.md)
-- [API Reference](https://pkg.go.dev/github.com/getaxonflow/axonflow-go)
+- [API Reference](https://pkg.go.dev/github.com/getaxonflow/axonflow-sdk-go/v5)
 - [AxonFlow Docs](https://docs.getaxonflow.com)

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -34,7 +34,7 @@ func main() {
 	// Execute a simple query
 	fmt.Println("\nExecuting governed query...")
 	resp, err := client.ProxyLLMCall(
-		"demo-user-token",
+		"", // SDK auto-populates user_token (defaults to "anonymous" if no JWT). Don't pass a literal — JWT-validating stacks reject it.
 		"What is the capital of France?",
 		"chat",
 		map[string]interface{}{
@@ -79,7 +79,7 @@ func main() {
 	fmt.Println(strings.Repeat("=", 60))
 
 	resp2, err := client.ProxyLLMCall(
-		"demo-user-token",
+		"", // SDK auto-populates user_token (defaults to "anonymous" if no JWT). Don't pass a literal — JWT-validating stacks reject it.
 		"My email is john.doe@example.com and my SSN is 123-45-6789",
 		"chat",
 		map[string]interface{}{},

--- a/examples/connectors/main.go
+++ b/examples/connectors/main.go
@@ -93,7 +93,7 @@ func main() {
 		fmt.Println("Querying Amadeus connector for flights...")
 
 		resp, err := client.QueryConnector(
-			"demo-user-token", // User token for authentication and audit
+			"", // SDK auto-populates user_token (defaults to "anonymous"). Don't hardcode a non-JWT literal — JWT-validating stacks reject it.
 			"amadeus-prod",
 			"Find flights from Paris to Amsterdam on 2025-12-15",
 			map[string]interface{}{
@@ -118,7 +118,7 @@ func main() {
 	fmt.Println("\nQuerying Redis connector...")
 
 	redisResp, err := client.QueryConnector(
-		"demo-user-token", // User token for authentication and audit
+		"", // SDK auto-populates user_token (defaults to "anonymous"). Don't hardcode a non-JWT literal — JWT-validating stacks reject it.
 		"redis-cache",
 		"Get cached user preferences for user-123",
 		map[string]interface{}{


### PR DESCRIPTION
## Summary

Deep code review (cross-SDK audit prompted by user's question \"why TS and Java only — what about Python and Go?\") caught several issues in the Go SDK that the original QF-10 pass missed because Go was tagged \"gold-standard, don't touch.\" PR #143 was a fast targeted URL fix; this PR is the proper deep-review pass that should have happened up-front.

## P0 — real bugs / live-CI hygiene

1. **`integration.yml` logs-after-teardown ordering.** `Stop Community Stack` (\`if: always\`) was declared BEFORE `Show Docker Logs on Failure` (\`if: failure\`). On a failed run, \`compose down --volumes --remove-orphans\` destroyed the containers; subsequent \`compose logs\` returned empty. **Fixed:** capture logs first, persist to disk, upload as artifact, then teardown.

2. **`integration.yml` `|| echo` swallowed real failures.** \`timeout 30 go run main.go || echo \"Example completed (may fail without LLM configured)\"\` masked compile errors, panics, connection refused, anything. Demo creds against the community stack should pass. **Fixed:** removed the masking line.

3. **`examples/README.md`, `SECURITY.md`, `CONTRIBUTING.md` — stale `axonflow-go` module-path trap.** \`go get github.com/getaxonflow/axonflow-go\` resolves to the v1.17.0 relic the main README warns about. Three docs were sending readers straight into that trap. **Fixed:** all paths corrected to \`github.com/getaxonflow/axonflow-sdk-go/v5\`; CONTRIBUTING clone URL fixed to the correct repo name.

## P1 — correctness / hardening

4. **`examples/basic/`, `examples/connectors/` hardcoded `\"demo-user-token\"` literal.** Any stack with JWT middleware enabled rejects this string outright (not a valid JWT). Community works because middleware is off, but the same example would fail against an enterprise stack. **Fixed:** replaced with empty string; SDK auto-populates `user_token` (defaults to \"anonymous\" per `axonflow.go:734`).

5. **`integration.yml` no concurrency group.** Back-to-back pushes spawn parallel docker-compose stacks fighting over ports 8080/8081. **Fixed:** added `concurrency: integration-${{ github.ref }}` with `cancel-in-progress: true`.

6. **`integration.yml` cron Monday → Tuesday 06:00 UTC.** Aligns with TS + Java SDK integration crons; failures land in EU/IN working hours, not weekend handover.

7. **`integration.yml` no `actions/upload-artifact` for logs.** Even with the ordering fixed, when the runner is gone the logs are gone. **Fixed:** persist `docker compose logs --tail=500` to disk before teardown, upload as artifact on failure.

8. **`integration.yml` `docker compose up -d --wait --wait-timeout 120`** for native dependency-aware health gating. Kept the existing curl /health loop as belt-and-suspenders.

9. **Fictional hostnames in docs + tests.** README VPC example used `vpc-private-endpoint.getaxonflow.com:8443` (doesn't resolve); SECURITY.md \"GOOD HTTPS\" example used `https://api.getaxonflow.com` (fictional); `axonflow_http_test.go:1207-1217` `TestNonLocalHostIncludesAuth` used the same `api.getaxonflow.com` hostname. **Fixed:** README → `<your-vpc-endpoint>.example.com:8443` placeholder; SECURITY → `https://your-axonflow-deployment.example.com`; test → `https://example.test`.

## What I did NOT change (deferred)

- Cache-disable semantics drift (`Cache.TTL=60s` defaults regardless of `Cache.Enabled=false`) — flagged as P2 cross-SDK API drift; needs a v6 design pass.
- `contract_wire_shape_test.go:352` `t.Skip` for `registered_types` baseline regen — flagged as P2 polish; needs a follow-up issue, not a one-line fix.
- `examples/wcp-retry-idempotency/main.go` `source /tmp/axonflow-e2e-env.sh` doc comment — minor.
- Module-path SHA-pin consistency on `actions/cache@v4` — P2 polish.

## What the original deep-review pass missed (and why)

The original deep-review pass (TS PRs #196/#197/#199 + Java PR #147) was scoped to TS + Java only because the brief said \"Go is gold-standard, don't touch.\" That assumption was wrong: Go's `integration.yml` had the same logs-after-teardown ordering bug as TS+Java had, the same missing concurrency / artifact-upload / --wait gaps, and the docs/examples had their own class of bugs (the v1.17.0 module-path trap in particular). The lesson: cross-SDK audits must always grep all 4 repos at once, not trust one repo's reputation as \"gold standard.\" Memory entry coming.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` passes — 3 packages, no failures, ~7s
- [ ] CI green on PR
- [ ] CI: live-integration green on push to main (basic example smoke + new ordering + new artifact upload)

## CHANGELOG

User-facing entries under \`[Unreleased] / Fixed\` for module-path corrections, demo-token literal fixes, and fictional-hostname placeholders.