### PR TITLE
fix(security): restrict GITHUB_TOKEN to contents:read on heartbeat workflow

### DIFF
--- a/.github/workflows/heartbeat-real-stack.yml
+++ b/.github/workflows/heartbeat-real-stack.yml
@@ -15,6 +15,9 @@ on:
 env:
   AXONFLOW_TELEMETRY: 'off'
 
+permissions:
+  contents: read
+
 jobs:
   real-stack:
     name: real-stack ${{ matrix.os }}


### PR DESCRIPTION
## Summary

Closes the open GitHub code-scanning alert `actions/missing-workflow-permissions` on `.github/workflows/heartbeat-real-stack.yml`.

The workflow declared no top-level `permissions:` block, so by default GitHub Actions granted its `GITHUB_TOKEN` write access to most scopes (contents, packages, issues, pull-requests, etc.). For a workflow that only checks out code, builds a Go binary, and runs a localhost smoke harness, every one of those write scopes is excess privilege — CWE-275 (Permission Issues).

## Fix

Add an explicit minimal top-level block:

```yaml
permissions:
  contents: read
```

The job only needs read access to check out the repository; no job in this workflow posts comments, writes packages, or pushes artefacts back, so no per-job overrides are required.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/heartbeat-real-stack.yml'))"` → parses cleanly.
- The workflow will continue to run on push/PR to `main`; only the token scopes change.

GitHub will auto-close the code-scanning alert once the workflow file no longer matches the rule pattern.