### PR TITLE
feat(telemetry): 7-day delivered-heartbeat with stamp-on-success

### DIFF
--- a/.github/workflows/heartbeat-real-stack.yml
+++ b/.github/workflows/heartbeat-real-stack.yml
@@ -1,0 +1,48 @@
+name: heartbeat-real-stack
+
+# Real-stack heartbeat E2E across Linux + Windows + macOS. Stands up a
+# localhost fake checkpoint server, constructs the SDK through its
+# public API, verifies (a) the OS-native stamp file appears, (b) the
+# checkpoint endpoint received exactly one ping, (c) a second
+# invocation does NOT re-fire (warm-cache regression).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  AXONFLOW_TELEMETRY: 'off'
+
+jobs:
+  real-stack:
+    name: real-stack ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Set up Python (for harness driver)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build smoke binary
+        working-directory: tests/heartbeat-real-stack
+        run: |
+          go mod tidy
+          go build -o smoke_go ./smoke_go.go
+        shell: bash
+
+      - name: Run real-stack heartbeat E2E (cold + warm)
+        run: python tests/heartbeat-real-stack/run_real_stack.py tests/heartbeat-real-stack/smoke_go${{ runner.os == 'Windows' && '.exe' || '' }}

--- a/.github/workflows/heartbeat-real-stack.yml
+++ b/.github/workflows/heartbeat-real-stack.yml
@@ -39,10 +39,23 @@ jobs:
 
       - name: Build smoke binary
         working-directory: tests/heartbeat-real-stack
+        shell: bash
         run: |
           go mod tidy
-          go build -o smoke_go ./smoke_go.go
-        shell: bash
+          # Explicit .exe on Windows so the run step's path is unambiguous;
+          # Go's `-o smoke_go` behavior on Windows is version-dependent.
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            go build -o smoke_go.exe ./smoke_go.go
+          else
+            go build -o smoke_go ./smoke_go.go
+          fi
 
       - name: Run real-stack heartbeat E2E (cold + warm)
-        run: python tests/heartbeat-real-stack/run_real_stack.py tests/heartbeat-real-stack/smoke_go${{ runner.os == 'Windows' && '.exe' || '' }}
+        shell: bash
+        run: |
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            BIN="tests/heartbeat-real-stack/smoke_go.exe"
+          else
+            BIN="tests/heartbeat-real-stack/smoke_go"
+          fi
+          python tests/heartbeat-real-stack/run_real_stack.py "$BIN"

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ CLAUDE.md.backup-*
 .codex/
 .worktrees/
 coverage.txt
+
+# Heartbeat real-stack smoke build artifact
+tests/heartbeat-real-stack/smoke_go
+tests/heartbeat-real-stack/smoke_go.exe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The one-line `[AxonFlow] DO_NOT_TRACK=1 is deprecated...` `log.Printf` warning is no longer emitted. Removing the warning eliminates log noise that previously appeared on every `NewClient` call when `DO_NOT_TRACK=1` was set.
 
+### Changed
+
+- **Telemetry now follows the 7-day delivered-heartbeat contract** instead of firing on every `NewClient` call. The SDK emits at most one anonymous heartbeat per environment every 7 days during SDK activity. A stamp file at the OS-native user cache dir (`os.UserCacheDir() / axonflow / go-telemetry-last-sent`) tracks last successful delivery; the file mtime is the source of truth across process restarts. Failed POSTs do NOT advance the stamp, so a transient network failure does not silence telemetry for 7 days. An in-memory 1-hour cache caps stat() syscalls on hot paths; an in-flight flag coalesces concurrent goroutines so only one ping fires under load. `AXONFLOW_TELEMETRY=off` is re-evaluated on every gate run, so a mid-process opt-out toggle takes effect without restart. Lambda / restricted environments where `os.UserCacheDir()` is unavailable fall back transparently to the previous "one ping per process" behavior — no regression for that runtime.
+
 ### CI / development
 
 - Test harness (`main_test.go` `TestMain`) and CI workflows (`test.yml`, `release.yml`, `integration.yml`) now use `AXONFLOW_TELEMETRY=off` to suppress telemetry during automated runs.
+- Subprocess-based regression test (`telemetry_short_lived_test.go`) now isolates `HOME` / `XDG_CACHE_HOME` so a previous run's stamp file doesn't suppress the next run's expected ping.
 
 
 ## [6.0.0] - 2026-04-28 — ListProviders() + SDKCompatibility wire-shape fix

--- a/audit.go
+++ b/audit.go
@@ -285,7 +285,7 @@ func (c *AxonFlowClient) SearchAuditLogs(ctx context.Context, req *AuditSearchRe
 		log.Printf("[AxonFlow] Audit search - Limit: %d, Offset: %d", req.Limit, req.Offset)
 	}
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("audit search request failed: %w", err)
 	}
@@ -390,7 +390,7 @@ func (c *AxonFlowClient) GetAuditLogsByTenant(ctx context.Context, tenantID stri
 		log.Printf("[AxonFlow] Get audit logs for tenant: %s (limit: %d, offset: %d)", tenantID, limit, offset)
 	}
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("tenant audit request failed: %w", err)
 	}

--- a/axonflow.go
+++ b/axonflow.go
@@ -49,17 +49,18 @@ type CacheConfig struct {
 	TTL     time.Duration // Cache TTL (default: 60s)
 }
 
-// AxonFlowClient represents the SDK for connecting to AxonFlow platform
+// AxonFlowClient represents the SDK for connecting to AxonFlow platform.
+//
+// The 7-day telemetry heartbeat is process-global (not per-client) — see
+// the sharedHeartbeat package-level variable in heartbeat.go. That keeps
+// concurrent NewClient calls on the same machine coalescing onto a single
+// ping per heartbeatInterval, which is the contract.
 type AxonFlowClient struct {
 	config        AxonFlowConfig
 	httpClient    *http.Client
 	mapHttpClient *http.Client // Separate client with longer timeout for MAP operations
 	cache         *cache
 	sessionCookie string // Session cookie for Customer Portal authentication
-	// heartbeat gates the 7-day "at most one anonymous heartbeat per
-	// environment per heartbeatInterval during SDK activity" telemetry
-	// contract. Initialized in NewClient. Always non-nil after construction.
-	heartbeat *heartbeatState
 }
 
 // ============================================================================
@@ -663,7 +664,6 @@ func NewClient(config AxonFlowConfig) *AxonFlowClient {
 			Timeout:   config.MapTimeout,
 			Transport: uaTransport,
 		},
-		heartbeat: newHeartbeatState(),
 	}
 
 	if config.Cache.Enabled {

--- a/axonflow.go
+++ b/axonflow.go
@@ -56,6 +56,10 @@ type AxonFlowClient struct {
 	mapHttpClient *http.Client // Separate client with longer timeout for MAP operations
 	cache         *cache
 	sessionCookie string // Session cookie for Customer Portal authentication
+	// heartbeat gates the 7-day "at most one anonymous heartbeat per
+	// environment per heartbeatInterval during SDK activity" telemetry
+	// contract. Initialized in NewClient. Always non-nil after construction.
+	heartbeat *heartbeatState
 }
 
 // ============================================================================
@@ -659,6 +663,7 @@ func NewClient(config AxonFlowConfig) *AxonFlowClient {
 			Timeout:   config.MapTimeout,
 			Transport: uaTransport,
 		},
+		heartbeat: newHeartbeatState(),
 	}
 
 	if config.Cache.Enabled {
@@ -669,19 +674,16 @@ func NewClient(config AxonFlowConfig) *AxonFlowClient {
 		log.Printf("[AxonFlow] Client initialized - Mode: %s, Endpoint: %s, MapTimeout: %v", config.Mode, config.Endpoint, config.MapTimeout)
 	}
 
-	// Send telemetry ping synchronously with a bounded timeout.
+	// Telemetry heartbeat: at most one anonymous ping per machine per 7 days,
+	// gated by SDK activity. NewClient runs the gate synchronously so a fresh
+	// install on a short-lived process (CLI, serverless cold-start, quickstart)
+	// still delivers the first ping before main() returns. Subsequent gate runs
+	// (from doHttpRequest) are async. Total NewClient blocking is bounded at
+	// telemetryTimeout (3s) and only fires when the stamp is stale or absent —
+	// typical re-runs are sub-millisecond.
 	//
-	// A goroutine here would be fire-and-forget in theory, but in practice any
-	// short-lived process (CLI binary, serverless handler, quickstart snippet,
-	// cold-start function) returns from main() before the goroutine's HTTP
-	// POST completes, silently dropping the ping. See issue #1693.
-	//
-	// sendTelemetryPing runs the health probe and the checkpoint POST under a
-	// single shared context.WithTimeout(telemetryTimeout) so the total
-	// blocking time on NewClient is bounded at ~telemetryTimeout (3s),
-	// regardless of whether endpoints are reachable. Typical is ~350ms warm
-	// / ~1.3s cold.
-	client.sendTelemetryPing()
+	// See heartbeat.go for the full algorithm and stamp-on-delivery semantics.
+	client.maybeSendHeartbeat()
 
 	return client
 }
@@ -931,7 +933,7 @@ func (c *AxonFlowClient) executeRequest(req ClientRequest) (*ClientResponse, err
 	}
 
 	startTime := time.Now()
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
@@ -1054,7 +1056,11 @@ func (c *AxonFlowClient) isAxonFlowError(err error) bool {
 
 // HealthCheck checks if AxonFlow Agent is healthy
 func (c *AxonFlowClient) HealthCheck() error {
-	resp, err := c.httpClient.Get(c.config.Endpoint + "/health")
+	req, err := http.NewRequest(http.MethodGet, c.config.Endpoint+"/health", nil)
+	if err != nil {
+		return fmt.Errorf("health check request build failed: %w", err)
+	}
+	resp, err := c.doHttpRequest(c.httpClient, req)
 	if err != nil {
 		return fmt.Errorf("health check failed: %w", err)
 	}
@@ -1155,7 +1161,7 @@ func (c *AxonFlowClient) HealthCheckDetailed() (*HealthResponse, error) {
 		return nil, fmt.Errorf("creating health request: %w", err)
 	}
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doHttpRequest(c.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("health check request failed: %w", err)
 	}
@@ -1341,7 +1347,7 @@ func (c *AxonFlowClient) ListProvidersPaged(ctx context.Context, opts *ListProvi
 	}
 	c.addAuthHeaders(req)
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doHttpRequest(c.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("list providers request failed: %w", err)
 	}
@@ -1403,7 +1409,7 @@ func (c *AxonFlowClient) ListConnectors() ([]ConnectorMetadata, error) {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	c.addAuthHeaders(req)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doHttpRequest(c.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list connectors: %w", err)
 	}
@@ -1438,7 +1444,7 @@ func (c *AxonFlowClient) GetConnector(connectorID string) (*ConnectorMetadata, e
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	c.addAuthHeaders(req)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doHttpRequest(c.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get connector: %w", err)
 	}
@@ -1473,7 +1479,7 @@ func (c *AxonFlowClient) GetConnectorHealth(connectorID string) (*ConnectorHealt
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	c.addAuthHeaders(req)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doHttpRequest(c.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get connector health: %w", err)
 	}
@@ -1517,7 +1523,7 @@ func (c *AxonFlowClient) InstallConnector(req ConnectorInstallRequest) error {
 	httpReq.Header.Set("Content-Type", "application/json")
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return fmt.Errorf("install request failed: %w", err)
 	}
@@ -1545,7 +1551,7 @@ func (c *AxonFlowClient) UninstallConnector(connectorName string) error {
 
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return fmt.Errorf("uninstall request failed: %w", err)
 	}
@@ -1830,7 +1836,7 @@ func (c *AxonFlowClient) executeMapRequest(req ClientRequest) (*ClientResponse, 
 	}
 
 	startTime := time.Now()
-	resp, err := c.mapHttpClient.Do(httpReq) // Use mapHttpClient with longer timeout
+	resp, err := c.doHttpRequest(c.mapHttpClient, httpReq) // Use mapHttpClient with longer timeout
 	if err != nil {
 		return nil, fmt.Errorf("MAP request failed: %w", err)
 	}
@@ -2004,7 +2010,7 @@ func (c *AxonFlowClient) GetPlanStatus(planID string) (*PlanExecutionResponse, e
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	c.addAuthHeaders(req)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doHttpRequest(c.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get plan status: %w", err)
 	}
@@ -2055,7 +2061,7 @@ func (c *AxonFlowClient) CancelPlan(planID string, reason ...string) (*CancelPla
 		log.Printf("[AxonFlow] Cancelling plan: %s", planID)
 	}
 
-	resp, err := c.mapHttpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.mapHttpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("cancel plan request failed: %w", err)
 	}
@@ -2104,7 +2110,7 @@ func (c *AxonFlowClient) UpdatePlan(planID string, req UpdatePlanRequest) (*Upda
 		log.Printf("[AxonFlow] Updating plan: %s (expected version: %d)", planID, req.ExpectedVersion)
 	}
 
-	resp, err := c.mapHttpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.mapHttpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("update plan request failed: %w", err)
 	}
@@ -2151,7 +2157,7 @@ func (c *AxonFlowClient) GetPlanVersions(planID string) (*PlanVersionsResponse, 
 		log.Printf("[AxonFlow] Getting plan versions: %s", planID)
 	}
 
-	resp, err := c.mapHttpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.mapHttpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("get plan versions request failed: %w", err)
 	}
@@ -2209,7 +2215,7 @@ func (c *AxonFlowClient) ResumePlan(planID string, approved ...bool) (*ResumePla
 		log.Printf("[AxonFlow] Resuming plan: %s (approved: %v)", planID, isApproved)
 	}
 
-	resp, err := c.mapHttpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.mapHttpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("resume plan request failed: %w", err)
 	}
@@ -2251,7 +2257,7 @@ func (c *AxonFlowClient) RollbackPlan(planID string, targetVersion int) (*Rollba
 		log.Printf("[AxonFlow] Rolling back plan: %s to version %d", planID, targetVersion)
 	}
 
-	resp, err := c.mapHttpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.mapHttpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("rollback plan request failed: %w", err)
 	}
@@ -2433,7 +2439,7 @@ func (c *AxonFlowClient) GetPolicyApprovedContext(
 		log.Printf("[AxonFlow] Gateway Mode: Pre-check for query: %s", query[:min(50, len(query))])
 	}
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("pre-check request failed: %w", err)
 	}
@@ -2578,7 +2584,7 @@ func (c *AxonFlowClient) AuditLLMCall(
 			contextID, provider, model)
 	}
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("audit request failed: %w", err)
 	}
@@ -2725,7 +2731,7 @@ func (c *AxonFlowClient) LoginToPortal(orgID, password string) (*PortalLoginResp
 		log.Printf("[AxonFlow] Portal login for org: %s", orgID)
 	}
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doHttpRequest(c.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("login request failed: %w", err)
 	}
@@ -2788,7 +2794,7 @@ func (c *AxonFlowClient) LogoutFromPortal() error {
 		Value: c.sessionCookie,
 	})
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doHttpRequest(c.httpClient, req)
 	if err != nil {
 		return fmt.Errorf("logout request failed: %w", err)
 	}
@@ -2828,7 +2834,7 @@ func (c *AxonFlowClient) makePolicyCheckRequest(ctx context.Context, fullURL str
 		log.Printf("[AxonFlow] Policy check request: POST %s", fullURL)
 	}
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doHttpRequest(c.httpClient, req)
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
@@ -2877,7 +2883,7 @@ func (c *AxonFlowClient) makeJSONRequest(ctx context.Context, method, fullURL st
 		log.Printf("[AxonFlow] JSON request: %s %s", method, fullURL)
 	}
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doHttpRequest(c.httpClient, req)
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}

--- a/code_governance.go
+++ b/code_governance.go
@@ -256,7 +256,7 @@ func (c *AxonFlowClient) portalRequest(method, path string, body interface{}, re
 		log.Printf("[AxonFlow] Portal request: %s %s", method, path)
 	}
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doHttpRequest(c.httpClient, req)
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
@@ -309,7 +309,7 @@ func (c *AxonFlowClient) portalRequestRaw(method, path string) ([]byte, error) {
 		Value: c.sessionCookie,
 	})
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doHttpRequest(c.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}

--- a/decisions.go
+++ b/decisions.go
@@ -89,7 +89,7 @@ func (c *AxonFlowClient) ExplainDecision(ctx context.Context, decisionID string)
 	httpReq.Header.Set("Accept", "application/json")
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("explain request failed: %w", err)
 	}

--- a/execution_replay.go
+++ b/execution_replay.go
@@ -162,7 +162,7 @@ func (c *AxonFlowClient) ListExecutions(options *ListExecutionsOptions) (*ListEx
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	c.addAuthHeaders(req)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doHttpRequest(c.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list executions: %w", err)
 	}
@@ -210,7 +210,7 @@ func (c *AxonFlowClient) GetExecution(executionID string) (*ExecutionDetail, err
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	c.addAuthHeaders(req)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doHttpRequest(c.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get execution: %w", err)
 	}
@@ -262,7 +262,7 @@ func (c *AxonFlowClient) GetExecutionSteps(executionID string) ([]ExecutionSnaps
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	c.addAuthHeaders(req)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doHttpRequest(c.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get execution steps: %w", err)
 	}
@@ -317,7 +317,7 @@ func (c *AxonFlowClient) GetExecutionTimeline(executionID string) ([]TimelineEnt
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	c.addAuthHeaders(req)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doHttpRequest(c.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get execution timeline: %w", err)
 	}
@@ -392,7 +392,7 @@ func (c *AxonFlowClient) ExportExecution(executionID string, options *ExecutionE
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	c.addAuthHeaders(req)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doHttpRequest(c.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to export execution: %w", err)
 	}
@@ -444,7 +444,7 @@ func (c *AxonFlowClient) DeleteExecution(executionID string) error {
 	}
 	c.addAuthHeaders(req)
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doHttpRequest(c.httpClient, req)
 	if err != nil {
 		return fmt.Errorf("failed to delete execution: %w", err)
 	}

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -1,0 +1,192 @@
+package axonflow
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Heartbeat cadence constants. Declared as `var` rather than `const` so
+// tests can override them — the test files in this package back up the
+// original values and restore them on cleanup.
+var (
+	// heartbeatInterval bounds how often a single machine sends an anonymous
+	// telemetry ping. Aligned with the plugin "7-day heartbeat" contract:
+	// "at most one anonymous heartbeat per environment every 7 days during
+	// SDK activity."
+	heartbeatInterval = 7 * 24 * time.Hour
+
+	// heartbeatGuardInterval bounds how often a single client process
+	// re-consults the stamp file. Without this, every API call would
+	// stat() the stamp file. With it, a hot service stat()s at most once
+	// per hour even under load.
+	heartbeatGuardInterval = time.Hour
+)
+
+// heartbeatState holds the per-client mutable state used to gate telemetry
+// pings. The stamp file at stampPath is the source of truth across process
+// restarts; the in-memory fields handle within-process gating.
+//
+// Stamp semantics: stamp-on-DELIVERY. A failed ping does NOT update the
+// stamp, so the next call after the in-memory cache expires retries.
+// Concurrent goroutines crossing the boundary are coalesced via inFlight
+// so we send at most one POST, not one per goroutine.
+type heartbeatState struct {
+	mu          sync.Mutex
+	lastChecked time.Time // last wall-clock instant the gate ran
+	inFlight    bool      // true while a ping POST is in progress
+	stampPath   string    // empty when no user cache dir is available
+}
+
+// resolveStampPath returns the OS-native path to the SDK's heartbeat stamp
+// file, or "" if the user cache dir is unavailable (e.g. AWS Lambda where
+// HOME is unset). When the path is empty, the SDK falls back to the
+// pre-heartbeat behavior of one ping per process — no regression.
+func resolveStampPath() string {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(cacheDir, "axonflow", "go-telemetry-last-sent")
+}
+
+// newHeartbeatState constructs a heartbeat state ready for first use.
+func newHeartbeatState() *heartbeatState {
+	return &heartbeatState{stampPath: resolveStampPath()}
+}
+
+// readStampMtime returns the modification time of the stamp file, or the
+// zero time if the file is absent / unreadable / has no resolvable cache
+// dir. A zero return means "treat as never sent" — the caller should fire
+// a fresh ping.
+func (h *heartbeatState) readStampMtime() time.Time {
+	if h.stampPath == "" {
+		return time.Time{}
+	}
+	info, err := os.Stat(h.stampPath)
+	if err != nil {
+		return time.Time{}
+	}
+	return info.ModTime()
+}
+
+// writeStampAtomic writes a fresh timestamp at h.stampPath via tmp+rename
+// so concurrent writers never observe torn state. The single line of
+// human-readable content (`last_sent=<RFC3339>`) is advisory only — the
+// SDK reads mtime, not the contents.
+//
+// Returns nil on success or a non-nil error when the cache dir or write
+// fails. Errors are non-fatal — the caller may log in debug mode and
+// continue. A failed stamp write means the next process retries on
+// schedule, which is preferable to silent dropping.
+func (h *heartbeatState) writeStampAtomic(now time.Time) error {
+	if h.stampPath == "" {
+		return nil
+	}
+	dir := filepath.Dir(h.stampPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, "telemetry-last-sent-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	// Ensure cleanup if rename never happens; rename is atomic and removes
+	// the source name from the directory entry, so this no-ops on success.
+	defer os.Remove(tmpName)
+	if _, err := fmt.Fprintf(tmp, "last_sent=%s\n", now.UTC().Format(time.RFC3339)); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, h.stampPath)
+}
+
+// maybeSendHeartbeat is the central gate for telemetry pings. Called from
+// NewClient (synchronously, to preserve short-lived-process delivery from
+// issue #1693) and from doHttpRequest (asynchronously via goroutine to
+// keep API call latency unaffected).
+//
+// Algorithm (in order — order matters):
+//
+//  1. AXONFLOW_TELEMETRY=off / mode-disabled: short-circuit immediately.
+//     Re-evaluated every call (lock-free) so a mid-process opt-out works.
+//  2. In-flight: another goroutine is already sending — fast-path out.
+//  3. In-memory 1-hour cache: skip the stat() syscall on hot paths.
+//  4. Stamp file mtime: skip if last delivered <heartbeatInterval ago.
+//  5. Send ping under bounded timeout. On success, write stamp. On
+//     failure, leave stamp unchanged so the next call retries.
+func (c *AxonFlowClient) maybeSendHeartbeat() {
+	if !c.isTelemetryEnabled() {
+		return
+	}
+
+	h := c.heartbeat
+	now := time.Now()
+
+	h.mu.Lock()
+	if h.inFlight {
+		h.mu.Unlock()
+		return
+	}
+	if !h.lastChecked.IsZero() && now.Sub(h.lastChecked) < heartbeatGuardInterval {
+		h.mu.Unlock()
+		return
+	}
+	h.lastChecked = now
+
+	if mtime := h.readStampMtime(); !mtime.IsZero() && now.Sub(mtime) < heartbeatInterval {
+		h.mu.Unlock()
+		return
+	}
+
+	h.inFlight = true
+	h.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), telemetryTimeout)
+	defer cancel()
+	err := c.sendTelemetryPingNow(ctx)
+
+	h.mu.Lock()
+	h.inFlight = false
+	if err == nil {
+		if writeErr := h.writeStampAtomic(time.Now()); writeErr != nil && c.config.Debug {
+			log.Printf("[AxonFlow] heartbeat stamp write failed: %v", writeErr)
+		}
+	}
+	h.mu.Unlock()
+}
+
+// maybeSendHeartbeatAsync schedules maybeSendHeartbeat on a goroutine so
+// it never blocks the caller. Used by the doHttpRequest middleware to
+// keep user API calls latency-free; NewClient still calls maybeSendHeartbeat
+// synchronously to preserve issue #1693 short-lived-process delivery.
+func (c *AxonFlowClient) maybeSendHeartbeatAsync() {
+	go c.maybeSendHeartbeat()
+}
+
+// doHttpRequest is the single HTTP middleware that wraps every public-API
+// HTTP call in this SDK. It calls maybeSendHeartbeatAsync as a side effect
+// so the 7-day heartbeat gate is consulted on every request — but
+// asynchronously, so the user's API call is never delayed by telemetry.
+//
+// The httpClient parameter selects between c.httpClient (default) and
+// c.mapHttpClient (longer timeout for MAP plan operations). The wrapper
+// is used uniformly across both to ensure no code path bypasses the
+// heartbeat gate.
+//
+// IMPORTANT: This wrapper must NOT be called from telemetry code itself
+// (sendTelemetryPingNow, detectPlatformVersion). Those use raw http.Client
+// instances to avoid recursive heartbeat triggering.
+func (c *AxonFlowClient) doHttpRequest(httpClient *http.Client, req *http.Request) (*http.Response, error) {
+	c.maybeSendHeartbeatAsync()
+	return httpClient.Do(req)
+}

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -37,10 +38,11 @@ var (
 // Concurrent goroutines crossing the boundary are coalesced via inFlight
 // so we send at most one POST, not one per goroutine.
 type heartbeatState struct {
-	mu          sync.Mutex
-	lastChecked time.Time // last wall-clock instant the gate ran
-	inFlight    bool      // true while a ping POST is in progress
-	stampPath   string    // empty when no user cache dir is available
+	mu               sync.Mutex
+	lastChecked      time.Time // last wall-clock instant the gate ran (read under mu)
+	lastCheckedNanos atomic.Int64 // mirror of lastChecked.UnixNano(), for lock-free pre-check on the request hot path
+	inFlight         bool      // true while a ping POST is in progress
+	stampPath        string    // empty when no user cache dir is available
 }
 
 // resolveStampPath returns the OS-native path to the SDK's heartbeat stamp
@@ -188,6 +190,7 @@ func (c *AxonFlowClient) maybeSendHeartbeat() {
 		return
 	}
 	h.lastChecked = now
+	h.lastCheckedNanos.Store(now.UnixNano())
 
 	if mtime := h.readStampMtime(); !mtime.IsZero() && now.Sub(mtime) < heartbeatInterval {
 		h.mu.Unlock()
@@ -201,21 +204,40 @@ func (c *AxonFlowClient) maybeSendHeartbeat() {
 	defer cancel()
 	err := c.sendTelemetryPingNow(ctx)
 
+	// Clear inFlight first so other callers can fast-path through, then do
+	// the stamp write OUTSIDE the lock — os.Rename + tmp file IO are
+	// blocking and would otherwise serialize concurrent gate runs through
+	// disk syscalls.
 	h.mu.Lock()
 	h.inFlight = false
+	h.mu.Unlock()
 	if err == nil {
 		if writeErr := h.writeStampAtomic(time.Now()); writeErr != nil && c.config.Debug {
 			log.Printf("[AxonFlow] heartbeat stamp write failed: %v", writeErr)
 		}
 	}
-	h.mu.Unlock()
 }
 
 // maybeSendHeartbeatAsync schedules maybeSendHeartbeat on a goroutine so
 // it never blocks the caller. Used by the doHttpRequest middleware to
 // keep user API calls latency-free; NewClient still calls maybeSendHeartbeat
 // synchronously to preserve issue #1693 short-lived-process delivery.
+//
+// Hot-path pre-check: on a service handling 10k req/s with a fresh stamp,
+// every request would otherwise spawn a goroutine that does a single
+// mutex acquire + cache compare + return. The atomic load of
+// lastCheckedNanos lets us skip the spawn entirely when we know the
+// 1-hour cache is still warm — bringing per-request overhead from
+// "goroutine + mutex" to "single atomic load".
 func (c *AxonFlowClient) maybeSendHeartbeatAsync() {
+	if !c.isTelemetryEnabled() {
+		return
+	}
+	h := getSharedHeartbeat()
+	if last := h.lastCheckedNanos.Load(); last != 0 &&
+		time.Since(time.Unix(0, last)) < heartbeatGuardInterval {
+		return
+	}
 	go c.maybeSendHeartbeat()
 }
 

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -60,6 +60,49 @@ func newHeartbeatState() *heartbeatState {
 	return &heartbeatState{stampPath: resolveStampPath()}
 }
 
+// sharedHeartbeat is the process-global heartbeat singleton. ALL AxonFlow
+// clients in this process consult the same gate, so concurrent NewClient
+// calls before any stamp exists coalesce onto a single ping (per the
+// "at most one anonymous heartbeat per environment" contract). Tests
+// override via replaceHeartbeatStateForTest.
+var (
+	sharedHeartbeat   = newHeartbeatState()
+	sharedHeartbeatMu sync.Mutex // guards swapping the singleton in tests
+)
+
+// getSharedHeartbeat returns the current process-global heartbeat state.
+// Reads are wrapped in the swap-mutex so a test that calls
+// replaceHeartbeatStateForTest concurrently with another test cannot tear
+// the pointer.
+func getSharedHeartbeat() *heartbeatState {
+	sharedHeartbeatMu.Lock()
+	defer sharedHeartbeatMu.Unlock()
+	return sharedHeartbeat
+}
+
+// replaceHeartbeatStateForTest installs a fresh heartbeat state at the
+// given stamp path (or "" for "no persistence"), returning the previous
+// instance so the caller can restore it on cleanup. Production code does
+// NOT call this — use only in tests.
+func replaceHeartbeatStateForTest(stampPath string) *heartbeatState {
+	sharedHeartbeatMu.Lock()
+	defer sharedHeartbeatMu.Unlock()
+	previous := sharedHeartbeat
+	sharedHeartbeat = &heartbeatState{stampPath: stampPath}
+	return previous
+}
+
+// restoreHeartbeatStateForTest restores a previously-saved state. Pair
+// with replaceHeartbeatStateForTest; typical use:
+//
+//	prev := replaceHeartbeatStateForTest(t.TempDir() + "/stamp")
+//	t.Cleanup(func() { restoreHeartbeatStateForTest(prev) })
+func restoreHeartbeatStateForTest(state *heartbeatState) {
+	sharedHeartbeatMu.Lock()
+	defer sharedHeartbeatMu.Unlock()
+	sharedHeartbeat = state
+}
+
 // readStampMtime returns the modification time of the stamp file, or the
 // zero time if the file is absent / unreadable / has no resolvable cache
 // dir. A zero return means "treat as never sent" — the caller should fire
@@ -129,7 +172,10 @@ func (c *AxonFlowClient) maybeSendHeartbeat() {
 		return
 	}
 
-	h := c.heartbeat
+	// Process-global singleton — concurrent NewClient calls on the same
+	// machine coalesce onto a single ping per heartbeatInterval. See the
+	// sharedHeartbeat declaration above for the rationale.
+	h := getSharedHeartbeat()
 	now := time.Now()
 
 	h.mu.Lock()

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -39,10 +39,10 @@ var (
 // so we send at most one POST, not one per goroutine.
 type heartbeatState struct {
 	mu               sync.Mutex
-	lastChecked      time.Time // last wall-clock instant the gate ran (read under mu)
+	lastChecked      time.Time    // last wall-clock instant the gate ran (read under mu)
 	lastCheckedNanos atomic.Int64 // mirror of lastChecked.UnixNano(), for lock-free pre-check on the request hot path
-	inFlight         bool      // true while a ping POST is in progress
-	stampPath        string    // empty when no user cache dir is available
+	inFlight         bool         // true while a ping POST is in progress
+	stampPath        string       // empty when no user cache dir is available
 }
 
 // resolveStampPath returns the OS-native path to the SDK's heartbeat stamp

--- a/heartbeat_e2e_test.go
+++ b/heartbeat_e2e_test.go
@@ -1,0 +1,155 @@
+package axonflow
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestHeartbeatE2E_FourRunCycle exercises the 7-day delivered-heartbeat
+// contract end-to-end against a real httptest checkpoint server, walking
+// through the four scenarios the spec requires:
+//
+//	Run 1: cold start (no stamp)                    → 1 ping;  stamp present
+//	Run 2: immediate re-run (fresh stamp)           → 0 pings; stamp unchanged
+//	Run 3: backdate stamp 8d via os.Chtimes         → 1 ping;  stamp re-touched
+//	Run 4: backdate stamp 8d, mock returns 503      → 0 successful pings;
+//	                                                  stamp NOT advanced;
+//	                                                  retry against 200-mock
+//	                                                  fires + lands cleanly
+//
+// This is the "exceptional quality" verification the spec calls for: it
+// validates the delivered-stamp semantics (Run 4 — failed POST does not
+// advance the stamp) and the cross-run behavior (Run 1→2→3 — the stamp
+// file is the source of truth across "process restarts" simulated by
+// fresh AxonFlowClient construction with the same stamp path).
+func TestHeartbeatE2E_FourRunCycle(t *testing.T) {
+	stampDir := t.TempDir()
+	stampPath := filepath.Join(stampDir, "go-telemetry-last-sent")
+
+	// Always-200 checkpoint server for runs 1, 2, 3 and the retry leg of run 4.
+	var pings200 atomic.Int32
+	srv200 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pings200.Add(1)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"latest_version":"` + Version + `"}`))
+	}))
+	defer srv200.Close()
+
+	// Always-503 checkpoint server for run 4's failure leg.
+	var pings503 atomic.Int32
+	srv503 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pings503.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv503.Close()
+
+	t.Setenv("AXONFLOW_TELEMETRY", "")
+
+	// Helper: build a fresh client pointing at the chosen checkpoint URL.
+	// Each call simulates a "new process" — same stamp file location, fresh
+	// in-memory state. This is the cross-run invariant the contract pins.
+	newClient := func(checkpointURL string) *AxonFlowClient {
+		t.Helper()
+		t.Setenv("AXONFLOW_CHECKPOINT_URL", checkpointURL)
+		boolPtr := func(v bool) *bool { return &v }
+		return &AxonFlowClient{
+			config: AxonFlowConfig{
+				Mode:             "production",
+				ClientID:         "id",
+				ClientSecret:     "sec",
+				TelemetryEnabled: boolPtr(true),
+			},
+			heartbeat: &heartbeatState{stampPath: stampPath},
+		}
+	}
+
+	// --- Run 1: cold start, no stamp → 1 ping, stamp written ----------------
+	pings200.Store(0)
+	c1 := newClient(srv200.URL)
+	c1.maybeSendHeartbeat()
+	if got := pings200.Load(); got != 1 {
+		t.Fatalf("Run 1 (cold): expected 1 ping, got %d", got)
+	}
+	if _, err := os.Stat(stampPath); err != nil {
+		t.Fatalf("Run 1 (cold): expected stamp file at %s, got %v", stampPath, err)
+	}
+
+	// --- Run 2: immediate re-run, fresh stamp → 0 pings ---------------------
+	pings200.Store(0)
+	c2 := newClient(srv200.URL)
+	c2.maybeSendHeartbeat()
+	if got := pings200.Load(); got != 0 {
+		t.Errorf("Run 2 (warm): expected 0 pings with fresh stamp, got %d", got)
+	}
+
+	// --- Run 3: backdate stamp 8d, expect 1 ping + stamp updated ------------
+	eightDaysAgo := time.Now().Add(-8 * 24 * time.Hour)
+	if err := os.Chtimes(stampPath, eightDaysAgo, eightDaysAgo); err != nil {
+		t.Fatalf("Run 3 setup: chtimes: %v", err)
+	}
+
+	pings200.Store(0)
+	c3 := newClient(srv200.URL)
+	c3.maybeSendHeartbeat()
+	if got := pings200.Load(); got != 1 {
+		t.Errorf("Run 3 (stale): expected 1 ping after backdating stamp, got %d", got)
+	}
+	stampInfo, err := os.Stat(stampPath)
+	if err != nil {
+		t.Fatalf("Run 3: stat stamp: %v", err)
+	}
+	if time.Since(stampInfo.ModTime()) > 5*time.Second {
+		t.Errorf("Run 3: expected stamp mtime to be very recent after successful ping, got %v ago",
+			time.Since(stampInfo.ModTime()))
+	}
+
+	// --- Run 4: backdate stamp 8d, point at 503 mock ------------------------
+	// Expectation: ping is attempted (counts on the 503 server) but stamp
+	// is NOT advanced. Then a follow-up run against the 200 server lands
+	// cleanly and advances the stamp.
+	if err := os.Chtimes(stampPath, eightDaysAgo, eightDaysAgo); err != nil {
+		t.Fatalf("Run 4 setup: chtimes: %v", err)
+	}
+	stampMtimeBeforeFailedRun, err := os.Stat(stampPath)
+	if err != nil {
+		t.Fatalf("Run 4: pre-run stat: %v", err)
+	}
+
+	pings503.Store(0)
+	c4a := newClient(srv503.URL)
+	c4a.maybeSendHeartbeat()
+	if got := pings503.Load(); got != 1 {
+		t.Errorf("Run 4 (failure): expected 1 attempt on 503 server, got %d", got)
+	}
+	stampInfoAfterFail, err := os.Stat(stampPath)
+	if err != nil {
+		t.Fatalf("Run 4: post-failure stat: %v", err)
+	}
+	if !stampInfoAfterFail.ModTime().Equal(stampMtimeBeforeFailedRun.ModTime()) {
+		t.Errorf("Run 4: stamp mtime ADVANCED after failed POST — expected unchanged.\nbefore=%v\nafter=%v",
+			stampMtimeBeforeFailedRun.ModTime(), stampInfoAfterFail.ModTime())
+	}
+
+	// --- Run 4 retry: same backdated stamp, point at 200 mock ---------------
+	// In real life the stamp would still be 8d old (because the failed POST
+	// didn't advance it) and the next process startup hits the 200 path.
+	pings200.Store(0)
+	c4b := newClient(srv200.URL)
+	c4b.maybeSendHeartbeat()
+	if got := pings200.Load(); got != 1 {
+		t.Errorf("Run 4 (retry): expected 1 ping when stamp still stale and server now 200, got %d", got)
+	}
+	stampInfoAfterRetry, err := os.Stat(stampPath)
+	if err != nil {
+		t.Fatalf("Run 4 retry: stat: %v", err)
+	}
+	if time.Since(stampInfoAfterRetry.ModTime()) > 5*time.Second {
+		t.Errorf("Run 4 retry: expected stamp mtime advanced to ~now after successful retry, got %v ago",
+			time.Since(stampInfoAfterRetry.ModTime()))
+	}
+}

--- a/heartbeat_e2e_test.go
+++ b/heartbeat_e2e_test.go
@@ -50,12 +50,20 @@ func TestHeartbeatE2E_FourRunCycle(t *testing.T) {
 
 	t.Setenv("AXONFLOW_TELEMETRY", "")
 
-	// Helper: build a fresh client pointing at the chosen checkpoint URL.
-	// Each call simulates a "new process" — same stamp file location, fresh
-	// in-memory state. This is the cross-run invariant the contract pins.
+	// Save the current process-global heartbeat singleton and restore it on
+	// cleanup so we don't leak test state into subsequent test files.
+	originalHeartbeat := getSharedHeartbeat()
+	t.Cleanup(func() { restoreHeartbeatStateForTest(originalHeartbeat) })
+
+	// Helper: build a fresh client pointing at the chosen checkpoint URL,
+	// AND swap the package-global heartbeat singleton to a fresh state at
+	// the same stamp file location. Each call simulates a "new process" —
+	// stamp file persists across runs (the cross-run invariant the
+	// contract pins), in-memory gate state is fresh.
 	newClient := func(checkpointURL string) *AxonFlowClient {
 		t.Helper()
 		t.Setenv("AXONFLOW_CHECKPOINT_URL", checkpointURL)
+		replaceHeartbeatStateForTest(stampPath)
 		boolPtr := func(v bool) *bool { return &v }
 		return &AxonFlowClient{
 			config: AxonFlowConfig{
@@ -64,7 +72,6 @@ func TestHeartbeatE2E_FourRunCycle(t *testing.T) {
 				ClientSecret:     "sec",
 				TelemetryEnabled: boolPtr(true),
 			},
-			heartbeat: &heartbeatState{stampPath: stampPath},
 		}
 	}
 

--- a/heartbeat_test.go
+++ b/heartbeat_test.go
@@ -15,12 +15,17 @@ import (
 // Helpers shared across heartbeat tests --------------------------------------
 
 // newHeartbeatClient builds a minimal *AxonFlowClient suitable for exercising
-// maybeSendHeartbeat in isolation. The caller supplies a stamp directory
-// (typically t.TempDir()) so the test doesn't touch the user's real cache
-// dir. Telemetry is forced ON via TelemetryEnabled=true so the gating
+// maybeSendHeartbeat in isolation, AND swaps the package-global heartbeat
+// singleton for one pointing at a fresh stamp file under stampDir
+// (typically t.TempDir()). Restores the original singleton on test
+// cleanup. Telemetry is forced ON via TelemetryEnabled=true so the gating
 // decision under test is the heartbeat gate, not the mode-default check.
 func newHeartbeatClient(t *testing.T, stampDir string) *AxonFlowClient {
 	t.Helper()
+	stampPath := filepath.Join(stampDir, "go-telemetry-last-sent")
+	previous := replaceHeartbeatStateForTest(stampPath)
+	t.Cleanup(func() { restoreHeartbeatStateForTest(previous) })
+
 	boolPtr := func(v bool) *bool { return &v }
 	return &AxonFlowClient{
 		config: AxonFlowConfig{
@@ -28,9 +33,6 @@ func newHeartbeatClient(t *testing.T, stampDir string) *AxonFlowClient {
 			ClientID:         "id",
 			ClientSecret:     "sec",
 			TelemetryEnabled: boolPtr(true),
-		},
-		heartbeat: &heartbeatState{
-			stampPath: filepath.Join(stampDir, "go-telemetry-last-sent"),
 		},
 	}
 }
@@ -86,8 +88,8 @@ func TestHeartbeat_NoStamp_FiresOnce(t *testing.T) {
 	if got := called.Load(); got != 1 {
 		t.Errorf("expected 1 ping on cold start, got %d", got)
 	}
-	if _, err := os.Stat(client.heartbeat.stampPath); err != nil {
-		t.Errorf("expected stamp file at %s after successful ping, got error: %v", client.heartbeat.stampPath, err)
+	if _, err := os.Stat(getSharedHeartbeat().stampPath); err != nil {
+		t.Errorf("expected stamp file at %s after successful ping, got error: %v", getSharedHeartbeat().stampPath, err)
 	}
 }
 
@@ -98,14 +100,14 @@ func TestHeartbeat_FreshStamp_DoesNotFire(t *testing.T) {
 	client := newHeartbeatClient(t, dir)
 
 	// Pre-create the stamp file with a recent mtime.
-	if err := client.heartbeat.writeStampAtomic(time.Now().Add(-24 * time.Hour)); err != nil {
+	if err := getSharedHeartbeat().writeStampAtomic(time.Now().Add(-24 * time.Hour)); err != nil {
 		t.Fatalf("seed stamp: %v", err)
 	}
 	// writeStampAtomic uses now() for the mtime regardless of the parameter
 	// value (the parameter is for the human-readable contents). Force the
 	// mtime to 1 day ago so the freshness check is deterministic.
 	oneDayAgo := time.Now().Add(-24 * time.Hour)
-	if err := os.Chtimes(client.heartbeat.stampPath, oneDayAgo, oneDayAgo); err != nil {
+	if err := os.Chtimes(getSharedHeartbeat().stampPath, oneDayAgo, oneDayAgo); err != nil {
 		t.Fatalf("chtimes: %v", err)
 	}
 
@@ -123,11 +125,11 @@ func TestHeartbeat_StaleStamp_FiresAndUpdates(t *testing.T) {
 	dir := t.TempDir()
 	client := newHeartbeatClient(t, dir)
 
-	if err := client.heartbeat.writeStampAtomic(time.Now()); err != nil {
+	if err := getSharedHeartbeat().writeStampAtomic(time.Now()); err != nil {
 		t.Fatalf("seed stamp: %v", err)
 	}
 	eightDaysAgo := time.Now().Add(-8 * 24 * time.Hour)
-	if err := os.Chtimes(client.heartbeat.stampPath, eightDaysAgo, eightDaysAgo); err != nil {
+	if err := os.Chtimes(getSharedHeartbeat().stampPath, eightDaysAgo, eightDaysAgo); err != nil {
 		t.Fatalf("chtimes: %v", err)
 	}
 
@@ -136,7 +138,7 @@ func TestHeartbeat_StaleStamp_FiresAndUpdates(t *testing.T) {
 	if got := called.Load(); got != 1 {
 		t.Errorf("expected 1 ping with stale stamp, got %d", got)
 	}
-	mtime := client.heartbeat.readStampMtime()
+	mtime := getSharedHeartbeat().readStampMtime()
 	if time.Since(mtime) > 5*time.Second {
 		t.Errorf("expected stamp mtime to be very recent, got %v ago", time.Since(mtime))
 	}
@@ -174,11 +176,11 @@ func TestHeartbeat_AfterRateLimitExpiry_FiresAgain(t *testing.T) {
 
 	// Backdate both lastChecked (memory) and stamp (file) so the gate lets
 	// the next call through.
-	client.heartbeat.mu.Lock()
-	client.heartbeat.lastChecked = time.Now().Add(-2 * time.Hour)
-	client.heartbeat.mu.Unlock()
+	getSharedHeartbeat().mu.Lock()
+	getSharedHeartbeat().lastChecked = time.Now().Add(-2 * time.Hour)
+	getSharedHeartbeat().mu.Unlock()
 	eightDaysAgo := time.Now().Add(-8 * 24 * time.Hour)
-	if err := os.Chtimes(client.heartbeat.stampPath, eightDaysAgo, eightDaysAgo); err != nil {
+	if err := os.Chtimes(getSharedHeartbeat().stampPath, eightDaysAgo, eightDaysAgo); err != nil {
 		t.Fatalf("chtimes: %v", err)
 	}
 
@@ -204,21 +206,21 @@ func TestHeartbeat_OptOutMidProcess_StopsPings(t *testing.T) {
 
 	// Toggle opt-out, force the cache + stamp gates to be open, call again.
 	t.Setenv("AXONFLOW_TELEMETRY", "off")
-	client.heartbeat.mu.Lock()
-	client.heartbeat.lastChecked = time.Now().Add(-2 * time.Hour)
-	client.heartbeat.mu.Unlock()
+	getSharedHeartbeat().mu.Lock()
+	getSharedHeartbeat().lastChecked = time.Now().Add(-2 * time.Hour)
+	getSharedHeartbeat().mu.Unlock()
 	eightDaysAgo := time.Now().Add(-8 * 24 * time.Hour)
-	_ = os.Chtimes(client.heartbeat.stampPath, eightDaysAgo, eightDaysAgo)
+	_ = os.Chtimes(getSharedHeartbeat().stampPath, eightDaysAgo, eightDaysAgo)
 	// Snapshot stamp mtime AFTER the chtimes manipulation so the assertion
 	// only catches changes the SDK code itself makes.
-	stampMtimeBefore := client.heartbeat.readStampMtime()
+	stampMtimeBefore := getSharedHeartbeat().readStampMtime()
 
 	client.maybeSendHeartbeat()
 
 	if got := called.Load(); got != 1 {
 		t.Errorf("expected opt-out to suppress 2nd ping, got %d total", got)
 	}
-	stampMtimeAfter := client.heartbeat.readStampMtime()
+	stampMtimeAfter := getSharedHeartbeat().readStampMtime()
 	if !stampMtimeAfter.Equal(stampMtimeBefore) {
 		t.Errorf("expected stamp mtime unchanged after opt-out call, before=%v after=%v", stampMtimeBefore, stampMtimeAfter)
 	}
@@ -256,8 +258,14 @@ func TestHeartbeat_ConcurrentCallers_CoalesceToOnePing(t *testing.T) {
 // regression for that runtime.
 func TestHeartbeat_NoCacheDir_PingsButNoStamp(t *testing.T) {
 	_, called := startCheckpointMock(t, http.StatusOK)
-	client := newHeartbeatClient(t, t.TempDir())
-	client.heartbeat.stampPath = "" // simulate UserCacheDir() failure
+	// Override the singleton with an empty stamp path to simulate a runtime
+	// where os.UserCacheDir() returned an error (Lambda-like). newHeartbeatClient
+	// installs a tmp-dir state which we immediately swap; we capture the tmp
+	// state and restore on cleanup.
+	tmpClient := newHeartbeatClient(t, t.TempDir())
+	previous := replaceHeartbeatStateForTest("")
+	t.Cleanup(func() { restoreHeartbeatStateForTest(previous) })
+	client := tmpClient // suppress unused-variable; we still need the *AxonFlowClient
 
 	// First call fires.
 	client.maybeSendHeartbeat()
@@ -273,12 +281,55 @@ func TestHeartbeat_NoCacheDir_PingsButNoStamp(t *testing.T) {
 
 	// Backdate cache, call again — fires again because no stamp exists to
 	// gate the 7-day path.
-	client.heartbeat.mu.Lock()
-	client.heartbeat.lastChecked = time.Now().Add(-2 * time.Hour)
-	client.heartbeat.mu.Unlock()
+	getSharedHeartbeat().mu.Lock()
+	getSharedHeartbeat().lastChecked = time.Now().Add(-2 * time.Hour)
+	getSharedHeartbeat().mu.Unlock()
 	client.maybeSendHeartbeat()
 	if got := called.Load(); got != 2 {
 		t.Errorf("expected 2nd ping when stamp absent and cache expired, got %d", got)
+	}
+}
+
+// Case 7b (regression for P1: per-client → per-process singleton): 50
+// AxonFlow clients constructed concurrently before any stamp exists must
+// coalesce onto exactly 1 ping (per the "at most one heartbeat per
+// environment" contract). Pre-fix this test would observe up to 50
+// pings because each client carried its own heartbeatState.
+func TestHeartbeat_ConcurrentMultiClient_CoalesceToOnePing(t *testing.T) {
+	_, called := startCheckpointMock(t, http.StatusOK)
+	dir := t.TempDir()
+	// Install a single shared heartbeat state pointing at the temp stamp.
+	// All clients constructed below will use this singleton — that's the
+	// invariant the P1 fix enforces.
+	stampPath := filepath.Join(dir, "go-telemetry-last-sent")
+	previous := replaceHeartbeatStateForTest(stampPath)
+	t.Cleanup(func() { restoreHeartbeatStateForTest(previous) })
+
+	const clientCount = 50
+	var wg sync.WaitGroup
+	wg.Add(clientCount)
+	start := make(chan struct{})
+	boolPtr := func(v bool) *bool { return &v }
+	for i := 0; i < clientCount; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			c := &AxonFlowClient{
+				config: AxonFlowConfig{
+					Mode:             "production",
+					ClientID:         "id",
+					ClientSecret:     "sec",
+					TelemetryEnabled: boolPtr(true),
+				},
+			}
+			c.maybeSendHeartbeat()
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := called.Load(); got != 1 {
+		t.Errorf("expected exactly 1 ping for %d concurrent clients sharing the heartbeat singleton, got %d", clientCount, got)
 	}
 }
 
@@ -295,14 +346,14 @@ func TestHeartbeat_PingFailure_StampNotWritten(t *testing.T) {
 		t.Fatalf("expected 1 attempt, got %d", got)
 	}
 	// Stamp must NOT be written on 5xx.
-	if _, err := os.Stat(client.heartbeat.stampPath); err == nil {
-		t.Errorf("expected NO stamp file after failed ping, but found one at %s", client.heartbeat.stampPath)
+	if _, err := os.Stat(getSharedHeartbeat().stampPath); err == nil {
+		t.Errorf("expected NO stamp file after failed ping, but found one at %s", getSharedHeartbeat().stampPath)
 	}
 
 	// Backdate the in-memory rate limit so the next call passes.
-	client.heartbeat.mu.Lock()
-	client.heartbeat.lastChecked = time.Now().Add(-2 * time.Hour)
-	client.heartbeat.mu.Unlock()
+	getSharedHeartbeat().mu.Lock()
+	getSharedHeartbeat().lastChecked = time.Now().Add(-2 * time.Hour)
+	getSharedHeartbeat().mu.Unlock()
 
 	// Swap mock to success and call again — should retry and now succeed.
 	successHits := atomic.Int32{}
@@ -318,7 +369,7 @@ func TestHeartbeat_PingFailure_StampNotWritten(t *testing.T) {
 	if got := successHits.Load(); got != 1 {
 		t.Errorf("expected retry to land 1 successful ping, got %d", got)
 	}
-	if _, err := os.Stat(client.heartbeat.stampPath); err != nil {
+	if _, err := os.Stat(getSharedHeartbeat().stampPath); err != nil {
 		t.Errorf("expected stamp file after successful retry, got error: %v", err)
 	}
 }

--- a/heartbeat_test.go
+++ b/heartbeat_test.go
@@ -1,0 +1,324 @@
+package axonflow
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Helpers shared across heartbeat tests --------------------------------------
+
+// newHeartbeatClient builds a minimal *AxonFlowClient suitable for exercising
+// maybeSendHeartbeat in isolation. The caller supplies a stamp directory
+// (typically t.TempDir()) so the test doesn't touch the user's real cache
+// dir. Telemetry is forced ON via TelemetryEnabled=true so the gating
+// decision under test is the heartbeat gate, not the mode-default check.
+func newHeartbeatClient(t *testing.T, stampDir string) *AxonFlowClient {
+	t.Helper()
+	boolPtr := func(v bool) *bool { return &v }
+	return &AxonFlowClient{
+		config: AxonFlowConfig{
+			Mode:             "production",
+			ClientID:         "id",
+			ClientSecret:     "sec",
+			TelemetryEnabled: boolPtr(true),
+		},
+		heartbeat: &heartbeatState{
+			stampPath: filepath.Join(stampDir, "go-telemetry-last-sent"),
+		},
+	}
+}
+
+// startCheckpointMock spins up an httptest server that counts pings and
+// optionally returns a configured status code. Returns the server's URL
+// and a *atomic.Int32 the caller reads after the gate runs.
+func startCheckpointMock(t *testing.T, statusCode int) (string, *atomic.Int32) {
+	t.Helper()
+	var called atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Add(1)
+		if statusCode == 0 {
+			statusCode = http.StatusOK
+		}
+		w.WriteHeader(statusCode)
+		if statusCode >= 200 && statusCode < 300 {
+			json.NewEncoder(w).Encode(telemetryResponse{LatestVersion: Version})
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("AXONFLOW_CHECKPOINT_URL", srv.URL)
+	t.Setenv("AXONFLOW_TELEMETRY", "")
+	return srv.URL, &called
+}
+
+// withFastIntervals replaces the package heartbeat constants with values
+// that make the assertions deterministic in test time, restoring originals
+// on cleanup. Using time.Hour-scale defaults in tests would make case-4
+// (1-hour cache holds within a process) impossible to verify in a
+// reasonable test runtime.
+func withFastIntervals(t *testing.T, heartbeat, guard time.Duration) {
+	t.Helper()
+	origH, origG := heartbeatInterval, heartbeatGuardInterval
+	heartbeatInterval = heartbeat
+	heartbeatGuardInterval = guard
+	t.Cleanup(func() {
+		heartbeatInterval = origH
+		heartbeatGuardInterval = origG
+	})
+}
+
+// 9-case matrix --------------------------------------------------------------
+
+// Case 1: cold start with no stamp → exactly 1 ping fires, stamp written.
+func TestHeartbeat_NoStamp_FiresOnce(t *testing.T) {
+	_, called := startCheckpointMock(t, http.StatusOK)
+	dir := t.TempDir()
+	client := newHeartbeatClient(t, dir)
+
+	client.maybeSendHeartbeat()
+
+	if got := called.Load(); got != 1 {
+		t.Errorf("expected 1 ping on cold start, got %d", got)
+	}
+	if _, err := os.Stat(client.heartbeat.stampPath); err != nil {
+		t.Errorf("expected stamp file at %s after successful ping, got error: %v", client.heartbeat.stampPath, err)
+	}
+}
+
+// Case 2: stamp written 1 day ago (well within heartbeatInterval) → 0 pings.
+func TestHeartbeat_FreshStamp_DoesNotFire(t *testing.T) {
+	_, called := startCheckpointMock(t, http.StatusOK)
+	dir := t.TempDir()
+	client := newHeartbeatClient(t, dir)
+
+	// Pre-create the stamp file with a recent mtime.
+	if err := client.heartbeat.writeStampAtomic(time.Now().Add(-24 * time.Hour)); err != nil {
+		t.Fatalf("seed stamp: %v", err)
+	}
+	// writeStampAtomic uses now() for the mtime regardless of the parameter
+	// value (the parameter is for the human-readable contents). Force the
+	// mtime to 1 day ago so the freshness check is deterministic.
+	oneDayAgo := time.Now().Add(-24 * time.Hour)
+	if err := os.Chtimes(client.heartbeat.stampPath, oneDayAgo, oneDayAgo); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	client.maybeSendHeartbeat()
+
+	if got := called.Load(); got != 0 {
+		t.Errorf("expected 0 pings with fresh stamp, got %d", got)
+	}
+}
+
+// Case 3: stamp written 8 days ago (past heartbeatInterval) → 1 ping fires,
+// stamp updated to now.
+func TestHeartbeat_StaleStamp_FiresAndUpdates(t *testing.T) {
+	_, called := startCheckpointMock(t, http.StatusOK)
+	dir := t.TempDir()
+	client := newHeartbeatClient(t, dir)
+
+	if err := client.heartbeat.writeStampAtomic(time.Now()); err != nil {
+		t.Fatalf("seed stamp: %v", err)
+	}
+	eightDaysAgo := time.Now().Add(-8 * 24 * time.Hour)
+	if err := os.Chtimes(client.heartbeat.stampPath, eightDaysAgo, eightDaysAgo); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	client.maybeSendHeartbeat()
+
+	if got := called.Load(); got != 1 {
+		t.Errorf("expected 1 ping with stale stamp, got %d", got)
+	}
+	mtime := client.heartbeat.readStampMtime()
+	if time.Since(mtime) > 5*time.Second {
+		t.Errorf("expected stamp mtime to be very recent, got %v ago", time.Since(mtime))
+	}
+}
+
+// Case 4: NewClient + 5 immediate API calls within the 1-hour cache window
+// → exactly 1 ping (the first call hits the gate and records lastChecked;
+// subsequent calls fast-path through the in-memory cache).
+func TestHeartbeat_RateLimitWithin1Hour_FiresOnce(t *testing.T) {
+	_, called := startCheckpointMock(t, http.StatusOK)
+	dir := t.TempDir()
+	client := newHeartbeatClient(t, dir)
+
+	for i := 0; i < 5; i++ {
+		client.maybeSendHeartbeat()
+	}
+
+	if got := called.Load(); got != 1 {
+		t.Errorf("expected 1 ping for 5 calls inside 1h cache window, got %d", got)
+	}
+}
+
+// Case 5: rate-limit cache expires (lastChecked backdated 2h) + stale stamp
+// (8d ago) → second ping fires, stamp updated.
+func TestHeartbeat_AfterRateLimitExpiry_FiresAgain(t *testing.T) {
+	_, called := startCheckpointMock(t, http.StatusOK)
+	dir := t.TempDir()
+	client := newHeartbeatClient(t, dir)
+
+	// First call: ping fires, stamp written.
+	client.maybeSendHeartbeat()
+	if got := called.Load(); got != 1 {
+		t.Fatalf("setup: expected 1st ping, got %d", got)
+	}
+
+	// Backdate both lastChecked (memory) and stamp (file) so the gate lets
+	// the next call through.
+	client.heartbeat.mu.Lock()
+	client.heartbeat.lastChecked = time.Now().Add(-2 * time.Hour)
+	client.heartbeat.mu.Unlock()
+	eightDaysAgo := time.Now().Add(-8 * 24 * time.Hour)
+	if err := os.Chtimes(client.heartbeat.stampPath, eightDaysAgo, eightDaysAgo); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	client.maybeSendHeartbeat()
+
+	if got := called.Load(); got != 2 {
+		t.Errorf("expected 2 pings after cache + stamp expiry, got %d", got)
+	}
+}
+
+// Case 6: AXONFLOW_TELEMETRY=off mid-process → 0 pings, stamp NOT written.
+// Re-evaluated on every call so the toggle works without a new process.
+func TestHeartbeat_OptOutMidProcess_StopsPings(t *testing.T) {
+	_, called := startCheckpointMock(t, http.StatusOK)
+	dir := t.TempDir()
+	client := newHeartbeatClient(t, dir)
+
+	// First call without opt-out: fires.
+	client.maybeSendHeartbeat()
+	if got := called.Load(); got != 1 {
+		t.Fatalf("setup: expected 1st ping, got %d", got)
+	}
+
+	// Toggle opt-out, force the cache + stamp gates to be open, call again.
+	t.Setenv("AXONFLOW_TELEMETRY", "off")
+	client.heartbeat.mu.Lock()
+	client.heartbeat.lastChecked = time.Now().Add(-2 * time.Hour)
+	client.heartbeat.mu.Unlock()
+	eightDaysAgo := time.Now().Add(-8 * 24 * time.Hour)
+	_ = os.Chtimes(client.heartbeat.stampPath, eightDaysAgo, eightDaysAgo)
+	// Snapshot stamp mtime AFTER the chtimes manipulation so the assertion
+	// only catches changes the SDK code itself makes.
+	stampMtimeBefore := client.heartbeat.readStampMtime()
+
+	client.maybeSendHeartbeat()
+
+	if got := called.Load(); got != 1 {
+		t.Errorf("expected opt-out to suppress 2nd ping, got %d total", got)
+	}
+	stampMtimeAfter := client.heartbeat.readStampMtime()
+	if !stampMtimeAfter.Equal(stampMtimeBefore) {
+		t.Errorf("expected stamp mtime unchanged after opt-out call, before=%v after=%v", stampMtimeBefore, stampMtimeAfter)
+	}
+}
+
+// Case 7: 100 concurrent goroutines all crossing the boundary at once →
+// exactly 1 ping (in-flight gate coalesces stampede).
+func TestHeartbeat_ConcurrentCallers_CoalesceToOnePing(t *testing.T) {
+	_, called := startCheckpointMock(t, http.StatusOK)
+	dir := t.TempDir()
+	client := newHeartbeatClient(t, dir)
+
+	const goroutines = 100
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			client.maybeSendHeartbeat()
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := called.Load(); got != 1 {
+		t.Errorf("expected exactly 1 ping under 100-goroutine stampede, got %d", got)
+	}
+}
+
+// Case 8: no writable cache dir (stampPath="") → ping fires per call,
+// but no crash and no stamp persistence. Mirrors AWS Lambda where HOME is
+// unset. Net effect is the same as today's pre-heartbeat behavior — no
+// regression for that runtime.
+func TestHeartbeat_NoCacheDir_PingsButNoStamp(t *testing.T) {
+	_, called := startCheckpointMock(t, http.StatusOK)
+	client := newHeartbeatClient(t, t.TempDir())
+	client.heartbeat.stampPath = "" // simulate UserCacheDir() failure
+
+	// First call fires.
+	client.maybeSendHeartbeat()
+	if got := called.Load(); got != 1 {
+		t.Fatalf("expected 1st ping, got %d", got)
+	}
+
+	// 1h cache holds inside the same process even without a stamp file.
+	client.maybeSendHeartbeat()
+	if got := called.Load(); got != 1 {
+		t.Errorf("expected in-memory cache to suppress 2nd call, got %d", got)
+	}
+
+	// Backdate cache, call again — fires again because no stamp exists to
+	// gate the 7-day path.
+	client.heartbeat.mu.Lock()
+	client.heartbeat.lastChecked = time.Now().Add(-2 * time.Hour)
+	client.heartbeat.mu.Unlock()
+	client.maybeSendHeartbeat()
+	if got := called.Load(); got != 2 {
+		t.Errorf("expected 2nd ping when stamp absent and cache expired, got %d", got)
+	}
+}
+
+// Case 9: ping returns network failure (5xx) → stamp NOT written, next
+// call after cache expiry retries. Stamp-on-DELIVERY semantics.
+func TestHeartbeat_PingFailure_StampNotWritten(t *testing.T) {
+	// First server returns 503 (failure); we'll swap to 200 for the retry.
+	_, called := startCheckpointMock(t, http.StatusServiceUnavailable)
+	dir := t.TempDir()
+	client := newHeartbeatClient(t, dir)
+
+	client.maybeSendHeartbeat()
+	if got := called.Load(); got != 1 {
+		t.Fatalf("expected 1 attempt, got %d", got)
+	}
+	// Stamp must NOT be written on 5xx.
+	if _, err := os.Stat(client.heartbeat.stampPath); err == nil {
+		t.Errorf("expected NO stamp file after failed ping, but found one at %s", client.heartbeat.stampPath)
+	}
+
+	// Backdate the in-memory rate limit so the next call passes.
+	client.heartbeat.mu.Lock()
+	client.heartbeat.lastChecked = time.Now().Add(-2 * time.Hour)
+	client.heartbeat.mu.Unlock()
+
+	// Swap mock to success and call again — should retry and now succeed.
+	successHits := atomic.Int32{}
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		successHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(telemetryResponse{LatestVersion: Version})
+	}))
+	defer srv2.Close()
+	t.Setenv("AXONFLOW_CHECKPOINT_URL", srv2.URL)
+
+	client.maybeSendHeartbeat()
+	if got := successHits.Load(); got != 1 {
+		t.Errorf("expected retry to land 1 successful ping, got %d", got)
+	}
+	if _, err := os.Stat(client.heartbeat.stampPath); err != nil {
+		t.Errorf("expected stamp file after successful retry, got error: %v", err)
+	}
+}

--- a/masfeat.go
+++ b/masfeat.go
@@ -386,7 +386,7 @@ func (c *AxonFlowClient) MASFEATRegisterSystem(req *RegisterSystemRequest) (*AIS
 	httpReq.Header.Set("Content-Type", "application/json")
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("register system request failed: %w", err)
 	}
@@ -423,7 +423,7 @@ func (c *AxonFlowClient) MASFEATGetSystem(systemID string) (*AISystemRegistry, e
 	}
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("get system request failed: %w", err)
 	}
@@ -463,7 +463,7 @@ func (c *AxonFlowClient) MASFEATUpdateSystem(systemID string, req *UpdateSystemR
 	httpReq.Header.Set("Content-Type", "application/json")
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("update system request failed: %w", err)
 	}
@@ -517,7 +517,7 @@ func (c *AxonFlowClient) MASFEATListSystems(opts *ListSystemsOptions) ([]AISyste
 	}
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("list systems request failed: %w", err)
 	}
@@ -559,7 +559,7 @@ func (c *AxonFlowClient) MASFEATActivateSystem(systemID string) (*AISystemRegist
 	httpReq.Header.Set("Content-Type", "application/json")
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("activate system request failed: %w", err)
 	}
@@ -595,7 +595,7 @@ func (c *AxonFlowClient) MASFEATRetireSystem(systemID string) (*AISystemRegistry
 		return nil, fmt.Errorf("failed to create retire system request: %w", err)
 	}
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("retire system request failed: %w", err)
 	}
@@ -628,7 +628,7 @@ func (c *AxonFlowClient) MASFEATGetRegistrySummary() (*RegistrySummary, error) {
 	}
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("get registry summary request failed: %w", err)
 	}
@@ -672,7 +672,7 @@ func (c *AxonFlowClient) MASFEATCreateAssessment(req *CreateAssessmentRequest) (
 	httpReq.Header.Set("Content-Type", "application/json")
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("create assessment request failed: %w", err)
 	}
@@ -709,7 +709,7 @@ func (c *AxonFlowClient) MASFEATGetAssessment(assessmentID string) (*FEATAssessm
 	}
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("get assessment request failed: %w", err)
 	}
@@ -749,7 +749,7 @@ func (c *AxonFlowClient) MASFEATUpdateAssessment(assessmentID string, req *Updat
 	httpReq.Header.Set("Content-Type", "application/json")
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("update assessment request failed: %w", err)
 	}
@@ -800,7 +800,7 @@ func (c *AxonFlowClient) MASFEATListAssessments(opts *ListAssessmentsOptions) ([
 	}
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("list assessments request failed: %w", err)
 	}
@@ -835,7 +835,7 @@ func (c *AxonFlowClient) MASFEATSubmitAssessment(assessmentID string) (*FEATAsse
 	httpReq.Header.Set("Content-Type", "application/json")
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("submit assessment request failed: %w", err)
 	}
@@ -879,7 +879,7 @@ func (c *AxonFlowClient) MASFEATApproveAssessment(assessmentID string, req *Appr
 	httpReq.Header.Set("Content-Type", "application/json")
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("approve assessment request failed: %w", err)
 	}
@@ -923,7 +923,7 @@ func (c *AxonFlowClient) MASFEATRejectAssessment(assessmentID string, req *Rejec
 	httpReq.Header.Set("Content-Type", "application/json")
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("reject assessment request failed: %w", err)
 	}
@@ -960,7 +960,7 @@ func (c *AxonFlowClient) MASFEATGetKillSwitch(systemID string) (*KillSwitch, err
 	}
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("get kill switch request failed: %w", err)
 	}
@@ -1000,7 +1000,7 @@ func (c *AxonFlowClient) MASFEATConfigureKillSwitch(systemID string, req *Config
 	httpReq.Header.Set("Content-Type", "application/json")
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("configure kill switch request failed: %w", err)
 	}
@@ -1044,7 +1044,7 @@ func (c *AxonFlowClient) MASFEATCheckKillSwitch(systemID string, req *CheckKillS
 	httpReq.Header.Set("Content-Type", "application/json")
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("check kill switch request failed: %w", err)
 	}
@@ -1088,7 +1088,7 @@ func (c *AxonFlowClient) MASFEATTriggerKillSwitch(systemID string, req *TriggerK
 	httpReq.Header.Set("Content-Type", "application/json")
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("trigger kill switch request failed: %w", err)
 	}
@@ -1143,7 +1143,7 @@ func (c *AxonFlowClient) MASFEATRestoreKillSwitch(systemID string, req *RestoreK
 	httpReq.Header.Set("Content-Type", "application/json")
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("restore kill switch request failed: %w", err)
 	}
@@ -1193,7 +1193,7 @@ func (c *AxonFlowClient) MASFEATEnableKillSwitch(systemID string) (*KillSwitch, 
 	httpReq.Header.Set("Content-Type", "application/json")
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("enable kill switch request failed: %w", err)
 	}
@@ -1231,7 +1231,7 @@ func (c *AxonFlowClient) MASFEATDisableKillSwitch(systemID string, reason string
 	httpReq.Header.Set("Content-Type", "application/json")
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("disable kill switch request failed: %w", err)
 	}
@@ -1267,7 +1267,7 @@ func (c *AxonFlowClient) MASFEATGetKillSwitchHistory(systemID string, limit int)
 	}
 	c.addAuthHeaders(httpReq)
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("get kill switch history request failed: %w", err)
 	}

--- a/policies.go
+++ b/policies.go
@@ -404,7 +404,7 @@ func (c *AxonFlowClient) orchestratorPolicyRequest(method, path string, body int
 		log.Printf("[AxonFlow] Policy request: %s %s", method, path)
 	}
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doHttpRequest(c.httpClient, req)
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
@@ -463,7 +463,7 @@ func (c *AxonFlowClient) policyRequest(method, path string, body interface{}, re
 		log.Printf("[AxonFlow] Policy request: %s %s", method, path)
 	}
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doHttpRequest(c.httpClient, req)
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
@@ -511,7 +511,7 @@ func (c *AxonFlowClient) policyRequestRaw(method, path string) ([]byte, error) {
 		log.Printf("[AxonFlow] Raw policy request: %s %s", method, path)
 	}
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doHttpRequest(c.httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}

--- a/telemetry.go
+++ b/telemetry.go
@@ -174,24 +174,36 @@ func (c *AxonFlowClient) isTelemetryEnabled() bool {
 	return c.config.Mode != "sandbox"
 }
 
-// sendTelemetryPing sends a synchronous telemetry ping to the checkpoint
-// service under a single shared context deadline covering both the /health
-// probe and the checkpoint POST. Never returns an error — all failures are
-// silently ignored. In debug mode, a version-outdated warning may be logged.
-//
-// Previously invoked as a goroutine (`go client.sendTelemetryPing()`), but
-// short-lived processes (CLI, serverless, quickstart scripts) returned from
-// main() before the goroutine's POST could complete, silently dropping the
-// ping. The function is now called synchronously from NewClient.
-//
-// Worst-case blocking time: telemetryTimeout (3s). Both detectPlatformVersion
-// and the checkpoint POST share the same context, so the individual
-// timeouts no longer stack. See issue #1693.
+// sendTelemetryPing is a thin compatibility wrapper around the gated path
+// used exclusively by older unit tests in this package. It checks
+// isTelemetryEnabled and, if enabled, sends a single ping via
+// sendTelemetryPingNow under a bounded context. It does NOT consult the
+// 7-day stamp file — that's the heartbeat orchestrator's job
+// (maybeSendHeartbeat). Production callers should always go through
+// NewClient → maybeSendHeartbeat instead of calling this directly.
 func (c *AxonFlowClient) sendTelemetryPing() {
 	if !c.isTelemetryEnabled() {
 		return
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), telemetryTimeout)
+	defer cancel()
+	_ = c.sendTelemetryPingNow(ctx)
+}
 
+// sendTelemetryPingNow sends a single telemetry ping to the checkpoint
+// service under the caller-provided context deadline. Returns nil if the
+// POST landed (HTTP 2xx) or a non-nil error otherwise. The caller is
+// responsible for the gating decision (whether to send at all) — this
+// function does NOT consult AXONFLOW_TELEMETRY, isTelemetryEnabled, the
+// stamp file, or any rate-limit state. That separation lets the heartbeat
+// orchestrator (maybeSendHeartbeat) make the gating decision once and
+// only update the stamp when this returns nil — implementing the
+// "stamp-on-delivery" contract.
+//
+// The /health probe and the checkpoint POST share the caller's context so
+// the total blocking time is bounded by ctx — no stacked sub-timeouts.
+// See issue #1693 for the original short-lived-process delivery fix.
+func (c *AxonFlowClient) sendTelemetryPingNow(ctx context.Context) error {
 	log.Printf("[AxonFlow] Anonymous telemetry enabled. Opt out: AXONFLOW_TELEMETRY=off | https://docs.getaxonflow.com/docs/telemetry")
 
 	// Determine the checkpoint URL.
@@ -205,14 +217,6 @@ func (c *AxonFlowClient) sendTelemetryPing() {
 	if deploymentMode == "" {
 		deploymentMode = "production"
 	}
-
-	// Single shared deadline covering the ENTIRE telemetry path (health
-	// probe + checkpoint POST). Without this, the /health GET and the
-	// checkpoint POST each had their own timeout (2s + 3s), stacking into
-	// ~5s of potential blocking on NewClient when endpoints are
-	// unreachable — defeating the "bounded at telemetryTimeout" guarantee.
-	ctx, cancel := context.WithTimeout(context.Background(), telemetryTimeout)
-	defer cancel()
 
 	// Detect platform version from health endpoint (uses the shared deadline).
 	platformVersion := detectPlatformVersion(ctx, c.config.Endpoint)
@@ -232,33 +236,35 @@ func (c *AxonFlowClient) sendTelemetryPing() {
 
 	body, err := json.Marshal(payload)
 	if err != nil {
-		return
+		return err
 	}
 
 	// POST uses whatever budget remains after the health probe.
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, checkpointURL, bytes.NewReader(body))
 	if err != nil {
-		return
+		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{
-		Timeout: telemetryTimeout,
-	}
-
+	client := &http.Client{Timeout: telemetryTimeout}
 	resp, err := client.Do(req)
 	if err != nil {
-		return
+		return err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("checkpoint returned HTTP %d", resp.StatusCode)
+	}
 
 	// Parse response for version check (debug mode only).
 	if c.config.Debug {
 		var telResp telemetryResponse
-		if err := json.NewDecoder(resp.Body).Decode(&telResp); err == nil {
+		if decErr := json.NewDecoder(resp.Body).Decode(&telResp); decErr == nil {
 			if telResp.LatestVersion != "" && telResp.LatestVersion != Version {
 				log.Printf("[AxonFlow] A newer SDK version is available: %s (current: %s)", telResp.LatestVersion, Version)
 			}
 		}
 	}
+	return nil
 }

--- a/telemetry_short_lived_test.go
+++ b/telemetry_short_lived_test.go
@@ -84,10 +84,18 @@ func TestTelemetryDeliveryOnShortLivedProcess(t *testing.T) {
 	// Run the binary, no wait, no sleep. Point telemetry at the mock server.
 	// Inherit parent env so the test works on any CI runner / shell, but
 	// scrub the two opt-out vars that might otherwise disable telemetry
-	// (e.g. a developer shell with DO_NOT_TRACK=1 exported globally).
+	// (e.g. a developer shell with DO_NOT_TRACK=1 exported globally) and
+	// pin HOME to a fresh temp dir so the heartbeat stamp file doesn't
+	// inherit any previous run's mtime — the stamp lives under
+	// `os.UserCacheDir() / axonflow /` and a stale stamp from a prior
+	// invocation would silence this run's ping (regression-test for the
+	// 7-day delivered-heartbeat contract).
+	telemetryHome := t.TempDir()
 	runCmd := exec.Command(binPath)
 	runCmd.Env = append(filterOptOutEnv(os.Environ()),
 		"AXONFLOW_CHECKPOINT_URL="+server.URL+"/v1/ping",
+		"HOME="+telemetryHome,
+		"XDG_CACHE_HOME="+filepath.Join(telemetryHome, ".cache"),
 	)
 	if out, err := runCmd.CombinedOutput(); err != nil {
 		t.Fatalf("binary run failed: %v\n%s", err, out)

--- a/tests/heartbeat-real-stack/go.mod
+++ b/tests/heartbeat-real-stack/go.mod
@@ -1,0 +1,7 @@
+module heartbeat-real-stack-smoke
+
+go 1.22
+
+require github.com/getaxonflow/axonflow-sdk-go/v6 v6.0.0
+
+replace github.com/getaxonflow/axonflow-sdk-go/v6 => ../..

--- a/tests/heartbeat-real-stack/go.sum
+++ b/tests/heartbeat-real-stack/go.sum
@@ -1,0 +1,2 @@
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tests/heartbeat-real-stack/run_real_stack.py
+++ b/tests/heartbeat-real-stack/run_real_stack.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Cross-platform driver for the heartbeat real-stack E2E.
+
+Stands up the fake checkpoint server (server.py), runs an SDK smoke
+twice, and verifies:
+
+  Cold (first run):  exactly 1 checkpoint hit, stamp file present
+  Warm (second run): 0 additional checkpoint hits, stamp unchanged
+
+Usage:
+    python run_real_stack.py <smoke_command...>
+
+The smoke command is invoked twice with these environment variables set:
+    AXONFLOW_AGENT_URL
+    AXONFLOW_CHECKPOINT_URL
+    AXONFLOW_TELEMETRY=""        (defensive; CI workflows often default to off)
+    HOME, USERPROFILE, LOCALAPPDATA, XDG_CACHE_HOME — all rerouted to a
+                                  temp dir so the smoke can verify a clean
+                                  cache state without touching the runner's
+                                  real cache.
+
+Exits 0 on success, non-zero on any failure.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+
+
+def fetch_counter(url: str) -> dict:
+    with urllib.request.urlopen(url + "/__counter", timeout=5) as r:
+        return json.loads(r.read())
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("Usage: run_real_stack.py <smoke_command...>", file=sys.stderr)
+        return 2
+
+    smoke_cmd = list(argv[1:])
+    # Java quirk: the JVM resolves user.home from native APIs at startup
+    # and ignores $HOME on macOS / Windows. Detect and rewrite.
+    java_target = any("java" == os.path.basename(p).lower().replace(".exe", "") for p in [smoke_cmd[0]])
+    here = Path(__file__).resolve().parent
+    server_script = here / "server.py"
+
+    work_root = Path(tempfile.mkdtemp(prefix="hb-real-stack-"))
+    port_file = work_root / "port.txt"
+
+    env = os.environ.copy()
+    env["HEARTBEAT_E2E_PORT_FILE"] = str(port_file)
+
+    # Launch fake server.
+    server_proc = subprocess.Popen(
+        [sys.executable, str(server_script)],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    try:
+        # Wait for port file to appear.
+        deadline = time.time() + 15
+        while time.time() < deadline:
+            if port_file.exists():
+                port_text = port_file.read_text().strip()
+                if port_text:
+                    break
+            time.sleep(0.1)
+        else:
+            print("FAIL: server didn't write port file in 15s", file=sys.stderr)
+            return 1
+
+        port = int(port_text)
+        server_url = f"http://127.0.0.1:{port}"
+        print(f"server: {server_url}")
+
+        # Sanity check.
+        before = fetch_counter(server_url)
+        assert before == {"checkpoint_hits": 0, "health_hits": 0}, before
+
+        # Build a clean HOME / cache redirect.
+        clean_home = work_root / "home"
+        clean_home.mkdir()
+
+        smoke_env = os.environ.copy()
+        smoke_env.update({
+            "AXONFLOW_AGENT_URL": server_url,
+            "AXONFLOW_CHECKPOINT_URL": f"{server_url}/v1/ping",
+            "AXONFLOW_TELEMETRY": "",
+            # Reroute cache dir on every OS:
+            "HOME": str(clean_home),                         # macOS, Linux
+            "USERPROFILE": str(clean_home),                  # Windows
+            "LOCALAPPDATA": str(clean_home / "AppData" / "Local"),  # Windows
+            "XDG_CACHE_HOME": str(clean_home / ".cache"),    # Linux
+        })
+        # Ensure those nested dirs exist for Windows.
+        Path(smoke_env["LOCALAPPDATA"]).mkdir(parents=True, exist_ok=True)
+        Path(smoke_env["XDG_CACHE_HOME"]).mkdir(parents=True, exist_ok=True)
+
+        # Java JVM ignores $HOME for user.home on macOS / Windows; pass
+        # -Duser.home=<clean_home> as the first JVM arg.
+        if java_target:
+            smoke_cmd[1:1] = [f"-Duser.home={clean_home}"]
+
+        # ---- Cold run ----
+        print("--- cold run ---")
+        cold = subprocess.run(smoke_cmd, env=smoke_env, capture_output=True, text=True)
+        sys.stdout.write(cold.stdout)
+        sys.stderr.write(cold.stderr)
+        if cold.returncode != 0:
+            print(f"FAIL: cold smoke exited {cold.returncode}", file=sys.stderr)
+            return 1
+
+        cold_counter = fetch_counter(server_url)
+        print(f"counter after cold: {cold_counter}")
+        if cold_counter["checkpoint_hits"] != 1:
+            print(
+                f"FAIL: expected 1 checkpoint hit on cold, got {cold_counter['checkpoint_hits']}",
+                file=sys.stderr,
+            )
+            return 1
+
+        # ---- Warm run (same clean_home, stamp now exists) ----
+        print("--- warm run ---")
+        warm = subprocess.run(smoke_cmd, env=smoke_env, capture_output=True, text=True)
+        sys.stdout.write(warm.stdout)
+        sys.stderr.write(warm.stderr)
+        if warm.returncode != 0:
+            print(f"FAIL: warm smoke exited {warm.returncode}", file=sys.stderr)
+            return 1
+
+        warm_counter = fetch_counter(server_url)
+        print(f"counter after warm: {warm_counter}")
+        delta = warm_counter["checkpoint_hits"] - cold_counter["checkpoint_hits"]
+        if delta != 0:
+            print(
+                f"FAIL: expected 0 additional pings on warm run, got {delta}",
+                file=sys.stderr,
+            )
+            return 1
+
+        print("\nOK: cold + warm pass — heartbeat real-stack contract holds")
+        return 0
+    finally:
+        server_proc.terminate()
+        try:
+            server_proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            server_proc.kill()
+        shutil.rmtree(work_root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/heartbeat-real-stack/run_real_stack.py
+++ b/tests/heartbeat-real-stack/run_real_stack.py
@@ -66,16 +66,42 @@ def main(argv: list[str]) -> int:
     )
 
     try:
-        # Wait for port file to appear.
-        deadline = time.time() + 15
+        # Wait for port file to appear. 60s is generous — macos-latest GitHub
+        # runners can be slow to cold-start Python; 15s sometimes wasn't enough.
+        # On any timeout we surface the server's stdout+stderr so the cause is
+        # visible in CI logs instead of failing silently.
+        deadline = time.time() + 60
+        port_text: str | None = None
         while time.time() < deadline:
+            if server_proc.poll() is not None:
+                # Server crashed before writing the port file.
+                stdout_bytes, _ = server_proc.communicate(timeout=2)
+                output = stdout_bytes.decode("utf-8", errors="replace") if stdout_bytes else ""
+                print(
+                    f"FAIL: server exited with code {server_proc.returncode} before writing port file.\n"
+                    f"--- server stdout/stderr ---\n{output}",
+                    file=sys.stderr,
+                )
+                return 1
             if port_file.exists():
                 port_text = port_file.read_text().strip()
                 if port_text:
                     break
             time.sleep(0.1)
-        else:
-            print("FAIL: server didn't write port file in 15s", file=sys.stderr)
+        if not port_text:
+            # Port file timeout — kill server and surface its output.
+            server_proc.terminate()
+            try:
+                stdout_bytes, _ = server_proc.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                server_proc.kill()
+                stdout_bytes, _ = server_proc.communicate()
+            output = stdout_bytes.decode("utf-8", errors="replace") if stdout_bytes else ""
+            print(
+                "FAIL: server didn't write port file in 60s.\n"
+                f"--- server stdout/stderr ---\n{output}",
+                file=sys.stderr,
+            )
             return 1
 
         port = int(port_text)

--- a/tests/heartbeat-real-stack/server.py
+++ b/tests/heartbeat-real-stack/server.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Cross-platform fake-agent + fake-checkpoint server for the heartbeat E2E.
+
+Same as /tmp/heartbeat-real-e2e/server.py but vendored alongside the
+per-SDK smokes so it can ship inside each SDK repo's tests/ directory.
+"""
+import json
+import os
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+CHECKPOINT_HITS = 0
+HEALTH_HITS = 0
+LOCK = threading.Lock()
+SDK_VERSION = "7.4.5"
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _send_json(self, status, body):
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(body).encode())
+
+    def do_GET(self):
+        global HEALTH_HITS
+        if self.path == "/health":
+            with LOCK:
+                HEALTH_HITS += 1
+            self._send_json(200, {"version": SDK_VERSION, "status": "ok"})
+        elif self.path == "/__counter":
+            with LOCK:
+                self._send_json(200, {"checkpoint_hits": CHECKPOINT_HITS, "health_hits": HEALTH_HITS})
+        else:
+            self._send_json(503, {"error": "not implemented"})
+
+    def do_POST(self):
+        global CHECKPOINT_HITS
+        length = int(self.headers.get("Content-Length", "0"))
+        if length:
+            self.rfile.read(length)
+        # Accept both /v1/ping (production path) and /v1/checkpoint (legacy local).
+        if self.path.startswith("/v1/"):
+            with LOCK:
+                CHECKPOINT_HITS += 1
+            self._send_json(200, {"latest_version": SDK_VERSION})
+        else:
+            self._send_json(503, {"error": "not implemented"})
+
+    def log_message(self, *_args):
+        pass
+
+
+def main():
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    host, port = server.server_address
+    base = f"http://{host}:{port}"
+    # Write port to a file so the launcher can read it (more reliable than
+    # parsing stdout under Windows + various shells).
+    with open(os.environ.get("HEARTBEAT_E2E_PORT_FILE", "port.txt"), "w") as f:
+        f.write(str(port))
+    print(f"SERVER_URL={base}", flush=True)
+    sys.stdout.flush()
+
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+
+    try:
+        # Run for up to 5 minutes; CI orchestrator kills us when done.
+        time.sleep(5 * 60)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/heartbeat-real-stack/smoke_go.go
+++ b/tests/heartbeat-real-stack/smoke_go.go
@@ -1,0 +1,55 @@
+// Cross-platform real-stack smoke for the Go SDK. See header in
+// smoke_python.py for the contract this implements.
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	axonflow "github.com/getaxonflow/axonflow-sdk-go/v6"
+)
+
+func main() {
+	agent := os.Getenv("AXONFLOW_AGENT_URL")
+	if agent == "" {
+		fmt.Fprintln(os.Stderr, "FAIL: AXONFLOW_AGENT_URL not set")
+		os.Exit(1)
+	}
+
+	expected := stampPath()
+
+	client := axonflow.NewClient(axonflow.AxonFlowConfig{
+		Endpoint:     agent,
+		ClientID:     "smoke-test",
+		ClientSecret: "smoke-secret",
+	})
+	_ = client.HealthCheck()
+	// Constructor's heartbeat is synchronous in Go; small grace window
+	// for the request-path async goroutine to settle.
+	time.Sleep(500 * time.Millisecond)
+
+	if _, err := os.Stat(expected); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: stamp not at %s: %v\n", expected, err)
+		os.Exit(1)
+	}
+	fmt.Printf("OK: stamp at %s\n", expected)
+}
+
+// stampPath mirrors heartbeat.go's resolveStampPath() exactly. We can't
+// call it directly because it's package-private to the SDK module.
+func stampPath() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return filepath.Join(os.Getenv("HOME"), "Library", "Caches", "axonflow", "go-telemetry-last-sent")
+	case "windows":
+		return filepath.Join(os.Getenv("LOCALAPPDATA"), "axonflow", "go-telemetry-last-sent")
+	default:
+		if xdg := os.Getenv("XDG_CACHE_HOME"); xdg != "" {
+			return filepath.Join(xdg, "axonflow", "go-telemetry-last-sent")
+		}
+		return filepath.Join(os.Getenv("HOME"), ".cache", "axonflow", "go-telemetry-last-sent")
+	}
+}


### PR DESCRIPTION
## Summary

Move SDK telemetry from "ping per NewClient" to:

> AxonFlow emits at most one anonymous heartbeat per environment every 7 days during SDK activity.

This is the Go reference implementation; mirrors followed in axonflow-sdk-python (#TBD), axonflow-sdk-typescript (#TBD), axonflow-sdk-java (#TBD), with the canonical contract codified in axonflow-enterprise (#TBD) `docs/TELEMETRY_CONTRACT.md` + ADR-039.

## Why

Today's per-NewClient ping over-counts process churn (Lambda cold starts, CLI tools) and silences long-running services after the boot ping. Neither matches the "active customer" signal we want.

## How

- New `heartbeat.go` with cross-platform stamp file (`os.UserCacheDir() / axonflow / go-telemetry-last-sent`), 1-hour in-memory cache, in-flight gate, **stamp-on-DELIVERY** semantics (failed POST does NOT advance the stamp).
- Single hook point via `doHttpRequest(client, request)` wrapper. All 57 raw `httpClient.Do` / `mapHttpClient.Do` call sites + `HealthCheck`'s `Get` migrated through it.
- `sendTelemetryPingNow(ctx) error` is the new pure-network function; `sendTelemetryPing()` is a thin compat shim for the existing test surface.

## Tests

- `heartbeat_test.go` — 9-case matrix (cold/warm/stale stamp; 1h cache; cache-expired retry; opt-out mid-process; 100-goroutine stampede; no cache dir; failed-ping no-stamp).
- `heartbeat_e2e_test.go` — 4-run cycle (cold→warm→stale→stale+503→retry).
- Existing 1000+ tests still pass (`go test -short ./...` exit 0).

## Test plan

- [x] `go test ./...` green
- [x] Live E2E 4-run cycle verified
- [ ] CI green