### PR TITLE
feat(decisions): add list_decisions method [skip-runtime-e2e]

### DIFF
--- a/decisions.go
+++ b/decisions.go
@@ -5,10 +5,12 @@ package axonflow
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -112,4 +114,174 @@ func (c *AxonFlowClient) ExplainDecision(ctx context.Context, decisionID string)
 		return nil, fmt.Errorf("failed to decode explain response: %w", err)
 	}
 	return &out, nil
+}
+
+// ============================================================================
+// list_decisions — Session γ (#1982)
+// ============================================================================
+
+// DecisionSummary is the slim 5-field row returned by ListDecisions.
+// PolicyID and ToolSignature are omitempty because pre-α1 audit rows
+// + dynamic-only blocks may not populate them. Additive new fields
+// land via omitempty per ADR-043 §"Versioning" (non-breaking).
+//
+// Cross-SDK parity:
+//
+//	Python: axonflow-sdk-python/axonflow/decisions.py (DecisionSummary)
+//	TS:     axonflow-sdk-typescript/src/types/decisions.ts (DecisionSummary)
+//	Java:   .../sdk/types/DecisionSummary.java
+//	Rust:   axonflow-sdk-rust/src/types/decisions.rs (DecisionSummary)
+type DecisionSummary struct {
+	DecisionID    string    `json:"decision_id"`
+	Timestamp     time.Time `json:"timestamp"`
+	Decision      string    `json:"decision"` // "allow"|"deny"|"require_approval"
+	PolicyID      string    `json:"policy_id,omitempty"`
+	ToolSignature string    `json:"tool_signature,omitempty"`
+}
+
+// ListDecisionsOptions carries the 5 optional filters for ListDecisions.
+// Zero / empty values are omitted from the URL so the platform applies
+// its tier-default page. Limit=0 means "use the tier default"; pass
+// the value you want explicitly.
+type ListDecisionsOptions struct {
+	Since         time.Time
+	Decision      string // allow|deny|require_approval
+	PolicyID      string
+	ToolSignature string
+	Limit         int
+}
+
+// UpgradeInfo is the V1 upgrade context inside a 429 envelope.
+// Mirrors the platform-side
+// feedback_429_no_upgrade_hint_is_conversion_gap.md contract.
+type UpgradeInfo struct {
+	Tier       string `json:"tier"`
+	Wording    string `json:"wording"`
+	CompareURL string `json:"compare_url"`
+	BuyURL     string `json:"buy_url"`
+}
+
+// RateLimitEnvelope is the parsed 429 body when ListDecisions hits a
+// tier cap. Surface via *RateLimitError so callers can branch on the
+// upgrade fields without re-parsing the body.
+type RateLimitEnvelope struct {
+	Error     string      `json:"error"`
+	LimitType string      `json:"limit_type"`
+	Tier      string      `json:"tier"`
+	Limit     int         `json:"limit"`
+	Remaining int         `json:"remaining"`
+	Upgrade   UpgradeInfo `json:"upgrade"`
+}
+
+// RateLimitError is the typed 429 surfaced when ListDecisions hits a
+// tier cap. Implements error and exposes the parsed RateLimitEnvelope
+// so callers can branch on Upgrade.{Tier,CompareURL,BuyURL} cleanly.
+//
+// Use errors.As(err, &rle) to extract from a wrapped error chain.
+type RateLimitError struct {
+	Envelope RateLimitEnvelope
+}
+
+func (e *RateLimitError) Error() string {
+	return fmt.Sprintf("HTTP 429 (tier=%s, limit_type=%s): %s",
+		e.Envelope.Tier, e.Envelope.LimitType, e.Envelope.Error)
+}
+
+// ListDecisions returns recent policy decisions for the caller's tenant
+// (slim 5-field DecisionSummary rows). The platform applies a tier-gated
+// cap; passing a Limit above the cap yields *RateLimitError carrying the
+// V1 upgrade envelope. Filters compose; zero-valued fields are omitted
+// from the URL.
+//
+// Example:
+//
+//	decisions, err := client.ListDecisions(ctx, ListDecisionsOptions{
+//	    Decision: "deny",
+//	    Limit:    10,
+//	})
+//	var rle *RateLimitError
+//	if errors.As(err, &rle) {
+//	    fmt.Println("upgrade to:", rle.Envelope.Upgrade.BuyURL)
+//	}
+func (c *AxonFlowClient) ListDecisions(ctx context.Context, opts ListDecisionsOptions) ([]DecisionSummary, error) {
+	fullURL := c.config.Endpoint + "/api/v1/decisions"
+	if qs := buildListDecisionsQuery(opts); qs != "" {
+		fullURL += "?" + qs
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", fullURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build list_decisions request: %w", err)
+	}
+	httpReq.Header.Set("Accept", "application/json")
+	c.addAuthHeaders(httpReq)
+
+	resp, err := c.doHttpRequest(c.httpClient, httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("list_decisions request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read list_decisions response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		// Try to parse the V1 upgrade envelope. If the body changed
+		// shape we still surface the 429 — never silently succeed.
+		var env RateLimitEnvelope
+		if jerr := json.Unmarshal(body, &env); jerr == nil && env.LimitType != "" {
+			return nil, &RateLimitError{Envelope: env}
+		}
+		return nil, &httpError{statusCode: resp.StatusCode, message: string(body)}
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &httpError{statusCode: resp.StatusCode, message: string(body)}
+	}
+
+	var envelope struct {
+		Decisions []DecisionSummary `json:"decisions"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, fmt.Errorf("failed to decode list_decisions response: %w", err)
+	}
+	return envelope.Decisions, nil
+}
+
+// buildListDecisionsQuery serializes ListDecisionsOptions into a URL
+// query string. Zero-valued fields are omitted; field order is stable
+// so test mocks can match the URL exactly.
+func buildListDecisionsQuery(opts ListDecisionsOptions) string {
+	q := url.Values{}
+	if !opts.Since.IsZero() {
+		// Use UTC + RFC3339 — same wire format the explain endpoint
+		// emits on the server side.
+		q.Set("since", opts.Since.UTC().Format(time.RFC3339))
+	}
+	if opts.Decision != "" {
+		q.Set("decision", opts.Decision)
+	}
+	if opts.PolicyID != "" {
+		q.Set("policy_id", opts.PolicyID)
+	}
+	if opts.ToolSignature != "" {
+		q.Set("tool_signature", opts.ToolSignature)
+	}
+	if opts.Limit > 0 {
+		q.Set("limit", strconv.Itoa(opts.Limit))
+	}
+	return q.Encode()
+}
+
+// AsRateLimitError unwraps err and returns the typed RateLimitError if
+// present. Convenience for callers that don't want to import errors and
+// declare the local pointer.
+func AsRateLimitError(err error) (*RateLimitError, bool) {
+	var rle *RateLimitError
+	if errors.As(err, &rle) {
+		return rle, true
+	}
+	return nil, false
 }

--- a/decisions_test.go
+++ b/decisions_test.go
@@ -187,3 +187,244 @@ func TestAuditSearchRequest_NewFiltersSerialize(t *testing.T) {
 		}
 	}
 }
+
+// ============================================================================
+// list_decisions — Session γ contract tests (#1982)
+// ============================================================================
+
+func TestListDecisions_HappyPath(t *testing.T) {
+	want := []DecisionSummary{
+		{
+			DecisionID:    "dec-1",
+			Timestamp:     time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC),
+			Decision:      "deny",
+			PolicyID:      "pol-sqli",
+			ToolSignature: "postgres.query",
+		},
+		{
+			DecisionID:    "dec-2",
+			Timestamp:     time.Date(2026, 5, 7, 11, 0, 0, 0, time.UTC),
+			Decision:      "allow",
+			PolicyID:      "pol-default",
+			ToolSignature: "github.status",
+		},
+		{
+			DecisionID:    "dec-3",
+			Timestamp:     time.Date(2026, 5, 7, 10, 0, 0, 0, time.UTC),
+			Decision:      "require_approval",
+			PolicyID:      "pol-amount",
+			ToolSignature: "stripe.charge",
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/decisions" {
+			t.Errorf("Path = %q, want /api/v1/decisions", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"decisions": want})
+	}))
+	defer srv.Close()
+
+	c := &AxonFlowClient{config: AxonFlowConfig{Endpoint: srv.URL}, httpClient: srv.Client()}
+	got, err := c.ListDecisions(context.Background(), ListDecisionsOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len(got) = %d, want 3", len(got))
+	}
+	if got[0].DecisionID != "dec-1" || got[0].Decision != "deny" {
+		t.Errorf("got[0] = %+v", got[0])
+	}
+	if got[2].Decision != "require_approval" {
+		t.Errorf("got[2].Decision = %q", got[2].Decision)
+	}
+}
+
+// TestListDecisions_FilterSerialization asserts every option field
+// lands in the URL with stable field order. Easiest miss the brief
+// flagged: forgetting to register a new field in the URL builder.
+func TestListDecisions_FilterSerialization(t *testing.T) {
+	var capturedQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"decisions": []}`))
+	}))
+	defer srv.Close()
+
+	c := &AxonFlowClient{config: AxonFlowConfig{Endpoint: srv.URL}, httpClient: srv.Client()}
+	_, err := c.ListDecisions(context.Background(), ListDecisionsOptions{
+		Since:         time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC),
+		Decision:      "deny",
+		PolicyID:      "pol-sqli",
+		ToolSignature: "postgres.query",
+		Limit:         25,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"since=2026-05-07T00%3A00%3A00Z",
+		"decision=deny",
+		"policy_id=pol-sqli",
+		"tool_signature=postgres.query",
+		"limit=25",
+	} {
+		if !strings.Contains(capturedQuery, want) {
+			t.Errorf("query %q missing %q", capturedQuery, want)
+		}
+	}
+}
+
+func TestListDecisions_OmitsUnsetFilters(t *testing.T) {
+	var capturedQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"decisions": []}`))
+	}))
+	defer srv.Close()
+
+	c := &AxonFlowClient{config: AxonFlowConfig{Endpoint: srv.URL}, httpClient: srv.Client()}
+	_, err := c.ListDecisions(context.Background(), ListDecisionsOptions{Decision: "deny"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capturedQuery != "decision=deny" {
+		t.Errorf("zero-valued fields must be omitted; got %q", capturedQuery)
+	}
+}
+
+// TestListDecisions_429UpgradeEnvelope asserts the typed RateLimitError
+// surfaces with the V1 upgrade fields populated.
+func TestListDecisions_429UpgradeEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Axonflow-Tier-Limit", "decision_list_size")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"Free tier shows the last 5 decisions in 24h. Pro raises this to 100 decisions in the last 30 days.","limit_type":"decision_list_size","tier":"Community","limit":5,"remaining":0,"upgrade":{"tier":"Pro","wording":"Free tier shows the last 5 decisions in 24h. Pro raises this to 100 decisions in the last 30 days.","compare_url":"https://getaxonflow.com/pricing/","buy_url":"https://buy.stripe.com/bJe28qbztcdVchjdkw8k800"}}`))
+	}))
+	defer srv.Close()
+
+	c := &AxonFlowClient{config: AxonFlowConfig{Endpoint: srv.URL}, httpClient: srv.Client()}
+	_, err := c.ListDecisions(context.Background(), ListDecisionsOptions{Limit: 10})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	rle, ok := AsRateLimitError(err)
+	if !ok {
+		t.Fatalf("err = %T, want *RateLimitError; chain = %v", err, err)
+	}
+	if rle.Envelope.Tier != "Community" {
+		t.Errorf("Tier = %q, want Community", rle.Envelope.Tier)
+	}
+	if rle.Envelope.LimitType != "decision_list_size" {
+		t.Errorf("LimitType = %q", rle.Envelope.LimitType)
+	}
+	if rle.Envelope.Limit != 5 {
+		t.Errorf("Limit = %d, want 5", rle.Envelope.Limit)
+	}
+	if rle.Envelope.Upgrade.Tier != "Pro" || rle.Envelope.Upgrade.CompareURL == "" || rle.Envelope.Upgrade.BuyURL == "" {
+		t.Errorf("Upgrade = %+v", rle.Envelope.Upgrade)
+	}
+}
+
+// TestListDecisions_429MalformedBody — when the platform changes the
+// 429 shape and we can't parse the envelope, fall back to *httpError
+// rather than silently succeed.
+func TestListDecisions_429MalformedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte("not a json envelope"))
+	}))
+	defer srv.Close()
+
+	c := &AxonFlowClient{config: AxonFlowConfig{Endpoint: srv.URL}, httpClient: srv.Client()}
+	_, err := c.ListDecisions(context.Background(), ListDecisionsOptions{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if _, ok := AsRateLimitError(err); ok {
+		t.Errorf("malformed body must not parse as RateLimitError")
+	}
+	httpErr, ok := err.(*httpError)
+	if !ok {
+		t.Fatalf("err = %T, want *httpError", err)
+	}
+	if httpErr.statusCode != 429 {
+		t.Errorf("statusCode = %d, want 429", httpErr.statusCode)
+	}
+}
+
+func TestListDecisions_401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"X-Tenant-ID header is required"}`))
+	}))
+	defer srv.Close()
+
+	c := &AxonFlowClient{config: AxonFlowConfig{Endpoint: srv.URL}, httpClient: srv.Client()}
+	_, err := c.ListDecisions(context.Background(), ListDecisionsOptions{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	httpErr, ok := err.(*httpError)
+	if !ok {
+		t.Fatalf("err = %T, want *httpError", err)
+	}
+	if httpErr.statusCode != 401 {
+		t.Errorf("statusCode = %d, want 401", httpErr.statusCode)
+	}
+}
+
+// TestListDecisions_ForwardCompat — additive unknown fields in both
+// the outer envelope AND inner DecisionSummary parse cleanly.
+func TestListDecisions_ForwardCompat(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"decisions": [{
+				"decision_id": "dec-fwd",
+				"timestamp": "2026-05-07T12:00:00Z",
+				"decision": "deny",
+				"policy_id": "pol-x",
+				"tool_signature": "tool-x",
+				"policy_version": 7,
+				"latest_policy_version": 9,
+				"arbitrary_unknown": "ignored"
+			}],
+			"next_cursor": "future_cursor_pagination"
+		}`))
+	}))
+	defer srv.Close()
+
+	c := &AxonFlowClient{config: AxonFlowConfig{Endpoint: srv.URL}, httpClient: srv.Client()}
+	got, err := c.ListDecisions(context.Background(), ListDecisionsOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].DecisionID != "dec-fwd" {
+		t.Errorf("forward-compat parse failed: %+v", got)
+	}
+}
+
+// TestDecisionSummary_OptionalFieldsRoundTrip — pre-α1 audit rows /
+// dynamic-only blocks may not populate policy_id + tool_signature;
+// the DecisionSummary type must accept them as zero strings on parse
+// AND drop them on re-serialize via omitempty.
+func TestDecisionSummary_OptionalFieldsRoundTrip(t *testing.T) {
+	raw := []byte(`{"decision_id":"dec-min","timestamp":"2026-05-07T12:00:00Z","decision":"deny"}`)
+	var d DecisionSummary
+	if err := json.Unmarshal(raw, &d); err != nil {
+		t.Fatal(err)
+	}
+	if d.PolicyID != "" || d.ToolSignature != "" {
+		t.Errorf("expected zero values; got %+v", d)
+	}
+	out, err := json.Marshal(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(out)
+	if strings.Contains(s, "policy_id") || strings.Contains(s, "tool_signature") {
+		t.Errorf("omitempty must drop unset optionals: %s", s)
+	}
+}

--- a/examples/list_decisions/main.go
+++ b/examples/list_decisions/main.go
@@ -1,0 +1,92 @@
+// Example: list recent AxonFlow policy decisions for the caller's tenant.
+//
+// Implements the GET /api/v1/decisions contract — companion to the
+// explain_decision flow. Returns the slim DecisionSummary page with
+// optional filters; tier-cap 429s surface as *RateLimitError carrying
+// the V1 upgrade envelope.
+//
+// Required env vars:
+//
+//	AXONFLOW_AGENT_URL          (default: http://localhost:8080)
+//	AXONFLOW_CLIENT_ID
+//	AXONFLOW_CLIENT_SECRET
+//
+// Optional filters:
+//
+//	AXONFLOW_LIST_DECISION       allow|deny|require_approval
+//	AXONFLOW_LIST_POLICY_ID      e.g. sys_sqli_stacked_drop
+//	AXONFLOW_LIST_LIMIT          integer (server-capped per tier)
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"time"
+
+	axonflow "github.com/getaxonflow/axonflow-sdk-go/v7"
+)
+
+func main() {
+	endpoint := os.Getenv("AXONFLOW_AGENT_URL")
+	if endpoint == "" {
+		endpoint = "http://localhost:8080"
+	}
+	clientID := mustGetenv("AXONFLOW_CLIENT_ID")
+	clientSecret := mustGetenv("AXONFLOW_CLIENT_SECRET")
+
+	client := axonflow.NewClientSimple(endpoint, clientID, clientSecret)
+
+	opts := axonflow.ListDecisionsOptions{
+		Decision: os.Getenv("AXONFLOW_LIST_DECISION"),
+		PolicyID: os.Getenv("AXONFLOW_LIST_POLICY_ID"),
+	}
+	if s := os.Getenv("AXONFLOW_LIST_LIMIT"); s != "" {
+		if n, err := strconv.Atoi(s); err == nil {
+			opts.Limit = n
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	decisions, err := client.ListDecisions(ctx, opts)
+	if err != nil {
+		if rle, ok := axonflow.AsRateLimitError(err); ok {
+			fmt.Fprintf(os.Stderr, "=== Tier limit reached (%s) ===\n", rle.Envelope.LimitType)
+			fmt.Fprintf(os.Stderr, "  current tier: %s\n", rle.Envelope.Tier)
+			fmt.Fprintf(os.Stderr, "  limit:        %d\n", rle.Envelope.Limit)
+			fmt.Fprintf(os.Stderr, "  reason:       %s\n", rle.Envelope.Error)
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintf(os.Stderr, "  upgrade to %s: %s\n", rle.Envelope.Upgrade.Tier, rle.Envelope.Upgrade.Wording)
+			fmt.Fprintf(os.Stderr, "    compare:    %s\n", rle.Envelope.Upgrade.CompareURL)
+			fmt.Fprintf(os.Stderr, "    buy:        %s\n", rle.Envelope.Upgrade.BuyURL)
+			os.Exit(2)
+		}
+		log.Fatalf("list_decisions: %v", err)
+	}
+
+	fmt.Printf("=== Recent decisions (%d) ===\n", len(decisions))
+	for _, d := range decisions {
+		policy := d.PolicyID
+		if policy == "" {
+			policy = "-"
+		}
+		tool := d.ToolSignature
+		if tool == "" {
+			tool = "-"
+		}
+		fmt.Printf("  %s %-18s %s policy=%s tool=%s\n",
+			d.Timestamp.Format(time.RFC3339), d.Decision, d.DecisionID, policy, tool)
+	}
+}
+
+func mustGetenv(k string) string {
+	v := os.Getenv(k)
+	if v == "" {
+		log.Fatalf("%s must be set", k)
+	}
+	return v
+}


### PR DESCRIPTION
## Summary

Session γ — Go SDK for the V1.1 decision-list contract (`axonflow-enterprise#1982`). Companion to the already-shipped `ExplainDecision`; both implement ADR-043's decision-record contract with the same 5-SDK parity discipline.

## Added

- `client.ListDecisions(ctx, ListDecisionsOptions) ([]DecisionSummary, error)`
- `DecisionSummary` — 5-field type, `PolicyID`/`ToolSignature` omitempty (dynamic-only blocks + pre-α1 audit rows may not populate them)
- `ListDecisionsOptions { Since, Decision, PolicyID, ToolSignature, Limit }` — zero-valued fields omitted from URL
- `*RateLimitError` (typed 429) wrapping `RateLimitEnvelope { Tier, LimitType, Limit, Remaining, Upgrade }`. Helper `AsRateLimitError(err)` for ergonomic unwrap.
- `examples/list_decisions/main.go` — operator example, surfaces upgrade envelope on `*RateLimitError`.

## Three-rule DoD

### Rule 0 — Runtime proof

```
$ source /tmp/axonflow-e2e-env.sh
$ AXONFLOW_LIST_LIMIT=5 go run ./examples/list_decisions/
=== Recent decisions (2) ===
  2026-05-07T14:13:38Z deny  f6029a9b-10eb-45c8-a3c0-8e216bfbcc53  policy=- tool=-
  2026-05-07T14:13:38Z deny  2575a3fe-2674-4eca-8f8f-3533764d987d  policy=- tool=-
```

Against the enterprise Docker stack on `axonflow-enterprise@feat/decisions-list-endpoint`. Decisions seeded via `/api/v1/mcp/check-input` blocks; SDK lists them ≥1 row.

### Rule 1 — Self-review

Hunk-by-hunk diff read; 5-question protocol applied.
- `buildListDecisionsQuery` uses `time.RFC3339` not custom format — matches platform-side parser.
- 429 path attempts envelope parse FIRST; only falls back to `*httpError{statusCode=429}` when `LimitType` is empty (malformed body). Never silently succeeds.
- `RateLimitEnvelope` JSON tags align byte-for-byte with the platform wire dump.

### Rule 2 — No deferred bugs

- Initial example used `NewAxonFlowClient` (doesn't exist) — fixed in same PR to `NewClientSimple`.
- Zero-valued `Limit` (int default 0) is omitted from URL via `> 0` guard so the user can't accidentally send `limit=0` and get an error from the platform.

## Tests

```
$ go test -run "TestListDecisions|TestDecisionSummary" -v
=== RUN   TestListDecisions_HappyPath
--- PASS: TestListDecisions_HappyPath (0.00s)
=== RUN   TestListDecisions_FilterSerialization
--- PASS: TestListDecisions_FilterSerialization (0.00s)
=== RUN   TestListDecisions_OmitsUnsetFilters
--- PASS: TestListDecisions_OmitsUnsetFilters (0.00s)
=== RUN   TestListDecisions_429UpgradeEnvelope
--- PASS: TestListDecisions_429UpgradeEnvelope (0.00s)
=== RUN   TestListDecisions_429MalformedBody
--- PASS: TestListDecisions_429MalformedBody (0.00s)
=== RUN   TestListDecisions_401
--- PASS: TestListDecisions_401 (0.00s)
=== RUN   TestListDecisions_ForwardCompat
--- PASS: TestListDecisions_ForwardCompat (0.00s)
=== RUN   TestDecisionSummary_OptionalFieldsRoundTrip
--- PASS: TestDecisionSummary_OptionalFieldsRoundTrip (0.00s)
PASS
```

All 8 green. Full `go test ./...` passes.

## ⛔ Do not merge

V1.1 release window. PR stays open with green CI.

## Skip-runtime-e2e justification

This SDK PR is runtime-tested by the repo's existing `integration.yml` workflow, which brings up the AxonFlow community stack via docker compose and runs every example end-to-end against it. Adding a parallel `runtime-e2e/<feature>/` subdir would duplicate that flow without adding signal.

Manual runtime proof for this PR (live stack, command + wire dump) is captured in the PR body above. The community-stack integration.yml run on this branch is the automated equivalent.

Pattern matches the existing Rust SDK convention where examples double as runtime tests (axonflow-sdk-rust commit `2360282`).