### PR TITLE
release: v7.0.0 (2026-04-29)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,12 @@ jobs:
             echo "### Installation"
             echo ""
             echo '```bash'
-            echo "go get github.com/getaxonflow/axonflow-sdk-go/v6@v${VERSION}"
+            echo "go get github.com/getaxonflow/axonflow-sdk-go/v7@v${VERSION}"
             echo '```'
             echo ""
             echo "### Documentation"
             echo ""
-            echo "- [pkg.go.dev](https://pkg.go.dev/github.com/getaxonflow/axonflow-sdk-go/v6@v${VERSION})"
+            echo "- [pkg.go.dev](https://pkg.go.dev/github.com/getaxonflow/axonflow-sdk-go/v7@v${VERSION})"
             echo "- [README](https://github.com/getaxonflow/axonflow-sdk-go#readme)"
             echo "- [Examples](https://github.com/getaxonflow/axonflow-sdk-go/tree/main/examples)"
             echo ""
@@ -105,4 +105,4 @@ jobs:
     - name: Trigger pkg.go.dev update
       run: |
         VERSION=${GITHUB_REF#refs/tags/}
-        curl https://proxy.golang.org/github.com/getaxonflow/axonflow-sdk-go/v6/@v/$VERSION.info
+        curl https://proxy.golang.org/github.com/getaxonflow/axonflow-sdk-go/v7/@v/$VERSION.info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,21 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.0.0] - 2026-04-29
+## [7.0.0] - 2026-04-29 — Production, quality, and security hardening — upgrade encouraged
 
-**Upgrade strongly recommended.** Over the past month we've shipped substantial production, quality, and security hardening across all AxonFlow SDKs and plugins — upgrade to the latest version for a more secure, reliable, and bug-free experience.
+**Upgrade strongly recommended.** Over the past month we've shipped substantial production, quality, and security hardening across the AxonFlow SDKs and platform — upgrade to the latest major for a more secure, reliable, and bug-free experience.
 
-Major release across the AxonFlow SDK family. Companion releases ship the same day: TypeScript v7.0.0 / Python v7.0.0 / Go v7.0.0 (with `/v7` module path migration) / Java v7.0.0.
+**Security highlights from this release cycle:**
+- **Webhook signing-key now exposed by SDK request type** (this release). The `webhookSigningKey` (HMAC-SHA256) field on `RegisterRequest` was missing from the SDK type, so callers had no way to retrieve the signing key and webhook signature verification was effectively un-implementable. The field is now wired through end-to-end. Documented in [`GHSA-mhc4-qq83-fmrr`](https://github.com/getaxonflow/axonflow-sdk-go/security/advisories/GHSA-mhc4-qq83-fmrr).
+- **`DO_NOT_TRACK` opt-out removed in favor of `AXONFLOW_TELEMETRY=off`** (this release). `DO_NOT_TRACK` was unreliable because host CLIs and runtimes commonly inject `DO_NOT_TRACK=1` regardless of user intent; an explicit AxonFlow-scoped opt-out is the only signal we honor now.
+- **Telemetry transport opt-out reliability** (last cycle, v6.x). Tests that mutate `DO_NOT_TRACK` no longer silently leak real pings from CI; the telemetry transport is mocked at the test boundary and a CI canary asserts it stays mocked.
+
+Major release across the AxonFlow SDK family. Companion releases ship the same day: TypeScript v7.0.0 / Python v7.0.0 / Go v7.0.0 (with `/v7` module path migration) / Java v7.0.0. The full set of platform-side security fixes shipped alongside this release is documented in the consolidated platform advisory [`GHSA-9h64-2846-7x7f`](https://github.com/getaxonflow/axonflow/security/advisories/GHSA-9h64-2846-7x7f).
+
+**Reliability and bug-fix highlights:**
+- **`retry_context` + `idempotency_key` for cross-step de-duplication** (last cycle, v6.x). Workflow steps that retry across pod restarts no longer record duplicate audit entries; idempotency_key flows end-to-end through MAP HITL approve/reject responses.
+- **Plane-scoped pending-approvals parity** (last cycle, v6.x). MAP plane now exposes `/api/v1/plans/approvals/pending` mirroring the WCP plane queue; the SDK gained a typed accessor with full pagination.
+- **Synchronous telemetry send for short-lived processes** (last cycle, v6.x). Short-lived CLI invocations no longer drop the ping at process exit; the synchronous send path delivers reliably and a version-alignment CI gate keeps `Version` and `go.mod` in lockstep.
 
 ### BREAKING
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.0.0] - 2026-04-29 — DO_NOT_TRACK removal + 7-day delivered heartbeat
 
+**Upgrade strongly recommended.** Over the past month we've shipped substantial production, quality, and security hardening across all AxonFlow SDKs and plugins — upgrade to the latest version for a more secure, reliable, and bug-free experience.
+
 Major release. Two headline changes: removal of `DO_NOT_TRACK` as an AxonFlow telemetry opt-out (`AXONFLOW_TELEMETRY=off` is now the canonical and only opt-out signal), and a move from "one ping per `NewClient`" to a 7-day delivered-heartbeat contract that better matches active-customer signal across both long-running services and short-lived Lambdas / CLI tools. Companion releases on the same day: TypeScript v7.0.0 / Python v7.0.0 / Java v7.0.0.
 
 ### BREAKING

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,15 @@ Major release across the AxonFlow SDK family. Companion releases ship the same d
 ### BREAKING
 
 - **Module import path is now `github.com/getaxonflow/axonflow-sdk-go/v7`** (was `/v6`). Required by Go's semantic-import versioning rule for any module at v2+. To upgrade: `go get github.com/getaxonflow/axonflow-sdk-go/v7@latest` and update every import statement from `/v6` → `/v7`. No symbol-level changes from the path migration itself.
-- **`DO_NOT_TRACK` is no longer honored as an AxonFlow telemetry opt-out.** Use `AXONFLOW_TELEMETRY=off` instead. `DO_NOT_TRACK` was deprecated because it is commonly inherited from host tools and developer environments (CLIs like Codex and Claude Code inject it unconditionally), which makes it an unreliable expression of user intent for AxonFlow telemetry.
+- **`DO_NOT_TRACK` is no longer honored as an AxonFlow telemetry opt-out.** Use `AXONFLOW_TELEMETRY=off` instead. Host tools and CLIs commonly inject `DO_NOT_TRACK=1` regardless of user intent, which makes it unreliable as a signal.
 
 ### Changed
 
-- **Telemetry now follows the 7-day delivered-heartbeat contract** instead of firing on every `NewClient` call. The SDK emits at most one anonymous heartbeat per environment every 7 days during SDK activity. A stamp file at the OS-native user cache dir (`os.UserCacheDir() / axonflow / go-telemetry-last-sent`) tracks last successful delivery; the file mtime is the source of truth across process restarts. Failed POSTs do NOT advance the stamp, so a transient network failure does not silence telemetry for 7 days. An in-memory 1-hour cache caps `stat()` syscalls on hot paths; an in-flight flag coalesces concurrent goroutines so only one ping fires under load. `AXONFLOW_TELEMETRY=off` is re-evaluated on every gate run, so a mid-process opt-out toggle takes effect without restart. Lambda / restricted environments where `os.UserCacheDir()` is unavailable fall back transparently to the previous "one ping per process" behavior — no regression for that runtime.
+- **Telemetry switched to a 7-day delivered-heartbeat.** At most one anonymous ping per environment every 7 days, with the stamp advanced only after the POST returns 2xx — a transient network failure doesn't silence telemetry until the next window. Concurrent goroutines are de-duplicated by an in-flight gate. Restricted runtimes where `os.UserCacheDir()` is unavailable (e.g. AWS Lambda) fall back transparently to the previous "one ping per process" behavior.
 
 ### Fixed
 
-- The one-line `[AxonFlow] DO_NOT_TRACK=1 is deprecated...` `log.Printf` warning is no longer emitted. Removing the warning eliminates log noise that previously appeared on every `NewClient` call when `DO_NOT_TRACK=1` was set.
+- The `DO_NOT_TRACK=1 is deprecated...` `log.Printf` warning is no longer emitted on every `NewClient` call when `DO_NOT_TRACK=1` is set.
 
 ## [6.0.0] - 2026-04-28 — ListProviders() + SDKCompatibility wire-shape fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.0.0] - 2026-04-29 — DO_NOT_TRACK removal + 7-day delivered heartbeat
+## [7.0.0] - 2026-04-29
 
 **Upgrade strongly recommended.** Over the past month we've shipped substantial production, quality, and security hardening across all AxonFlow SDKs and plugins — upgrade to the latest version for a more secure, reliable, and bug-free experience.
 
-Major release. Two headline changes: removal of `DO_NOT_TRACK` as an AxonFlow telemetry opt-out (`AXONFLOW_TELEMETRY=off` is now the canonical and only opt-out signal), and a move from "one ping per `NewClient`" to a 7-day delivered-heartbeat contract that better matches active-customer signal across both long-running services and short-lived Lambdas / CLI tools. Companion releases on the same day: TypeScript v7.0.0 / Python v7.0.0 / Java v7.0.0.
+Major release across the AxonFlow SDK family. Companion releases ship the same day: TypeScript v7.0.0 / Python v7.0.0 / Go v7.0.0 (with `/v7` module path migration) / Java v7.0.0.
 
 ### BREAKING
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,18 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [7.0.0] - 2026-04-29 — DO_NOT_TRACK removal
 
-### Removed
+Major release. The single breaking change is the removal of `DO_NOT_TRACK` as an AxonFlow telemetry opt-out — `AXONFLOW_TELEMETRY=off` is now the canonical and only opt-out signal. Companion releases on the same day: TypeScript v7.0.0 / Python v7.0.0 / Java v7.0.0.
 
-- **BREAKING:** `DO_NOT_TRACK` is no longer honored as an AxonFlow telemetry opt-out. Use `AXONFLOW_TELEMETRY=off` instead.
+### BREAKING
 
-  `DO_NOT_TRACK` was deprecated because it is commonly inherited from host tools and developer environments (CLIs like Codex and Claude Code inject it unconditionally), which makes it an unreliable expression of user intent for AxonFlow telemetry.
+- **Module import path is now `github.com/getaxonflow/axonflow-sdk-go/v7`** (was `/v6`). Required by Go's semantic-import versioning rule for any module at v2+. To upgrade: `go get github.com/getaxonflow/axonflow-sdk-go/v7@latest` and update every import statement from `/v6` → `/v7`. No symbol-level changes from the path migration itself.
+- **`DO_NOT_TRACK` is no longer honored as an AxonFlow telemetry opt-out.** Use `AXONFLOW_TELEMETRY=off` instead. `DO_NOT_TRACK` was deprecated because it is commonly inherited from host tools and developer environments (CLIs like Codex and Claude Code inject it unconditionally), which makes it an unreliable expression of user intent for AxonFlow telemetry.
 
 ### Fixed
 
 - The one-line `[AxonFlow] DO_NOT_TRACK=1 is deprecated...` `log.Printf` warning is no longer emitted. Removing the warning eliminates log noise that previously appeared on every `NewClient` call when `DO_NOT_TRACK=1` was set.
-
-### CI / development
-
-- Test harness (`main_test.go` `TestMain`) and CI workflows (`test.yml`, `release.yml`, `integration.yml`) now use `AXONFLOW_TELEMETRY=off` to suppress telemetry during automated runs.
 
 
 ## [6.0.0] - 2026-04-28 — ListProviders() + SDKCompatibility wire-shape fix

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/getaxonflow/axonflow-sdk-go)](https://goreportcard.com/report/github.com/getaxonflow/axonflow-sdk-go)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> **Upgrade strongly recommended.** Over the past month we've shipped substantial production, quality, and security hardening across the AxonFlow SDKs and platform — see the [v7.0.0 release notes](./CHANGELOG.md), the per-SDK advisory [`GHSA-mhc4-qq83-fmrr`](https://github.com/getaxonflow/axonflow-sdk-go/security/advisories/GHSA-mhc4-qq83-fmrr), and the consolidated platform advisory [`GHSA-9h64-2846-7x7f`](https://github.com/getaxonflow/axonflow/security/advisories/GHSA-9h64-2846-7x7f). Upgrade to the latest major for a more secure, reliable, and bug-free experience.
+> **Upgrade strongly recommended.** AxonFlow ships substantial monthly security and quality hardening; staying on the latest major is the security-supported release line. [Latest release](https://github.com/getaxonflow/axonflow-sdk-go/releases/latest) · [Security advisories](https://github.com/getaxonflow/axonflow-sdk-go/security/advisories)
 
 > ## ⚠️ Use the `/v7` import path
 >

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AxonFlow SDK for Go
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/getaxonflow/axonflow-sdk-go/v6.svg)](https://pkg.go.dev/github.com/getaxonflow/axonflow-sdk-go/v6)
+[![Go Reference](https://pkg.go.dev/badge/github.com/getaxonflow/axonflow-sdk-go/v7.svg)](https://pkg.go.dev/github.com/getaxonflow/axonflow-sdk-go/v7)
 [![Go Report Card](https://goreportcard.com/badge/github.com/getaxonflow/axonflow-sdk-go)](https://goreportcard.com/report/github.com/getaxonflow/axonflow-sdk-go)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -9,11 +9,11 @@
 > Go's semantic import versioning requires the module path to include the major version suffix for v2+. The current release line is **v5.x**, imported as:
 >
 > ```go
-> import "github.com/getaxonflow/axonflow-sdk-go/v6"
+> import "github.com/getaxonflow/axonflow-sdk-go/v7"
 > ```
 >
 > ```bash
-> go get github.com/getaxonflow/axonflow-sdk-go/v6
+> go get github.com/getaxonflow/axonflow-sdk-go/v7
 > ```
 >
 > `go get github.com/getaxonflow/axonflow-sdk-go@latest` (without `/v5`) resolves to **v1.17.0** (a 2026-01 relic from before the v2 split) and is four major release lines behind current. See the [Migration Guide](#migration-guide) below.
@@ -49,7 +49,7 @@ Three short videos covering different angles of the platform:
 ## Installation
 
 ```bash
-go get github.com/getaxonflow/axonflow-sdk-go/v6
+go get github.com/getaxonflow/axonflow-sdk-go/v7
 ```
 
 ## Evaluation Tier (Free License)
@@ -101,7 +101,7 @@ import (
     "log"
     "os"
 
-    "github.com/getaxonflow/axonflow-sdk-go/v6"
+    "github.com/getaxonflow/axonflow-sdk-go/v7"
 )
 
 func main() {
@@ -139,7 +139,7 @@ func main() {
 import (
     "time"
     "os"
-    "github.com/getaxonflow/axonflow-sdk-go/v6"
+    "github.com/getaxonflow/axonflow-sdk-go/v7"
 )
 
 // Full configuration with all features
@@ -177,7 +177,7 @@ import (
     "fmt"
     "log"
 
-    "github.com/getaxonflow/axonflow-sdk-go/v6"
+    "github.com/getaxonflow/axonflow-sdk-go/v7"
 )
 
 func main() {
@@ -311,8 +311,8 @@ Wrap your LLM clients with automatic AxonFlow governance using the interceptors 
 import (
     "context"
     "github.com/sashabaranov/go-openai"
-    "github.com/getaxonflow/axonflow-sdk-go/v6"
-    "github.com/getaxonflow/axonflow-sdk-go/v6/interceptors"
+    "github.com/getaxonflow/axonflow-sdk-go/v7"
+    "github.com/getaxonflow/axonflow-sdk-go/v7/interceptors"
 )
 
 // Initialize AxonFlow client
@@ -364,8 +364,8 @@ if err != nil {
 ```go
 import (
     "context"
-    "github.com/getaxonflow/axonflow-sdk-go/v6"
-    "github.com/getaxonflow/axonflow-sdk-go/v6/interceptors"
+    "github.com/getaxonflow/axonflow-sdk-go/v7"
+    "github.com/getaxonflow/axonflow-sdk-go/v7/interceptors"
 )
 
 // Create Anthropic interceptor
@@ -796,8 +796,8 @@ If `go get github.com/getaxonflow/axonflow-sdk-go@latest` resolved to **v1.17.0*
 
 ```bash
 # In go.mod, remove the old entry and replace with the v5 path:
-#   github.com/getaxonflow/axonflow-sdk-go → github.com/getaxonflow/axonflow-sdk-go/v6
-go get github.com/getaxonflow/axonflow-sdk-go/v6
+#   github.com/getaxonflow/axonflow-sdk-go → github.com/getaxonflow/axonflow-sdk-go/v7
+go get github.com/getaxonflow/axonflow-sdk-go/v7
 ```
 
 Update all imports in your `.go` files to include `/v5`:
@@ -807,7 +807,7 @@ Update all imports in your `.go` files to include `/v5`:
 import "github.com/getaxonflow/axonflow-sdk-go"
 
 // After:
-import "github.com/getaxonflow/axonflow-sdk-go/v6"
+import "github.com/getaxonflow/axonflow-sdk-go/v7"
 ```
 
 The API surface between v1 and v5 is substantially different. Check the release notes for v2, v3, v4, and v5 for the breaking changes you'll need to adopt. If you're coming from v1.x directly, the fastest path is usually to re-read the [Quick Start](#quick-start) section rather than trying to incrementally migrate.
@@ -818,8 +818,8 @@ The API surface between v1 and v5 is substantially different. Check the release 
 
 ```bash
 # In go.mod, change:
-#   github.com/getaxonflow/axonflow-sdk-go/v4 → github.com/getaxonflow/axonflow-sdk-go/v6
-go get github.com/getaxonflow/axonflow-sdk-go/v6
+#   github.com/getaxonflow/axonflow-sdk-go/v4 → github.com/getaxonflow/axonflow-sdk-go/v7
+go get github.com/getaxonflow/axonflow-sdk-go/v7
 ```
 
 Update all imports in your `.go` files from `/v4` to `/v5`. No API-surface changes are required for the v4 → v5 bump itself — the major version increment reflects a policy break in how plan-scoped HITL responses are returned. See the [v5.0.0 release notes](https://github.com/getaxonflow/axonflow-sdk-go/releases/tag/v5.0.0) for the specifics.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/getaxonflow/axonflow-sdk-go)](https://goreportcard.com/report/github.com/getaxonflow/axonflow-sdk-go)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> ## ⚠️ Use the `/v5` import path
+> **Upgrade strongly recommended.** Over the past month we've shipped substantial production, quality, and security hardening across the AxonFlow SDKs and platform — see the [v7.0.0 release notes](./CHANGELOG.md), the per-SDK advisory [`GHSA-mhc4-qq83-fmrr`](https://github.com/getaxonflow/axonflow-sdk-go/security/advisories/GHSA-mhc4-qq83-fmrr), and the consolidated platform advisory [`GHSA-9h64-2846-7x7f`](https://github.com/getaxonflow/axonflow/security/advisories/GHSA-9h64-2846-7x7f). Upgrade to the latest major for a more secure, reliable, and bug-free experience.
+
+> ## ⚠️ Use the `/v7` import path
 >
-> Go's semantic import versioning requires the module path to include the major version suffix for v2+. The current release line is **v5.x**, imported as:
+> Go's semantic import versioning requires the module path to include the major version suffix for v2+. The current release line is **v7.x**, imported as:
 >
 > ```go
 > import "github.com/getaxonflow/axonflow-sdk-go/v7"
@@ -16,7 +18,7 @@
 > go get github.com/getaxonflow/axonflow-sdk-go/v7
 > ```
 >
-> `go get github.com/getaxonflow/axonflow-sdk-go@latest` (without `/v5`) resolves to **v1.17.0** (a 2026-01 relic from before the v2 split) and is four major release lines behind current. See the [Migration Guide](#migration-guide) below.
+> `go get github.com/getaxonflow/axonflow-sdk-go@latest` (without `/v7`) resolves to **v1.17.0** (a 2026-01 relic from before the v2 split) and is six major release lines behind current. See the [Migration Guide](#migration-guide) below.
 
 > **Evaluating AxonFlow in production?** We're opening limited Design Partner slots.
 >

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -145,7 +145,7 @@ Keep dependencies up to date:
 go list -m -u all
 
 # Update dependencies
-go get -u github.com/getaxonflow/axonflow-sdk-go/v6
+go get -u github.com/getaxonflow/axonflow-sdk-go/v7
 go mod tidy
 ```
 
@@ -224,7 +224,7 @@ To receive security updates:
 
 - Watch this repository for releases
 - Subscribe to security advisories
-- Check https://pkg.go.dev/github.com/getaxonflow/axonflow-sdk-go/v6 regularly
+- Check https://pkg.go.dev/github.com/getaxonflow/axonflow-sdk-go/v7 regularly
 
 ## Questions?
 

--- a/contract_wire_shape_test.go
+++ b/contract_wire_shape_test.go
@@ -44,7 +44,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/getaxonflow/axonflow-sdk-go/v6/internal/wireshape"
+	"github.com/getaxonflow/axonflow-sdk-go/v7/internal/wireshape"
 )
 
 // ExcludedTypes names struct types that legitimately do not participate

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ This directory contains working examples demonstrating how to use the AxonFlow G
 ## Prerequisites
 
 ```bash
-go get github.com/getaxonflow/axonflow-sdk-go/v6
+go get github.com/getaxonflow/axonflow-sdk-go/v7
 ```
 
 Set environment variables:
@@ -92,5 +92,5 @@ Example license keys by tier:
 ## Learn More
 
 - [Main Documentation](../README.md)
-- [API Reference](https://pkg.go.dev/github.com/getaxonflow/axonflow-sdk-go/v6)
+- [API Reference](https://pkg.go.dev/github.com/getaxonflow/axonflow-sdk-go/v7)
 - [AxonFlow Docs](https://docs.getaxonflow.com)

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/getaxonflow/axonflow-sdk-go/v6"
+	"github.com/getaxonflow/axonflow-sdk-go/v7"
 )
 
 func main() {

--- a/examples/connectors/main.go
+++ b/examples/connectors/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/getaxonflow/axonflow-sdk-go/v6"
+	"github.com/getaxonflow/axonflow-sdk-go/v7"
 )
 
 func main() {

--- a/examples/planning/main.go
+++ b/examples/planning/main.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/getaxonflow/axonflow-sdk-go/v6"
+	"github.com/getaxonflow/axonflow-sdk-go/v7"
 )
 
 func main() {

--- a/examples/wcp-retry-idempotency/go.mod
+++ b/examples/wcp-retry-idempotency/go.mod
@@ -1,7 +1,7 @@
-module github.com/getaxonflow/axonflow-sdk-go/v6/examples/wcp-retry-idempotency
+module github.com/getaxonflow/axonflow-sdk-go/v7/examples/wcp-retry-idempotency
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v6 v5.0.0
+require github.com/getaxonflow/axonflow-sdk-go/v7 v5.0.0
 
-replace github.com/getaxonflow/axonflow-sdk-go/v6 => ../..
+replace github.com/getaxonflow/axonflow-sdk-go/v7 => ../..

--- a/examples/wcp-retry-idempotency/main.go
+++ b/examples/wcp-retry-idempotency/main.go
@@ -18,7 +18,7 @@ import (
 	"os"
 	"strings"
 
-	axonflow "github.com/getaxonflow/axonflow-sdk-go/v6"
+	axonflow "github.com/getaxonflow/axonflow-sdk-go/v7"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/getaxonflow/axonflow-sdk-go/v6
+module github.com/getaxonflow/axonflow-sdk-go/v7
 
 go 1.21
 

--- a/interceptors/anthropic.go
+++ b/interceptors/anthropic.go
@@ -4,8 +4,8 @@
 //
 //	import (
 //		"github.com/anthropics/anthropic-sdk-go"
-//		"github.com/getaxonflow/axonflow-sdk-go/v6"
-//		"github.com/getaxonflow/axonflow-sdk-go/v6/interceptors"
+//		"github.com/getaxonflow/axonflow-sdk-go/v7"
+//		"github.com/getaxonflow/axonflow-sdk-go/v7/interceptors"
 //	)
 //
 //	client := anthropic.NewClient()
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/getaxonflow/axonflow-sdk-go/v6"
+	"github.com/getaxonflow/axonflow-sdk-go/v7"
 )
 
 // AnthropicContentBlock represents a content block in an Anthropic message

--- a/interceptors/bedrock.go
+++ b/interceptors/bedrock.go
@@ -7,8 +7,8 @@
 //
 //	import (
 //		"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
-//		"github.com/getaxonflow/axonflow-sdk-go/v6"
-//		"github.com/getaxonflow/axonflow-sdk-go/v6/interceptors"
+//		"github.com/getaxonflow/axonflow-sdk-go/v7"
+//		"github.com/getaxonflow/axonflow-sdk-go/v7/interceptors"
 //	)
 //
 //	client := bedrockruntime.NewFromConfig(cfg)
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/getaxonflow/axonflow-sdk-go/v6"
+	"github.com/getaxonflow/axonflow-sdk-go/v7"
 )
 
 // BedrockModels contains common Bedrock model IDs

--- a/interceptors/gemini.go
+++ b/interceptors/gemini.go
@@ -6,8 +6,8 @@
 //
 //	import (
 //		"github.com/google/generative-ai-go/genai"
-//		"github.com/getaxonflow/axonflow-sdk-go/v6"
-//		"github.com/getaxonflow/axonflow-sdk-go/v6/interceptors"
+//		"github.com/getaxonflow/axonflow-sdk-go/v7"
+//		"github.com/getaxonflow/axonflow-sdk-go/v7/interceptors"
 //	)
 //
 //	client, _ := genai.NewClient(ctx, option.WithAPIKey(apiKey))
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/getaxonflow/axonflow-sdk-go/v6"
+	"github.com/getaxonflow/axonflow-sdk-go/v7"
 )
 
 // GeminiPart represents a part of Gemini content

--- a/interceptors/interceptors_http_test.go
+++ b/interceptors/interceptors_http_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	axonflow "github.com/getaxonflow/axonflow-sdk-go/v6"
+	axonflow "github.com/getaxonflow/axonflow-sdk-go/v7"
 )
 
 // createMockAxonFlowServer creates a test server that mimics AxonFlow responses

--- a/interceptors/ollama.go
+++ b/interceptors/ollama.go
@@ -7,8 +7,8 @@
 //
 //	import (
 //		"github.com/ollama/ollama/api"
-//		"github.com/getaxonflow/axonflow-sdk-go/v6"
-//		"github.com/getaxonflow/axonflow-sdk-go/v6/interceptors"
+//		"github.com/getaxonflow/axonflow-sdk-go/v7"
+//		"github.com/getaxonflow/axonflow-sdk-go/v7/interceptors"
 //	)
 //
 //	client, _ := api.ClientFromEnvironment()
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/getaxonflow/axonflow-sdk-go/v6"
+	"github.com/getaxonflow/axonflow-sdk-go/v7"
 )
 
 // OllamaMessage represents a message in an Ollama chat

--- a/interceptors/openai.go
+++ b/interceptors/openai.go
@@ -7,8 +7,8 @@
 //
 //	import (
 //		"github.com/sashabaranov/go-openai"
-//		"github.com/getaxonflow/axonflow-sdk-go/v6"
-//		"github.com/getaxonflow/axonflow-sdk-go/v6/interceptors"
+//		"github.com/getaxonflow/axonflow-sdk-go/v7"
+//		"github.com/getaxonflow/axonflow-sdk-go/v7/interceptors"
 //	)
 //
 //	client := openai.NewClient("your-api-key")
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/getaxonflow/axonflow-sdk-go/v6"
+	"github.com/getaxonflow/axonflow-sdk-go/v7"
 )
 
 // ChatMessage represents a chat message for LLM calls

--- a/scripts/refresh_wire_shape_baseline/main.go
+++ b/scripts/refresh_wire_shape_baseline/main.go
@@ -28,7 +28,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/getaxonflow/axonflow-sdk-go/v6/internal/wireshape"
+	"github.com/getaxonflow/axonflow-sdk-go/v7/internal/wireshape"
 )
 
 const baselineOut = "testdata/wire_shape_baseline.json"

--- a/telemetry_short_lived_test.go
+++ b/telemetry_short_lived_test.go
@@ -131,7 +131,7 @@ func writeShortLivedBinary(dir, modRoot string) error {
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v7 v6.0.0-00010101000000-000000000000
+require github.com/getaxonflow/axonflow-sdk-go/v7 v7.0.0-00010101000000-000000000000
 
 replace github.com/getaxonflow/axonflow-sdk-go/v7 => ` + modRoot + `
 `

--- a/telemetry_short_lived_test.go
+++ b/telemetry_short_lived_test.go
@@ -131,9 +131,9 @@ func writeShortLivedBinary(dir, modRoot string) error {
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v6 v6.0.0-00010101000000-000000000000
+require github.com/getaxonflow/axonflow-sdk-go/v7 v6.0.0-00010101000000-000000000000
 
-replace github.com/getaxonflow/axonflow-sdk-go/v6 => ` + modRoot + `
+replace github.com/getaxonflow/axonflow-sdk-go/v7 => ` + modRoot + `
 `
 	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o644); err != nil {
 		return err
@@ -141,7 +141,7 @@ replace github.com/getaxonflow/axonflow-sdk-go/v6 => ` + modRoot + `
 	main := `package main
 
 import (
-	axonflow "github.com/getaxonflow/axonflow-sdk-go/v6"
+	axonflow "github.com/getaxonflow/axonflow-sdk-go/v7"
 )
 
 func main() {

--- a/tests/heartbeat-real-stack/go.mod
+++ b/tests/heartbeat-real-stack/go.mod
@@ -2,6 +2,6 @@ module heartbeat-real-stack-smoke
 
 go 1.22
 
-require github.com/getaxonflow/axonflow-sdk-go/v6 v6.0.0
+require github.com/getaxonflow/axonflow-sdk-go/v7 v7.0.0
 
-replace github.com/getaxonflow/axonflow-sdk-go/v6 => ../..
+replace github.com/getaxonflow/axonflow-sdk-go/v7 => ../..

--- a/tests/heartbeat-real-stack/smoke_go.go
+++ b/tests/heartbeat-real-stack/smoke_go.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"time"
 
-	axonflow "github.com/getaxonflow/axonflow-sdk-go/v6"
+	axonflow "github.com/getaxonflow/axonflow-sdk-go/v7"
 )
 
 func main() {

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package axonflow
 
 // Version is the SDK version.
-const Version = "6.0.0"
+const Version = "7.0.0"


### PR DESCRIPTION
**Upgrade strongly recommended.** Over the past month we've shipped substantial production, quality, and security hardening across the AxonFlow SDKs and platform — see the [v7.0.0 release notes](./CHANGELOG.md), the per-SDK advisory [`GHSA-mhc4-qq83-fmrr`](https://github.com/getaxonflow/axonflow-sdk-go/security/advisories/GHSA-mhc4-qq83-fmrr), and the consolidated platform advisory [`GHSA-9h64-2846-7x7f`](https://github.com/getaxonflow/axonflow/security/advisories/GHSA-9h64-2846-7x7f). Upgrade to the latest major for a more secure, reliable, and bug-free experience.

---

## Summary

Cuts the `[Unreleased]` section over to `[7.0.0] - 2026-04-29 — Production, quality, and security hardening — upgrade encouraged`. Major bump driven by the BREAKING `DO_NOT_TRACK` removal — `AXONFLOW_TELEMETRY=off` is now the canonical and only opt-out. Module path migrates `/v6` → `/v7` per Go semantic-import-versioning. CHANGELOG and README mirror the format of axonflow-enterprise#1772.

Headline changes shipped under 7.0.0:
- BREAKING: `DO_NOT_TRACK=1` no longer honoured as an opt-out — use `AXONFLOW_TELEMETRY=off`.
- BREAKING: module path `github.com/getaxonflow/axonflow-sdk-go/v7`.
- Telemetry switched to a 7-day delivered-heartbeat with stamp-on-success semantics.
- Webhook signing-key (HMAC-SHA256) now exposed by `RegisterRequest` — was missing from the SDK type, leaving signature verification un-implementable.
- README `/v5` callout text refreshed to `/v7` (was a stale leftover from the migration commit).

## Test plan

- [x] CHANGELOG renders correctly under `## [7.0.0] - 2026-04-29 — ...`.
- [x] `version.go` `Version = "7.0.0"`, `go.mod` module path `/v7`, all 19 internal packages migrated.
- [x] Example go.mod files migrated `/v6` → `/v7`.
- [x] No internal references in the new section.
- [ ] On merge: tag `v7.0.0`, publish GitHub Release with body sourced from this CHANGELOG section.