### PR TITLE
docs(telemetry): scope AXONFLOW_TELEMETRY=off to its actual data layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -972,6 +972,10 @@ No email required. Optional contact if you want a response.
 This SDK sends anonymous usage telemetry (SDK version, OS, enabled features) to help improve AxonFlow.
 No prompts, payloads, or PII are ever collected. Opt out: `AXONFLOW_TELEMETRY=off`.
 
+### Scope of `AXONFLOW_TELEMETRY=off`
+
+`AXONFLOW_TELEMETRY=off` disables the anonymous SDK heartbeat (version, OS, architecture). On **self-hosted** and **in-VPC** deployments, that heartbeat is the only data the SDK sends to AxonFlow, so setting `=off` means we receive nothing. On **Community SaaS** (`try.getaxonflow.com`) the hosted service also processes operational data — registrations, audit logs, policy enforcement records, workflow state, plan data, and request-header metadata aggregated for usage analytics — as part of running the platform; that operational data flow is governed by the [Privacy Policy](https://getaxonflow.com/privacy/), not by `AXONFLOW_TELEMETRY`.
+
 `DO_NOT_TRACK` is **not** honored as an opt-out for AxonFlow telemetry. It is commonly inherited from host tools and developer environments, which makes it an unreliable expression of user intent.
 
 See [Telemetry Documentation](https://docs.getaxonflow.com/docs/telemetry) for full details.


### PR DESCRIPTION
## Summary
- Adds a short "Scope" subsection clarifying that `AXONFLOW_TELEMETRY=off` disables the anonymous SDK heartbeat, which on self-hosted / in-VPC deployments is the only data the SDK sends. On Community SaaS the hosted service also processes operational data (registrations, audit logs, policy enforcement records, workflow state, plan data, request-header metadata) as part of running the platform; that flow is governed by the Privacy Policy, not by this env var.
- Goal: stop implying the flag is the universal privacy lever — it suppresses one specific data path, and self-hosted users get the full benefit while Community SaaS users have a different and broader data flow inherent to the hosted service.

## Coordinated rollout
Same canonical 3-sentence scoping note landing across 11 repos as separate PRs:
- 5 SDK READMEs (this one + ts/python/java/rust)
- 4 plugin READMEs (claude / cursor / codex / openclaw)
- axonflow-enterprise (TELEMETRY.md + TELEMETRY_CONTRACT.md + README + 2 ADRs + SDK_FEATURE_COVERAGE.md + rust-quickstart.md)
- axonflow-docs (telemetry.md + 4 integration pages + 2 deployment pages + rust-getting-started.md)
- axonflow-landing (privacy.html — long form with GDPR + categories + source-tagging note)

## Test plan
- [x] Self-reviewed every hunk per HARD RULE #1 5-question protocol (single-hunk PR; verified: matches commit msg, no copy-paste residue, URLs valid `https://docs.getaxonflow.com/docs/telemetry` + `https://getaxonflow.com/privacy/`, accurate description of what flag controls vs what it doesn't, customer-shippable copy)
- No code change. README markdown only.

## NOT MERGE — user review pending
Per primary-session direction, holding merge for explicit user review of each of the 11 PRs.