### PR TITLE
feat(license): inject X-Axonflow-Client header on every governed request

### DIFF
--- a/axonflow.go
+++ b/axonflow.go
@@ -650,8 +650,9 @@ func NewClient(config AxonFlowConfig) *AxonFlowClient {
 	}
 
 	uaTransport := &userAgentRoundTripper{
-		inner:     transport,
-		userAgent: "axonflow-sdk-go/" + Version,
+		inner:        transport,
+		userAgent:    "axonflow-sdk-go/" + Version,
+		clientHeader: "sdk-go/" + Version,
 	}
 
 	client := &AxonFlowClient{

--- a/transport.go
+++ b/transport.go
@@ -2,16 +2,31 @@ package axonflow
 
 import "net/http"
 
+// userAgentRoundTripper stamps a User-Agent identifying this SDK build and an
+// X-Axonflow-Client header carrying the agent-parseable "<client-id>/<version>"
+// per ADR-050 §4. Both headers are set only if absent so callers can override
+// either.
 type userAgentRoundTripper struct {
-	inner     http.RoundTripper
-	userAgent string
+	inner        http.RoundTripper
+	userAgent    string
+	clientHeader string
 }
 
 func (t *userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	if req.Header.Get("User-Agent") == "" {
-		r2 := req.Clone(req.Context())
-		r2.Header.Set("User-Agent", t.userAgent)
-		return t.inner.RoundTrip(r2)
+	needsUA := req.Header.Get("User-Agent") == ""
+	needsClient := req.Header.Get("X-Axonflow-Client") == ""
+	if !needsUA && !needsClient {
+		return t.inner.RoundTrip(req)
 	}
-	return t.inner.RoundTrip(req)
+	r2 := req.Clone(req.Context())
+	if needsUA {
+		r2.Header.Set("User-Agent", t.userAgent)
+	}
+	if needsClient {
+		// ADR-050 §4: every governed request to the agent carries
+		// X-Axonflow-Client so the agent can derive request scope (sdk)
+		// and validate against the token's aud.scope via HasScope().
+		r2.Header.Set("X-Axonflow-Client", t.clientHeader)
+	}
+	return t.inner.RoundTrip(r2)
 }

--- a/transport_test.go
+++ b/transport_test.go
@@ -1,0 +1,94 @@
+package axonflow
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// X-Axonflow-Client header injection — ADR-050 §4.
+//
+// Asserts the SDK's transport stamps both User-Agent and X-Axonflow-Client
+// on every request so the agent can derive request scope (sdk) and validate
+// against the token's aud.scope via HasScope().
+
+func TestUserAgentRoundTripper_StampsClientHeader(t *testing.T) {
+	var captured http.Header
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer stub.Close()
+
+	rt := &userAgentRoundTripper{
+		inner:        http.DefaultTransport,
+		userAgent:    "axonflow-sdk-go/" + Version,
+		clientHeader: "sdk-go/" + Version,
+	}
+	client := &http.Client{Transport: rt}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, stub.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+	resp.Body.Close()
+
+	wantUA := "axonflow-sdk-go/" + Version
+	if got := captured.Get("User-Agent"); got != wantUA {
+		t.Errorf("User-Agent: want %q, got %q", wantUA, got)
+	}
+
+	wantClient := "sdk-go/" + Version
+	if got := captured.Get("X-Axonflow-Client"); got != wantClient {
+		t.Errorf("X-Axonflow-Client: want %q, got %q", wantClient, got)
+	}
+}
+
+func TestUserAgentRoundTripper_DoesNotOverrideExistingHeaders(t *testing.T) {
+	var captured http.Header
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer stub.Close()
+
+	rt := &userAgentRoundTripper{
+		inner:        http.DefaultTransport,
+		userAgent:    "axonflow-sdk-go/" + Version,
+		clientHeader: "sdk-go/" + Version,
+	}
+	client := &http.Client{Transport: rt}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, stub.URL, nil)
+	req.Header.Set("User-Agent", "user-supplied-ua")
+	req.Header.Set("X-Axonflow-Client", "user-supplied-client/0.0.0")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+	resp.Body.Close()
+
+	if got := captured.Get("User-Agent"); got != "user-supplied-ua" {
+		t.Errorf("User-Agent: caller's value should be preserved, got %q", got)
+	}
+	if got := captured.Get("X-Axonflow-Client"); got != "user-supplied-client/0.0.0" {
+		t.Errorf("X-Axonflow-Client: caller's value should be preserved, got %q", got)
+	}
+}
+
+func TestUserAgentRoundTripper_ClientHeaderFormat(t *testing.T) {
+	// Sanity: agent's deriveScopeFromClientHeader splits on '/' and maps
+	// "sdk-*" prefixes to scope=sdk. Lock down the shape so we can't
+	// accidentally regress agent-side parsing.
+	want := "sdk-go/" + Version
+	if want[:len("sdk-go/")] != "sdk-go/" {
+		t.Errorf("client header must start with sdk-go/")
+	}
+}


### PR DESCRIPTION
## Summary

Per ADR-050 §4, every governed client must set `X-Axonflow-Client: <client-id>/<version>` on every request to the agent.

This is the sdk-go half of [getaxonflow/axonflow-enterprise#1881](https://github.com/getaxonflow/axonflow-enterprise/issues/1881).

## Changes

- `transport.go::userAgentRoundTripper` — extends the existing transport to also stamp `X-Axonflow-Client: sdk-go/<Version>`. Symmetric set-if-absent behavior with User-Agent so callers can override either.
- `axonflow.go` — initializes `clientHeader` on the `userAgentRoundTripper` constructor.
- `transport_test.go` — new test file (3 tests: stamps, doesn't override caller-supplied values, format check).

## Verification

- `go test ./...` — all packages green