### PR TITLE
docs(examples): add explain-decision example [skip-runtime-e2e]

### DIFF
--- a/examples/explain-decision/go.mod
+++ b/examples/explain-decision/go.mod
@@ -1,0 +1,7 @@
+module github.com/getaxonflow/axonflow-sdk-go/v7/examples/explain-decision
+
+go 1.23
+
+require github.com/getaxonflow/axonflow-sdk-go/v7 v7.1.0
+
+replace github.com/getaxonflow/axonflow-sdk-go/v7 => ../..

--- a/examples/explain-decision/go.sum
+++ b/examples/explain-decision/go.sum
@@ -1,0 +1,2 @@
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/explain-decision/main.go
+++ b/examples/explain-decision/main.go
@@ -1,0 +1,114 @@
+// Example: explain a previously-made AxonFlow policy decision.
+//
+// Implements the ADR-043 explainability flow. Given a decision_id (typically
+// surfaced on the response of a blocked governed call, an audit_logs row, or
+// the `explain_decision` MCP tool), this example fetches the structured
+// explanation and renders the matched policies, risk level, and override
+// availability.
+//
+// Required env vars:
+//
+//	AXONFLOW_AGENT_URL          (default: http://localhost:8080)
+//	AXONFLOW_CLIENT_ID
+//	AXONFLOW_CLIENT_SECRET
+//	AXONFLOW_DECISION_ID        the decision to explain
+//
+// Get a decision_id quickly by hitting a known-blocked policy:
+//
+//	curl -u "$AXONFLOW_CLIENT_ID:$AXONFLOW_CLIENT_SECRET" \
+//	     -X POST $AXONFLOW_AGENT_URL/api/v1/mcp/check-input \
+//	     -H 'Content-Type: application/json' \
+//	     -d '{"connector_type":"postgres","operation":"execute","statement":"SELECT 1; DROP TABLE users;--","user_token":"u1"}'
+//
+// then read decision_id from the block response or the most recent audit row.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/getaxonflow/axonflow-sdk-go/v7"
+)
+
+func main() {
+	agentURL := getEnv("AXONFLOW_AGENT_URL", "http://localhost:8080")
+	clientID := getEnv("AXONFLOW_CLIENT_ID", "community")
+	clientSecret := getEnv("AXONFLOW_CLIENT_SECRET", "")
+	decisionID := getEnv("AXONFLOW_DECISION_ID", "")
+
+	if decisionID == "" {
+		log.Fatal("AXONFLOW_DECISION_ID must be set (a decision_id from a recent blocked call)")
+	}
+
+	fmt.Printf("Initializing AxonFlow client at %s...\n", agentURL)
+	client := axonflow.NewClientSimple(agentURL, clientID, clientSecret)
+
+	fmt.Printf("Explaining decision %s...\n\n", decisionID)
+	exp, err := client.ExplainDecision(context.Background(), decisionID)
+	if err != nil {
+		log.Fatalf("ExplainDecision failed: %v", err)
+	}
+
+	fmt.Println("=== Decision Explanation ===")
+	fmt.Printf("  decision_id: %s\n", exp.DecisionID)
+	fmt.Printf("  timestamp:   %s\n", exp.Timestamp.Format("2006-01-02 15:04:05 MST"))
+	fmt.Printf("  decision:    %s\n", exp.Decision)
+	fmt.Printf("  reason:      %s\n", exp.Reason)
+	if exp.RiskLevel != "" {
+		fmt.Printf("  risk_level:  %s\n", exp.RiskLevel)
+	}
+	if exp.ToolSignature != "" {
+		fmt.Printf("  tool:        %s\n", exp.ToolSignature)
+	}
+
+	fmt.Printf("\n  policy_matches (%d):\n", len(exp.PolicyMatches))
+	for i, m := range exp.PolicyMatches {
+		name := m.PolicyName
+		if name == "" {
+			name = "(unnamed)"
+		}
+		action := m.Action
+		if action == "" {
+			action = "-"
+		}
+		risk := m.RiskLevel
+		if risk == "" {
+			risk = "-"
+		}
+		fmt.Printf("    [%d] %s (%s) — action=%s risk=%s allow_override=%t\n",
+			i, m.PolicyID, name, action, risk, m.AllowOverride)
+	}
+
+	if len(exp.MatchedRules) > 0 {
+		fmt.Printf("\n  matched_rules (%d):\n", len(exp.MatchedRules))
+		for _, r := range exp.MatchedRules {
+			ruleID := r.RuleID
+			if ruleID == "" {
+				ruleID = "(no rule id)"
+			}
+			matchedOn := r.MatchedOn
+			if matchedOn == "" {
+				matchedOn = "-"
+			}
+			fmt.Printf("    %s on %s: matched=%s\n", r.PolicyID, ruleID, matchedOn)
+		}
+	}
+
+	fmt.Printf("\n  override_available:           %t\n", exp.OverrideAvailable)
+	if exp.OverrideExistingID != "" {
+		fmt.Printf("  override_existing_id:         %s\n", exp.OverrideExistingID)
+	}
+	fmt.Printf("  historical_hit_count_session: %d\n", exp.HistoricalHitCountSession)
+	if exp.PolicySourceLink != "" {
+		fmt.Printf("  policy_source_link:           %s\n", exp.PolicySourceLink)
+	}
+}
+
+func getEnv(key, fallback string) string {
+	if v, ok := os.LookupEnv(key); ok {
+		return v
+	}
+	return fallback
+}


### PR DESCRIPTION
Closes the example-parity gap: `ExplainDecision()` shipped in April but no runnable example existed. Mirror the Rust SDK pattern (axonflow-sdk-rust#29 / commit `2360282`) so a caller can copy a complete demo without reading the SDK source.

## Scope

- New `examples/explain-decision/` with its own go module (mirrors the `examples/wcp-retry-idempotency/` layout — `replace` directive points at the parent SDK).
- Reads `AXONFLOW_DECISION_ID` from env, calls `ExplainDecision`, prints every ADR-043 field: matched policies, matched rules, decision, reason, risk level, override availability, historical hit count.
- Defaults `AXONFLOW_CLIENT_ID` to `community` (the cross-SDK Basic-auth default) so a fresh community-stack docker-compose can run the example with one env var.

## Three-rule definition of done

**Rule 0 — Runtime proof.** Live run against the local community stack at `localhost:8080` (agent v7.7.0 / orchestrator v7.7.0):

Step 1 — trigger a real decision:
```bash
curl -s -u "community:" -X POST http://localhost:8080/api/v1/mcp/check-input \
  -H "Content-Type: application/json" \
  -H "X-User-Email: go-explain-e2e@axonflow.com" \
  -d '{"connector_type":"postgres","operation":"execute","statement":"SELECT 1; DROP TABLE users;--","user_token":"u1"}'
```
Response: `decision_id=7a4876eb-3fd5-4467-a412-b0b42833e165`, policy `sys_sqli_drop_table`, risk `critical`.

Step 2 — explain via the new example:
```bash
AXONFLOW_AGENT_URL=http://localhost:8080 \
AXONFLOW_CLIENT_ID=community \
AXONFLOW_CLIENT_SECRET="" \
AXONFLOW_DECISION_ID=7a4876eb-3fd5-4467-a412-b0b42833e165 \
go run main.go
```

Output:
```
Initializing AxonFlow client at http://localhost:8080...
Explaining decision 7a4876eb-3fd5-4467-a412-b0b42833e165...

=== Decision Explanation ===
  decision_id: 7a4876eb-3fd5-4467-a412-b0b42833e165
  timestamp:   2026-05-07 12:16:36 UTC
  decision:    deny
  reason:      Detects DROP TABLE statement
  risk_level:  critical

  policy_matches (1):
    [0] sys_sqli_drop_table (DROP TABLE Statement) — action=- risk=critical allow_override=false

  override_available:           false
  historical_hit_count_session: 0
```

**Rule 1 — Self-review.** Hunk-by-hunk:
- `go.mod` — module path matches `wcp-retry-idempotency` sibling. `require` pinned to `v7.1.0` (current SDK tag). `replace` directive points at parent SDK source. ✓
- `go.sum` — minimal, single transitive (yaml.v3). ✓
- `main.go` — every field access matches `decisions.go` exactly: `DecisionID`, `Timestamp`, `Decision`, `Reason`, `RiskLevel`, `ToolSignature`, `PolicyMatches{PolicyID,PolicyName,Action,RiskLevel,AllowOverride}`, `MatchedRules`, `OverrideAvailable`, `OverrideExistingID`, `HistoricalHitCountSession`, `PolicySourceLink`. Compiles + runs end-to-end (above).
- Self-review caught one issue pre-push: the compiled binary was accidentally `git add`-ed. Removed before commit.
- Slight divergence from older examples noted in the body: relaxed env-var requirement so `community:` defaults work without a 3-line setup. Aligns with how the Rust example I just shipped behaves.

**Rule 2 — No deferred bugs.** None found in path. The example compiles cleanly with the current Go SDK and against the v7.7.0 platform.

## ⛔ Do not merge — V1.1 release window

Per the `feedback_v1_1_no_merge_during_release_window.md` guideline. V1.1 is the next coordinated release train; nothing lands on `main` across V1.1-related PRs until the user explicitly authorizes the V1.1 release.

## Skip-runtime-e2e justification

This SDK PR is runtime-tested by the repo's existing `integration.yml` workflow, which brings up the AxonFlow community stack via docker compose and runs every example end-to-end against it. Adding a parallel `runtime-e2e/<feature>/` subdir would duplicate that flow without adding signal.

Manual runtime proof for this PR (live stack, command + wire dump) is captured in the PR body above. The community-stack integration.yml run on this branch is the automated equivalent.

Pattern matches the existing Rust SDK convention where examples double as runtime tests (axonflow-sdk-rust commit `2360282`).