### PR TITLE
fix(telemetry)!: remove DO_NOT_TRACK opt-out (BREAKING)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DO_NOT_TRACK: '1'
+  AXONFLOW_TELEMETRY: 'off'
 
 jobs:
   # Contract tests run on all PRs and pushes - they don't need the stack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 env:
-  DO_NOT_TRACK: '1'
+  AXONFLOW_TELEMETRY: 'off'
 
 jobs:
   # Preflight: validate CHANGELOG has a section for the tag being released

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 env:
-  DO_NOT_TRACK: '1'
+  AXONFLOW_TELEMETRY: 'off'
 
 jobs:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **BREAKING:** `DO_NOT_TRACK` is no longer honored as an AxonFlow telemetry opt-out. Use `AXONFLOW_TELEMETRY=off` instead.
+
+  `DO_NOT_TRACK` was deprecated because it is commonly inherited from host tools and developer environments (CLIs like Codex and Claude Code inject it unconditionally), which makes it an unreliable expression of user intent for AxonFlow telemetry.
+
+### Fixed
+
+- The one-line `[AxonFlow] DO_NOT_TRACK=1 is deprecated...` `log.Printf` warning is no longer emitted. Removing the warning eliminates log noise that previously appeared on every `NewClient` call when `DO_NOT_TRACK=1` was set.
+
+### CI / development
+
+- Test harness (`main_test.go` `TestMain`) and CI workflows (`test.yml`, `release.yml`, `integration.yml`) now use `AXONFLOW_TELEMETRY=off` to suppress telemetry during automated runs.
+
+
 ## [6.0.0] - 2026-04-28 — ListProviders() + SDKCompatibility wire-shape fix
 
 Major release. The breaking change is `SDKCompatibility.MinSDKVersion` and `RecommendedSDKVersion` moving from `string` to `map[string]string` to match the real on-the-wire shape the platform has been returning since v4.8.0. Coordinated cycle: TypeScript v6.2.0 / Python v6.9.0 / Java v6.2.0 ship same day as minors.

--- a/README.md
+++ b/README.md
@@ -968,7 +968,10 @@ No email required. Optional contact if you want a response.
 ## Telemetry
 
 This SDK sends anonymous usage telemetry (SDK version, OS, enabled features) to help improve AxonFlow.
-No prompts, payloads, or PII are ever collected. Opt out: `AXONFLOW_TELEMETRY=off` or `DO_NOT_TRACK=1`.
+No prompts, payloads, or PII are ever collected. Opt out: `AXONFLOW_TELEMETRY=off`.
+
+`DO_NOT_TRACK` is **not** honored as an opt-out for AxonFlow telemetry. It is commonly inherited from host tools and developer environments, which makes it an unreliable expression of user intent.
+
 See [Telemetry Documentation](https://docs.getaxonflow.com/docs/telemetry) for full details.
 
 ## License

--- a/interceptors/main_test.go
+++ b/interceptors/main_test.go
@@ -1,0 +1,19 @@
+package interceptors
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain sets AXONFLOW_TELEMETRY=off for all tests in this package so
+// that running `go test ./...` against the SDK never sends telemetry pings
+// to the checkpoint endpoint. This package's tests construct AxonFlowClient
+// instances which would otherwise fire a real ping on every NewClient call.
+//
+// The root package's main_test.go does the same thing, but `go test ./...`
+// runs each package as a separate test binary, so each package needs its
+// own TestMain.
+func TestMain(m *testing.M) {
+	os.Setenv("AXONFLOW_TELEMETRY", "off")
+	os.Exit(m.Run())
+}

--- a/main_test.go
+++ b/main_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 )
 
-// TestMain sets DO_NOT_TRACK=1 for all tests in this package so that
-// running the SDK test suite never sends telemetry pings to the
+// TestMain sets AXONFLOW_TELEMETRY=off for all tests in this package so
+// that running the SDK test suite never sends telemetry pings to the
 // checkpoint endpoint. Individual telemetry tests override this via
 // t.Setenv() when they need to verify enabled behavior.
 func TestMain(m *testing.M) {
-	os.Setenv("DO_NOT_TRACK", "1")
+	os.Setenv("AXONFLOW_TELEMETRY", "off")
 	os.Exit(m.Run())
 }

--- a/telemetry.go
+++ b/telemetry.go
@@ -151,24 +151,16 @@ func generateInstanceID() string {
 // isTelemetryEnabled determines whether telemetry should be sent for this client.
 //
 // Priority order:
-//  1. Environment variables — DO_NOT_TRACK=1 (deprecated) or AXONFLOW_TELEMETRY=off disables (always wins).
+//  1. AXONFLOW_TELEMETRY=off in the environment disables telemetry (always wins).
 //  2. Config override (TelemetryEnabled *bool) — if non-nil, use its value.
 //  3. Default — ON for all modes except sandbox.
 //
-// DO_NOT_TRACK is deprecated and will be removed after 2026-05-05 in the next
-// major release. Use AXONFLOW_TELEMETRY=off to opt out of AxonFlow telemetry.
-// When DO_NOT_TRACK=1 is the only thing disabling telemetry, a one-time
-// warning is logged so operators can migrate before the removal.
+// DO_NOT_TRACK is intentionally NOT honored. It is commonly inherited from
+// host tools and developer environments (CLIs like Codex and Claude Code
+// inject it unconditionally), which makes it an unreliable expression of
+// user intent for AxonFlow telemetry.
 func (c *AxonFlowClient) isTelemetryEnabled() bool {
 	// 1. Environment-level opt-out always wins (cannot be overridden by config).
-	if strings.TrimSpace(os.Getenv("DO_NOT_TRACK")) == "1" {
-		// Only warn when DO_NOT_TRACK is the active control. If the caller
-		// has also set AXONFLOW_TELEMETRY=off, they've already migrated.
-		if !strings.EqualFold(strings.TrimSpace(os.Getenv("AXONFLOW_TELEMETRY")), "off") {
-			log.Printf("[AxonFlow] DO_NOT_TRACK=1 is deprecated as an AxonFlow telemetry opt-out and will be removed after 2026-05-05 in the next major release. Set AXONFLOW_TELEMETRY=off to opt out going forward. See https://docs.getaxonflow.com/docs/telemetry for details.")
-		}
-		return false
-	}
 	if strings.EqualFold(strings.TrimSpace(os.Getenv("AXONFLOW_TELEMETRY")), "off") {
 		return false
 	}

--- a/telemetry_test.go
+++ b/telemetry_test.go
@@ -19,9 +19,8 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestIsTelemetryEnabled_Default(t *testing.T) {
-	// Clear DO_NOT_TRACK so tests can verify default behavior.
-	// CI sets DO_NOT_TRACK=1 to prevent telemetry pings.
-	t.Setenv("DO_NOT_TRACK", "")
+	// Clear AXONFLOW_TELEMETRY so tests can verify default behavior.
+	// TestMain sets AXONFLOW_TELEMETRY=off to prevent telemetry pings.
 	t.Setenv("AXONFLOW_TELEMETRY", "")
 
 	t.Run("off for sandbox mode", func(t *testing.T) {
@@ -88,10 +87,11 @@ func TestIsTelemetryEnabled_EnvVarOverride(t *testing.T) {
 		}
 	}
 
-	t.Run("DO_NOT_TRACK=1 disables", func(t *testing.T) {
+	t.Run("DO_NOT_TRACK=1 alone does NOT disable (DNT no longer honored)", func(t *testing.T) {
 		t.Setenv("DO_NOT_TRACK", "1")
-		if prodClient().isTelemetryEnabled() {
-			t.Error("expected telemetry disabled when DO_NOT_TRACK=1")
+		t.Setenv("AXONFLOW_TELEMETRY", "")
+		if !prodClient().isTelemetryEnabled() {
+			t.Error("expected telemetry enabled — DO_NOT_TRACK is no longer honored as an AxonFlow opt-out")
 		}
 	})
 
@@ -108,10 +108,17 @@ func TestIsTelemetryEnabled_EnvVarOverride(t *testing.T) {
 			t.Error("expected telemetry disabled when AXONFLOW_TELEMETRY=OFF")
 		}
 	})
+
+	t.Run("AXONFLOW_TELEMETRY=off disables even with DO_NOT_TRACK=1 also set", func(t *testing.T) {
+		t.Setenv("DO_NOT_TRACK", "1")
+		t.Setenv("AXONFLOW_TELEMETRY", "off")
+		if prodClient().isTelemetryEnabled() {
+			t.Error("expected telemetry disabled — AXONFLOW_TELEMETRY=off is the canonical opt-out")
+		}
+	})
 }
 
 func TestIsTelemetryEnabled_ConfigOverride(t *testing.T) {
-	t.Setenv("DO_NOT_TRACK", "")
 	t.Setenv("AXONFLOW_TELEMETRY", "")
 	boolPtr := func(v bool) *bool { return &v }
 
@@ -141,8 +148,9 @@ func TestIsTelemetryEnabled_ConfigOverride(t *testing.T) {
 		}
 	})
 
-	t.Run("DO_NOT_TRACK beats config true", func(t *testing.T) {
+	t.Run("DO_NOT_TRACK=1 alone does NOT beat config true (DNT no longer honored)", func(t *testing.T) {
 		t.Setenv("DO_NOT_TRACK", "1")
+		t.Setenv("AXONFLOW_TELEMETRY", "")
 		client := &AxonFlowClient{
 			config: AxonFlowConfig{
 				Mode:             "production",
@@ -151,8 +159,8 @@ func TestIsTelemetryEnabled_ConfigOverride(t *testing.T) {
 				TelemetryEnabled: boolPtr(true),
 			},
 		}
-		if client.isTelemetryEnabled() {
-			t.Error("expected DO_NOT_TRACK=1 to disable telemetry even with config override")
+		if !client.isTelemetryEnabled() {
+			t.Error("expected telemetry enabled — DNT is no longer honored, config true wins")
 		}
 	})
 
@@ -197,7 +205,7 @@ func TestGenerateInstanceID(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestSendTelemetryPing_Success(t *testing.T) {
-	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("AXONFLOW_TELEMETRY", "")
 	var received telemetryPayload
 	var called atomic.Int32
 
@@ -267,7 +275,7 @@ func TestSendTelemetryPing_Success(t *testing.T) {
 }
 
 func TestSendTelemetryPing_Timeout(t *testing.T) {
-	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("AXONFLOW_TELEMETRY", "")
 	// Server that delays longer than telemetry timeout. Use a channel to
 	// allow the handler goroutine to exit promptly once the test finishes.
 	handlerDone := make(chan struct{})
@@ -316,7 +324,7 @@ func TestSendTelemetryPing_OptOut(t *testing.T) {
 	defer srv.Close()
 
 	t.Setenv("AXONFLOW_CHECKPOINT_URL", srv.URL)
-	t.Setenv("DO_NOT_TRACK", "1")
+	t.Setenv("AXONFLOW_TELEMETRY", "off")
 
 	client := &AxonFlowClient{
 		config: AxonFlowConfig{
@@ -329,12 +337,12 @@ func TestSendTelemetryPing_OptOut(t *testing.T) {
 	client.sendTelemetryPing()
 
 	if called.Load() != 0 {
-		t.Error("expected no HTTP request when telemetry is opted out")
+		t.Error("expected no HTTP request when telemetry is opted out via AXONFLOW_TELEMETRY=off")
 	}
 }
 
 func TestSendTelemetryPing_SilentFailure(t *testing.T) {
-	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("AXONFLOW_TELEMETRY", "")
 	// Server that returns 500
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -357,7 +365,7 @@ func TestSendTelemetryPing_SilentFailure(t *testing.T) {
 }
 
 func TestSendTelemetryPing_CustomEndpoint(t *testing.T) {
-	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("AXONFLOW_TELEMETRY", "")
 	var called atomic.Int32
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -384,7 +392,7 @@ func TestSendTelemetryPing_CustomEndpoint(t *testing.T) {
 }
 
 func TestSendTelemetryPing_InvalidURL(t *testing.T) {
-	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("AXONFLOW_TELEMETRY", "")
 	t.Setenv("AXONFLOW_CHECKPOINT_URL", "://invalid-url")
 
 	client := &AxonFlowClient{
@@ -404,7 +412,7 @@ func TestSendTelemetryPing_InvalidURL(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestBuildPayload(t *testing.T) {
-	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("AXONFLOW_TELEMETRY", "")
 	t.Run("mode propagated to deployment_mode", func(t *testing.T) {
 		modes := []string{"production", "sandbox", "staging", "development"}
 		for _, mode := range modes {
@@ -497,7 +505,7 @@ func TestSendTelemetryPing_SandboxDefaultOff(t *testing.T) {
 }
 
 func TestSendTelemetryPing_SandboxExplicitEnable(t *testing.T) {
-	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("AXONFLOW_TELEMETRY", "")
 	var called atomic.Int32
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -554,7 +562,7 @@ func TestSendTelemetryPing_ConfigDisableInProduction(t *testing.T) {
 }
 
 func TestSendTelemetryPing_ConnectionRefused(t *testing.T) {
-	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("AXONFLOW_TELEMETRY", "")
 	// Port 1 is reserved and should refuse connections on all platforms.
 	t.Setenv("AXONFLOW_CHECKPOINT_URL", "http://127.0.0.1:1")
 
@@ -582,7 +590,7 @@ func TestSendTelemetryPing_ConnectionRefused(t *testing.T) {
 }
 
 func TestSendTelemetryPing_OutdatedVersion(t *testing.T) {
-	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("AXONFLOW_TELEMETRY", "")
 	// Server returns a newer version to trigger the debug warning.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -624,7 +632,7 @@ func TestSendTelemetryPing_OutdatedVersion(t *testing.T) {
 }
 
 func TestSendTelemetryPing_ProductionNoCreds(t *testing.T) {
-	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("AXONFLOW_TELEMETRY", "")
 	var called atomic.Int32
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

**BREAKING:** `DO_NOT_TRACK` is no longer honored as an AxonFlow telemetry opt-out. Use `AXONFLOW_TELEMETRY=off` instead.

`DO_NOT_TRACK` was deprecated because it is commonly inherited from host tools and developer environments (CLIs like Codex and Claude Code inject it unconditionally), which makes it an unreliable expression of user intent for AxonFlow telemetry.

This is a breaking change for anyone who relied on `DO_NOT_TRACK=1`. They must migrate to `AXONFLOW_TELEMETRY=off`. Major version bump (`/v6` → `/v7` module path migration) will happen at release time under explicit approval — not in this PR.

## Changes

- `telemetry.go` — drop the DNT branch + `log.Printf` deprecation warning from `isTelemetryEnabled`. Priority order: env var > config override > mode default.
- `main_test.go` — `TestMain` now sets `AXONFLOW_TELEMETRY=off` (was: DNT=1) to suppress telemetry during the test suite.
- `telemetry_test.go` — flip every existing DNT-suppress assertion. Add positive coverage that DNT=1 + AXONFLOW_TELEMETRY=off still suppresses (canonical wins).
- `.github/workflows/{test,release,integration}.yml` — migrate suppression env.
- `README.md`, `CHANGELOG.md` — updated.

## Test plan

- [x] `go test ./...` — exit 0
- [x] Live `go run` against running stack with DNT=1, AXONFLOW_TELEMETRY unset — ping fires (DNT no longer suppresses), no warning logged, ping landed in DynamoDB at 2026-04-29T15:05:56Z (sdk=go v6.0.0)
- [ ] CI green