### PR TITLE
chore(ci): add definition-of-done gate + runtime-e2e seed [skip-runtime-e2e]

### DIFF
--- a/.github/workflows/definition-of-done.yml
+++ b/.github/workflows/definition-of-done.yml
@@ -1,0 +1,171 @@
+name: Definition of Done
+
+# Enforces CLAUDE.md HARD RULE #0: a user-facing feature is not done until
+# demonstrated through its actual runtime. See axonflow-claude-plugin#59
+# for the doctrine + lint-no-mocks rationale.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  lint-no-mocks-in-runtime-e2e:
+    name: Lint — no mocks in runtime-e2e/
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run lint
+        run: |
+          if [ -x scripts/lint-no-mocks-in-runtime-e2e.sh ]; then
+            ./scripts/lint-no-mocks-in-runtime-e2e.sh
+          else
+            echo "lint-no-mocks-in-runtime-e2e.sh not present — skipping (older branch)."
+          fi
+
+  runtime-e2e-required:
+    name: Runtime E2E required for user-facing changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect user-facing surface changes
+        id: detect
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -uo pipefail
+          # Go SDK user-facing surface:
+          #  - all root-level *.go files (the SDK's exported public API:
+          #    axonflow.go, transport.go, register.go, decisions.go,
+          #    execution.go, governed_tool.go, telemetry.go, hitl.go, etc.)
+          #  - interceptors/ subpackage (provider interceptors imported by users)
+          #  - examples/ (user-runnable demonstrations)
+          #  - go.mod / go.sum (dependency surface)
+          #
+          # Tests (*_test.go) and runtime-e2e/ are NOT user-facing — they
+          # exercise the surface, they aren't the surface.
+          USER_FACING_PREFIXES=(
+            'interceptors/'
+            'examples/'
+          )
+          USER_FACING_FILES=(
+            'go.mod'
+            'go.sum'
+          )
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD" || true)
+          echo "Changed files in PR:" >&2
+          printf '  %s\n' $CHANGED >&2
+
+          MATCHED=""
+          for f in $CHANGED; do
+            # Root-level *.go (excluding *_test.go) — the SDK's exported
+            # public API at the package root.
+            case "$f" in
+              */*) ;;
+              *_test.go) ;;
+              *.go) MATCHED="$MATCHED $f"; continue ;;
+            esac
+
+            # Explicit user-facing top-level files.
+            for explicit in "${USER_FACING_FILES[@]}"; do
+              if [ "$f" = "$explicit" ]; then
+                MATCHED="$MATCHED $f"
+                continue 2
+              fi
+            done
+
+            # Prefix-based directory globs (subpackages + examples).
+            for pat in "${USER_FACING_PREFIXES[@]}"; do
+              case "$f" in
+                "$pat"*)
+                  # Skip test files inside these prefixes too.
+                  case "$f" in
+                    *_test.go) ;;
+                    *)
+                      MATCHED="$MATCHED $f"
+                      ;;
+                  esac
+                  continue 2
+                  ;;
+              esac
+            done
+          done
+
+          RUNTIME_E2E_TOUCHED=$(echo "$CHANGED" | grep -c '^runtime-e2e/' || true)
+
+          {
+            echo "user_facing_changed=$([ -n "$MATCHED" ] && echo true || echo false)"
+            echo "runtime_e2e_touched=$RUNTIME_E2E_TOUCHED"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ -n "$MATCHED" ]; then
+            echo "User-facing files changed:" >&2
+            for f in $MATCHED; do echo "  - $f" >&2; done
+          fi
+
+      - name: Check escape-hatch justification
+        id: hatch
+        if: steps.detect.outputs.user_facing_changed == 'true' && steps.detect.outputs.runtime_e2e_touched == '0'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -uo pipefail
+          if [[ "$PR_TITLE" == *"[skip-runtime-e2e]"* ]]; then
+            if echo "$PR_BODY" | grep -q '## Skip-runtime-e2e justification'; then
+              echo "Escape hatch active." >&2
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "::error::PR title carries [skip-runtime-e2e] but body has no '## Skip-runtime-e2e justification' section."
+              exit 1
+            fi
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Enforce runtime-e2e/ presence
+        if: steps.detect.outputs.user_facing_changed == 'true' && steps.detect.outputs.runtime_e2e_touched == '0' && steps.hatch.outputs.skip != 'true'
+        run: |
+          cat <<'EOF' >&2
+          ::error::This PR touches user-facing surface (root-level *.go,
+          interceptors/, examples/, go.mod, go.sum) but does not add or
+          update any runtime-e2e/ test in the same PR.
+
+          Per CLAUDE.md HARD RULE #0:
+          A user-facing feature is not done until you have demonstrated it
+          working through its actual runtime — real `import` of this SDK
+          from a real Go program with real `net/http` to a real running
+          AxonFlow agent.
+
+          Mocks, stubs, httptest.NewServer, capture-stub harnesses do NOT
+          count as runtime proof.
+
+          To resolve, do ONE of:
+            1. Add a test under runtime-e2e/<feature>/ that invokes the
+               feature through the actual user-facing surface (i.e. import
+               the SDK, call NewClient, hit a real agent).
+            2. If genuinely internal (build / deps / lint baseline / docs),
+               add `[skip-runtime-e2e]` to PR title AND a
+               `## Skip-runtime-e2e justification` section to PR body.
+
+          See: axonflow-internal-docs/engineering/E2E_EXAMPLES_TESTING_WORKFLOW.md
+          EOF
+          exit 1
+
+      - name: All clear
+        if: steps.detect.outputs.user_facing_changed == 'false' || steps.detect.outputs.runtime_e2e_touched != '0' || steps.hatch.outputs.skip == 'true'
+        run: |
+          if [ "${{ steps.detect.outputs.user_facing_changed }}" = 'false' ]; then
+            echo "No user-facing surface changed. Gate not applicable." >&2
+          elif [ "${{ steps.detect.outputs.runtime_e2e_touched }}" != '0' ]; then
+            echo "User-facing change detected and runtime-e2e/ updated in same PR. ✓" >&2
+          else
+            echo "Escape hatch active with valid justification. ✓" >&2
+          fi

--- a/runtime-e2e/README.md
+++ b/runtime-e2e/README.md
@@ -1,0 +1,59 @@
+# SDK runtime tests — axonflow-sdk-go
+
+Per CLAUDE.md HARD RULE #0: a user-facing feature is not done until you
+have demonstrated it working through the SDK's actual runtime — a real
+`import "github.com/getaxonflow/axonflow-sdk-go/v7"` from a real Go
+program with real `net/http` against a real running AxonFlow agent.
+
+**Tests in this directory MUST hit a real endpoint.** No
+`httptest.NewServer`, no fixture servers, no capture-stub harnesses.
+The `scripts/lint-no-mocks-in-runtime-e2e.sh` lint enforces this; a
+forbidden mock pattern fails CI. (If a specific driver legitimately
+needs an in-process listener — e.g. to inject a license token the SDK
+itself does not surface — mark it inline with `// allow-mocks-here:
+<reason>` and justify in PR review.)
+
+## Convention
+
+Each test lives in its own subdirectory like `runtime-e2e/<feature>/`.
+Each subdirectory has a `main.go` invokable via `go run`. The driver
+file uses `//go:build ignore` so it is excluded from the SDK package's
+normal build/`go vet`/`go test` pass — these are runners, not unit
+tests.
+
+```
+runtime-e2e/
+  README.md                      # this file
+  <feature>/
+    main.go                      # //go:build ignore — invoked via `go run`
+```
+
+## How to run locally
+
+Set `AXONFLOW_AGENT_URL` (default `http://localhost:8080`). Bring up a
+local agent via the standard E2E setup script (see
+`axonflow-internal-docs/engineering/E2E_EXAMPLES_TESTING_WORKFLOW.md`).
+Then:
+
+```
+export AXONFLOW_AGENT_URL=http://localhost:8080
+
+# Register a community-saas tenant
+RESP=$(curl -s -X POST $AXONFLOW_AGENT_URL/api/v1/register \
+  -H "Content-Type: application/json" -d '{"label":"sdk-runtime-e2e"}')
+export AXONFLOW_TENANT_ID=$(echo "$RESP" | jq -r .tenant_id)
+export AXONFLOW_TENANT_SECRET=$(echo "$RESP" | jq -r .secret)
+
+# Mint a plugin-aud token (see x-axonflow-client/ for use)
+export AXONFLOW_E2E_PLUGIN_TOKEN=<jwt with aud=axonflow.saas.plugin>
+
+go run runtime-e2e/x-axonflow-client/main.go
+```
+
+## What counts as a test
+
+Each `main.go` exits non-zero if the SDK's real wire output to a real
+agent isn't what you expect. The strongest evidence pattern is to
+capture an agent response that echoes a value the SDK should have sent
+(e.g. `X-Axonflow-Client: sdk-go/<version>` reflected back from the
+agent's scope-mismatch handler).

--- a/runtime-e2e/x-axonflow-client/main.go
+++ b/runtime-e2e/x-axonflow-client/main.go
@@ -1,0 +1,101 @@
+//go:build ignore
+
+// runtime-e2e/x-axonflow-client/main.go
+//
+// Per CLAUDE.md HARD RULE #0: real-wire test of the SDK's
+// userAgentRoundTripper emitting X-Axonflow-Client: sdk-go/<Version>
+// against a real running AxonFlow agent.
+//
+// The SDK does not expose its internal http.Client, so to inject a
+// known X-License-Token (so the agent can answer with a deterministic
+// scope_mismatch echo) we run a tiny in-process reverse proxy that
+// forwards every request to the real agent endpoint and prepends
+// X-License-Token. This is real-wire forwarding, not a stub: the
+// proxy adds a header and copies bytes; the agent's response is what
+// drives the assertion.
+//
+// Run via:
+//   go run runtime-e2e/x-axonflow-client/main.go
+//
+// Prereqs: AXONFLOW_AGENT_URL, AXONFLOW_TENANT_ID, AXONFLOW_TENANT_SECRET,
+// AXONFLOW_E2E_PLUGIN_TOKEN — see ../README.md.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+
+	axonflow "github.com/getaxonflow/axonflow-sdk-go/v7"
+)
+
+func main() {
+	endpoint := os.Getenv("AXONFLOW_AGENT_URL")
+	if endpoint == "" {
+		endpoint = "http://localhost:8080"
+	}
+	tenant := os.Getenv("AXONFLOW_TENANT_ID")
+	secret := os.Getenv("AXONFLOW_TENANT_SECRET")
+	token := os.Getenv("AXONFLOW_E2E_PLUGIN_TOKEN")
+	if tenant == "" || secret == "" || token == "" {
+		fmt.Fprintln(os.Stderr, "AXONFLOW_TENANT_ID + AXONFLOW_TENANT_SECRET + AXONFLOW_E2E_PLUGIN_TOKEN must be set; see ../README.md")
+		os.Exit(2)
+	}
+
+	// Spin up an in-process reverse proxy that forwards every request to
+	// the real agent at AXONFLOW_AGENT_URL and prepends X-License-Token.
+	// The SDK is pointed at this proxy. Bytes flow real → real.
+	target, err := url.Parse(endpoint)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid AXONFLOW_AGENT_URL: %v\n", err)
+		os.Exit(2)
+	}
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	origDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		origDirector(req)
+		req.Host = target.Host
+		req.Header.Set("X-License-Token", token)
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "listen: %v\n", err)
+		os.Exit(2)
+	}
+	defer listener.Close()
+	go func() {
+		_ = http.Serve(listener, proxy)
+	}()
+	proxyURL := "http://" + listener.Addr().String()
+
+	client := axonflow.NewClient(axonflow.AxonFlowConfig{
+		Endpoint:     proxyURL,
+		ClientID:     tenant,
+		ClientSecret: secret,
+	})
+
+	expected := "sdk-go/" + axonflow.Version
+	fmt.Printf("Asserting wire X-Axonflow-Client = %s\n", expected)
+
+	_, err = client.MCPCheckInput(context.Background(), axonflow.MCPCheckInputRequest{
+		ConnectorType: "postgres",
+		Statement:     "SELECT 1",
+	})
+	if err != nil && strings.Contains(err.Error(), fmt.Sprintf("client \"%s\"", expected)) {
+		fmt.Printf("PASS: agent reflected %s in scope_mismatch response\n", expected)
+		os.Exit(0)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: error did not echo expected client header; got: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Fprintln(os.Stderr, "UNEXPECTED 200 — agent should have rejected scope_mismatch")
+	os.Exit(1)
+}

--- a/scripts/lint-no-mocks-in-runtime-e2e.sh
+++ b/scripts/lint-no-mocks-in-runtime-e2e.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# lint-no-mocks-in-runtime-e2e.sh
+#
+# Per HARD RULE #0 in CLAUDE.md: runtime-e2e/ tests MUST hit a real endpoint
+# (real plugin in real host CLI; real SDK with real fetch against a real
+# running agent). Mocks, stubs, simulators, capture-stub harnesses do NOT
+# count as runtime proof.
+#
+# This script greps runtime-e2e/ for forbidden mock-pattern strings and
+# fails the build if any are found. It runs in CI as part of the
+# definition-of-done.yml gate.
+#
+# To bypass for a specific file (rare, must justify in PR):
+#   add a line `# allow-mocks-here: <reason>` near the offending line and
+#   the lint will skip that file. Reviewers should challenge any usage.
+
+set -uo pipefail
+
+SCAN_DIR="${1:-runtime-e2e}"
+
+if [ ! -d "$SCAN_DIR" ]; then
+  echo "lint-no-mocks: $SCAN_DIR not present, nothing to scan."
+  exit 0
+fi
+
+# Forbidden patterns. Each one represents a way to fake a runtime response.
+# Add to this list as new mock libraries arrive in the codebase.
+PATTERNS=(
+  'mockFetch'                    # jest fetch mock
+  'jest\.mock'                   # jest module mock
+  'jest\.fn'                     # jest stub
+  'sinon\.stub'                  # sinon test double
+  'unittest\.mock'               # python stdlib mock
+  'MagicMock'                    # python mock class
+  'httpx_mock\.add_response'     # python httpx mock
+  'wiremock'                     # java/jvm wiremock
+  'WireMockServer'               # wiremock builder
+  'stubFor'                      # wiremock stub
+  'httptest\.NewServer'          # go httptest stub server
+  'capture-stub\.py'             # local capture harness
+  'fixture-server'               # generic fixture server
+  'msw\.setupServer'             # jsdom mock service worker
+  'nock\.'                       # nock http stubs (node)
+)
+
+EXIT=0
+COUNT=0
+
+# Build a regex from PATTERNS; escape literal dots already in the pattern source
+REGEX=$(IFS='|'; echo "${PATTERNS[*]}")
+
+# Use plain grep -r so we catch untracked files too (CI sees tracked PR
+# content, but local dev/pre-commit may run against new files not yet added).
+matches=$(grep -rnE "$REGEX" "$SCAN_DIR" 2>/dev/null || true)
+
+if [ -z "$matches" ]; then
+  echo "lint-no-mocks: $SCAN_DIR is clean (no forbidden mock patterns found)."
+  exit 0
+fi
+
+# Filter out lines explicitly allowed via the inline marker.
+while IFS= read -r line; do
+  file=$(echo "$line" | cut -d: -f1)
+  if [ -n "$file" ] && grep -q "allow-mocks-here:" "$file" 2>/dev/null; then
+    continue
+  fi
+  echo "  $line"
+  COUNT=$((COUNT + 1))
+  EXIT=1
+done <<< "$matches"
+
+if [ "$EXIT" -ne 0 ]; then
+  echo ""
+  echo "lint-no-mocks: $COUNT forbidden mock-pattern hit(s) in $SCAN_DIR." >&2
+  echo "" >&2
+  echo "Per CLAUDE.md HARD RULE #0, runtime-e2e/ tests MUST hit a real endpoint." >&2
+  echo "Mocks, stubs, fixture-servers, and capture harnesses do NOT count as" >&2
+  echo "runtime proof. The runtime-e2e/ test for a feature must invoke the" >&2
+  echo "feature through its actual user-facing surface (host CLI tool/skill," >&2
+  echo "real SDK fetch to a running agent, etc.)." >&2
+  echo "" >&2
+  echo "If a specific test legitimately needs a stub (rare — usually means" >&2
+  echo "it's not actually a runtime test and belongs elsewhere), add a" >&2
+  echo "  # allow-mocks-here: <reason>" >&2
+  echo "comment on the line and a reviewer must explicitly approve it." >&2
+fi
+
+exit "$EXIT"


### PR DESCRIPTION
## Summary

Mirrors axonflow-claude-plugin#59 / axonflow-cursor-plugin#48 / axonflow-codex-plugin#48 / axonflow-openclaw-plugin#101. Lands the mechanical enforcement of CLAUDE.md HARD RULE #0 in axonflow-sdk-go.

- `.github/workflows/definition-of-done.yml` — required check. Fails any PR touching the SDK's user-facing surface (root-level `*.go` excluding `*_test.go`; `interceptors/`; `examples/`; `go.mod`; `go.sum`) without adding or updating a `runtime-e2e/` test in the same PR. Test files and `internal/` are excluded. Escape hatch: `[skip-runtime-e2e]` in PR title plus a `## Skip-runtime-e2e justification` section in the body.
- `scripts/lint-no-mocks-in-runtime-e2e.sh` — greps `runtime-e2e/` for forbidden mock patterns (`httptest.NewServer`, `jest.mock`, `unittest.mock`, `MagicMock`, `httpx_mock.add_response`, `wiremock`, `stubFor`, `capture-stub.py`, `msw.setupServer`, `nock`, etc.). Inline `// allow-mocks-here: <reason>` opt-out for legitimate cases (must justify in review).
- `runtime-e2e/README.md` — convention (one feature per subdir, each has `main.go` invokable via `go run`, `//go:build ignore` keeps drivers out of the package's normal build/vet/test pass).
- `runtime-e2e/x-axonflow-client/main.go` — first runner. Real-wire test of `userAgentRoundTripper` emitting `X-Axonflow-Client: sdk-go/<Version>`. Spins up an in-process `httputil.ReverseProxy` that forwards to the real agent at `AXONFLOW_AGENT_URL` and prepends `X-License-Token` (so the agent can reject with a deterministic `scope_mismatch` echo); the SDK is pointed at the proxy. Bytes flow real-to-real.

## Skip-runtime-e2e justification

This PR is the gate itself plus the seed test driver — there is no user-facing SDK surface change. Root-level `*.go` and `interceptors/` are untouched. The `runtime-e2e/` tree is added but not yet wired into a CI runner that brings up a full stack; the gate will catch future PRs that change user-facing surface without updating `runtime-e2e/`.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/definition-of-done.yml'))"` — YAML parses
- [x] `./scripts/lint-no-mocks-in-runtime-e2e.sh` — exits 0 (clean)
- [x] `go vet ./...` — clean (driver excluded via `//go:build ignore`)
- [x] `go build runtime-e2e/x-axonflow-client/main.go` — compiles
- [x] Surface-detection logic dry-run: matches `axonflow.go`, `interceptors/anthropic.go`, `examples/basic/main.go`, `go.mod`, `go.sum`; correctly skips `axonflow_test.go`, `internal/foo.go`, `tests/integration.go`, `runtime-e2e/x.go`, `.github/workflows/test.yml`, `CHANGELOG.md`
- [ ] Pilot a deliberately-broken PR (touches `axonflow.go` without `runtime-e2e/`) to confirm the gate fires (separate PR)
- [ ] Live runtime-e2e/x-axonflow-client/main.go run against a community-saas stack (separate validation; needs `AXONFLOW_E2E_PLUGIN_TOKEN` minted from agent)