### PR TITLE
fix(release): correct SDK version v7.7.0 → v7.1.0 [skip-runtime-e2e]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.7.0] - 2026-05-06 — X-Axonflow-Client header + scope-aware license validation
+## [7.1.0] - 2026-05-06 — X-Axonflow-Client header + scope-aware license validation
 
 **Companion release to platform v7.7.0.** The Go SDK now sends an
 `X-Axonflow-Client` identification header on every governed request, which
@@ -25,7 +25,7 @@ license token's audience claim per the ADR-050 license matrix.
 
 - **Go module path stays `github.com/getaxonflow/axonflow-sdk-go/v7`** —
   no major bump, no import-path migration. Existing v7.0.x callers
-  rebuild against v7.7.0 with no source changes.
+  rebuild against v7.1.0 with no source changes.
 - **Backward-compatible against pre-v7.7.0 agents.** The header is
   silently dropped by older agents; the SDK behaves identically against
   v7.0.x / v7.1.x / v7.6.x agents as before.
@@ -38,8 +38,8 @@ license token's audience claim per the ADR-050 license matrix.
 - **Platform v7.7.0** — V1 SaaS Plugin Pro launch, license matrix,
   per-tenant tier resolution, GDPR right-to-erasure
   ([CHANGELOG](https://github.com/getaxonflow/axonflow/blob/main/CHANGELOG.md))
-- **Python SDK v7.7.0** / **TypeScript SDK v7.7.0** /
-  **Java SDK v7.7.0** — same `X-Axonflow-Client` injection
+- **Python SDK v7.1.0** / **TypeScript SDK v7.1.0** /
+  **Java SDK v7.1.0** — same `X-Axonflow-Client` injection
 - **Plugins** — Claude Code / Cursor / Codex v1.2.0; OpenClaw v2.2.0
   with Pro license token paste activating Pro features
 

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package axonflow
 
 // Version is the SDK version.
-const Version = "7.7.0"
+const Version = "7.1.0"


### PR DESCRIPTION
## Summary

Previous release PR #155 bumped the Go SDK directly from v7.0.0 to v7.7.0 to platform-align with the V1 SaaS Plugin Pro launch. **That was incorrect semver.**

The only substantive change since v7.0.0 is the X-Axonflow-Client header injection — one minor feature — so the natural bump is **v7.1.0**, not v7.7.0.

## Why semver wins here

- Platform-aligned SDK versioning would force a no-code SDK bump on every minor platform release, decoupling SDK semver from actual SDK changes
- The `/health` endpoint's `MinSDKVersion` + `RecommendedSDKVersion` already covers any platform-version relationship users care about

## Changes

- `version.go` 7.7.0 → 7.1.0
- CHANGELOG header `[7.7.0]` → `[7.1.0]` (2026-05-06 stamp preserved)
- Cross-references to sister SDK versions corrected (Python / TypeScript / Java v7.1.0)
- Compatibility note: existing v7.0.x callers rebuild against v7.1.0

Plugin releases stay correct at v1.2.0 / v2.2.0 (those have multiple substantive commits → semver-true minor bumps).

## Skip-runtime-e2e justification

Version-correction only — no code behavior change. The X-Axonflow-Client header injection runtime contract was validated when #153 landed and re-confirmed when #155 merged. This PR only fixes the version string from the incorrect v7.7.0 to the semver-correct v7.1.0.