### PR TITLE
feat(telemetry): emit v1 schema fields [skip-runtime-e2e]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ the bottom of this entry for that.
   pings from production heartbeat — see the checkpoint-service
   `IsValidIncomingStream` allowlist for the wire-side gate.
 
+### Telemetry payload (v1 schema, axonflow-enterprise#2008)
+
+- New heartbeat fields: `telemetry_type: "sdk"`, `profile` (from `AXONFLOW_PROFILE`, `unknown` when unset), `deployment_mode` aligned to `self_hosted | community_saas | unknown` via `ClassifyDeploymentMode` (host + `AXONFLOW_TRY=1` override).
+- `ClassifyEndpoint` no longer returns `community-saas` — that value moved off endpoint_type onto deployment_mode; analytics queries on the legacy value must update.
+
 ## [7.1.0] - 2026-05-06 — X-Axonflow-Client header + scope-aware license validation
 
 **Companion release to platform v7.7.0.** The Go SDK now sends an

--- a/telemetry.go
+++ b/telemetry.go
@@ -23,25 +23,67 @@ const (
 
 // telemetryPayload is the JSON body sent to the checkpoint endpoint.
 type telemetryPayload struct {
+	// TelemetryType discriminates this ping for the v1 schema receiver
+	// (axonflow-enterprise#2008). Always "sdk" for clients of this package.
+	TelemetryType   string  `json:"telemetry_type"`
 	SDK             string  `json:"sdk"`
 	SDKVersion      string  `json:"sdk_version"`
 	PlatformVersion *string `json:"platform_version"`
 	OS              string  `json:"os"`
 	Arch            string  `json:"arch"`
 	RuntimeVersion  string  `json:"runtime_version"`
-	DeploymentMode  string  `json:"deployment_mode"`
+	// DeploymentMode is the v1 schema topology dimension:
+	// "self_hosted" | "community_saas" | "unknown". Derived from the
+	// configured endpoint host plus the explicit AXONFLOW_TRY=1
+	// override; see ClassifyDeploymentMode.
+	DeploymentMode string `json:"deployment_mode"`
 	// EndpointType: SDK-derived classification of the configured endpoint.
 	// One of: "localhost", "private_network", "remote", "unknown". See
 	// ClassifyEndpoint. The raw URL is never sent. Issue #1525.
 	EndpointType string   `json:"endpoint_type"`
 	Features     []string `json:"features"`
 	InstanceID   string   `json:"instance_id"`
+	// Profile is the free-form deployment profile from AXONFLOW_PROFILE
+	// (e.g. "production", "staging", "dev"); reports "unknown" when
+	// unset. Analytics dimension only; no behavioural effect.
+	Profile string `json:"profile"`
 	// Stream classifies the heartbeat sub-stream. Sandbox-mode clients emit
 	// "sandbox" so analytics can distinguish dev/test pings from production
 	// pings without conflating them; production-mode clients omit the field
 	// and the server defaults to "heartbeat". The wire-allowlist is enforced
 	// server-side — see checkpoint-service IsValidIncomingStream.
 	Stream string `json:"stream,omitempty"`
+}
+
+// DeploymentMode classifications for telemetry (v1 schema, axonflow-enterprise#2008).
+const (
+	DeploymentModeSelfHosted    = "self_hosted"
+	DeploymentModeCommunitySaaS = "community_saas"
+	DeploymentModeUnknown       = "unknown"
+)
+
+// ClassifyDeploymentMode classifies the configured AxonFlow endpoint into
+// the v1 deployment-mode allowlist (self_hosted | community_saas | unknown).
+// Community-SaaS is detected from either an *.try.getaxonflow.com host or
+// AXONFLOW_TRY=1 (the explicit override path for tenants behind a custom
+// hostname proxying try.getaxonflow.com). Empty/unparseable endpoint
+// resolves to "unknown" rather than defaulting to "self_hosted".
+func ClassifyDeploymentMode(endpoint string) string {
+	if os.Getenv("AXONFLOW_TRY") == "1" {
+		return DeploymentModeCommunitySaaS
+	}
+	if endpoint == "" {
+		return DeploymentModeUnknown
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Hostname() == "" {
+		return DeploymentModeUnknown
+	}
+	host := strings.ToLower(u.Hostname())
+	if host == "try.getaxonflow.com" || strings.HasSuffix(host, ".try.getaxonflow.com") {
+		return DeploymentModeCommunitySaaS
+	}
+	return DeploymentModeSelfHosted
 }
 
 // EndpointType classifications for telemetry.
@@ -63,10 +105,11 @@ const (
 //     and the suffixes .local, .internal, .lan, .intranet
 //   - "remote": everything else
 //   - "unknown": on parse failure
+//
+// As of v8.0 the legacy "community-saas" return value is removed —
+// deployment topology lives on `deployment_mode` (see ClassifyDeploymentMode)
+// per the v1 schema (axonflow-enterprise#2008).
 func ClassifyEndpoint(endpoint string) string {
-	if os.Getenv("AXONFLOW_TRY") == "1" {
-		return "community-saas"
-	}
 	if endpoint == "" {
 		return EndpointTypeUnknown
 	}
@@ -215,10 +258,18 @@ func (c *AxonFlowClient) sendTelemetryPingNow(ctx context.Context) error {
 		checkpointURL = defaultCheckpointURL
 	}
 
-	// Determine deployment mode.
-	deploymentMode := c.config.Mode
-	if deploymentMode == "" {
-		deploymentMode = "production"
+	// v1 telemetry-schema (axonflow-enterprise#2008) deployment_mode classifier.
+	// The prior config.Mode-based "production"/"development" split is removed —
+	// the dimension now reflects deployment topology only: self_hosted |
+	// community_saas | unknown.
+	deploymentMode := ClassifyDeploymentMode(c.config.Endpoint)
+
+	// v1 telemetry-schema profile dimension. Free-form deployment classifier
+	// (e.g. "production", "staging", "dev") sourced from AXONFLOW_PROFILE;
+	// reports "unknown" when unset. Analytics dimension only.
+	profile := strings.TrimSpace(os.Getenv("AXONFLOW_PROFILE"))
+	if profile == "" {
+		profile = "unknown"
 	}
 
 	// Detect platform version from health endpoint (uses the shared deadline).
@@ -235,6 +286,7 @@ func (c *AxonFlowClient) sendTelemetryPingNow(ctx context.Context) error {
 	}
 
 	payload := telemetryPayload{
+		TelemetryType:   "sdk",
 		SDK:             "go",
 		SDKVersion:      Version,
 		PlatformVersion: platformVersion,
@@ -245,6 +297,7 @@ func (c *AxonFlowClient) sendTelemetryPingNow(ctx context.Context) error {
 		EndpointType:    ClassifyEndpoint(c.config.Endpoint),
 		Features:        []string{},
 		InstanceID:      generateInstanceID(),
+		Profile:         profile,
 		Stream:          stream,
 	}
 

--- a/telemetry_test.go
+++ b/telemetry_test.go
@@ -179,8 +179,16 @@ func TestSendTelemetryPing_Success(t *testing.T) {
 	if strings.HasPrefix(received.RuntimeVersion, "go") {
 		t.Errorf("runtime_version should not have 'go' prefix, got %q", received.RuntimeVersion)
 	}
-	if received.DeploymentMode != "production" {
-		t.Errorf("expected deployment_mode=production, got %q", received.DeploymentMode)
+	// v1 telemetry-schema: deployment_mode now derives from endpoint host
+	// (not config.Mode). Empty endpoint resolves to "unknown".
+	if received.DeploymentMode != "unknown" {
+		t.Errorf("expected deployment_mode=unknown (empty endpoint), got %q", received.DeploymentMode)
+	}
+	if received.TelemetryType != "sdk" {
+		t.Errorf("expected telemetry_type=sdk, got %q", received.TelemetryType)
+	}
+	if received.Profile != "unknown" {
+		t.Errorf("expected profile=unknown (AXONFLOW_PROFILE unset), got %q", received.Profile)
 	}
 	if received.Features == nil {
 		t.Error("expected features to be non-nil (empty array)")
@@ -324,15 +332,26 @@ func TestSendTelemetryPing_InvalidURL(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// buildPayload tests (test #12: mode propagated)
+// buildPayload tests
 // ---------------------------------------------------------------------------
 
 func TestBuildPayload(t *testing.T) {
 	t.Setenv("AXONFLOW_TELEMETRY", "")
-	t.Run("mode propagated to deployment_mode", func(t *testing.T) {
-		modes := []string{"production", "sandbox", "staging", "development"}
-		for _, mode := range modes {
-			t.Run(mode, func(t *testing.T) {
+	t.Run("deployment_mode classifies from endpoint host (v1 schema)", func(t *testing.T) {
+		cases := []struct {
+			name     string
+			endpoint string
+			tryFlag  string
+			want     string
+		}{
+			{"try.getaxonflow.com", "https://try.getaxonflow.com", "", "community_saas"},
+			{"AXONFLOW_TRY=1 wins on remote host", "https://my-proxy.example.com", "1", "community_saas"},
+			{"public host -> self_hosted", "https://api.example.com", "", "self_hosted"},
+			{"unparseable -> unknown", "not a url", "", "unknown"},
+			{"empty -> unknown", "", "", "unknown"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
 				var received telemetryPayload
 
 				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -342,10 +361,12 @@ func TestBuildPayload(t *testing.T) {
 				defer srv.Close()
 
 				t.Setenv("AXONFLOW_CHECKPOINT_URL", srv.URL)
+				t.Setenv("AXONFLOW_TRY", tc.tryFlag)
 
 				client := &AxonFlowClient{
 					config: AxonFlowConfig{
-						Mode:         mode,
+						Endpoint:     tc.endpoint,
+						Mode:         "production",
 						ClientID:     "id",
 						ClientSecret: "sec",
 					},
@@ -353,35 +374,46 @@ func TestBuildPayload(t *testing.T) {
 
 				client.sendTelemetryPing()
 
-				if received.DeploymentMode != mode {
-					t.Errorf("expected deployment_mode=%q, got %q", mode, received.DeploymentMode)
+				if received.DeploymentMode != tc.want {
+					t.Errorf("expected deployment_mode=%q, got %q", tc.want, received.DeploymentMode)
+				}
+				if received.TelemetryType != "sdk" {
+					t.Errorf("expected telemetry_type=sdk, got %q", received.TelemetryType)
 				}
 			})
 		}
 	})
 
-	t.Run("empty mode defaults to production", func(t *testing.T) {
-		var received telemetryPayload
-
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			json.NewDecoder(r.Body).Decode(&received)
-			json.NewEncoder(w).Encode(telemetryResponse{LatestVersion: Version})
-		}))
-		defer srv.Close()
-
-		t.Setenv("AXONFLOW_CHECKPOINT_URL", srv.URL)
-
-		client := &AxonFlowClient{
-			config: AxonFlowConfig{
-				ClientID:     "id",
-				ClientSecret: "sec",
-			},
+	t.Run("profile from AXONFLOW_PROFILE; unknown when unset", func(t *testing.T) {
+		cases := []struct {
+			env  string
+			want string
+		}{
+			{"", "unknown"},
+			{"production", "production"},
+			{"staging", "staging"},
 		}
+		for _, tc := range cases {
+			t.Run(tc.want, func(t *testing.T) {
+				var received telemetryPayload
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					json.NewDecoder(r.Body).Decode(&received)
+					json.NewEncoder(w).Encode(telemetryResponse{LatestVersion: Version})
+				}))
+				defer srv.Close()
 
-		client.sendTelemetryPing()
+				t.Setenv("AXONFLOW_CHECKPOINT_URL", srv.URL)
+				t.Setenv("AXONFLOW_PROFILE", tc.env)
 
-		if received.DeploymentMode != "production" {
-			t.Errorf("expected deployment_mode=production when mode is empty, got %q", received.DeploymentMode)
+				client := &AxonFlowClient{
+					config: AxonFlowConfig{Mode: "production", ClientID: "id", ClientSecret: "sec"},
+				}
+				client.sendTelemetryPing()
+
+				if received.Profile != tc.want {
+					t.Errorf("expected profile=%q, got %q", tc.want, received.Profile)
+				}
+			})
 		}
 	})
 
@@ -459,8 +491,10 @@ func TestSendTelemetryPing_SandboxFiresWithStreamTag(t *testing.T) {
 	if received.Stream != "sandbox" {
 		t.Errorf("expected payload Stream=%q, got %q", "sandbox", received.Stream)
 	}
-	if received.DeploymentMode != "sandbox" {
-		t.Errorf("expected payload DeploymentMode=%q, got %q", "sandbox", received.DeploymentMode)
+	// v1 schema: deployment_mode classifies from endpoint host, not config.Mode.
+	// The empty endpoint here resolves to "unknown".
+	if received.DeploymentMode != "unknown" {
+		t.Errorf("expected payload DeploymentMode=%q (empty endpoint), got %q", "unknown", received.DeploymentMode)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes the #2007 contract (axonflow-enterprise) on top of v8.0. v8.0 shipped the `TelemetryEnabled` field removal + `stream` classifier; this patch adds the three remaining v1 schema fields. Additive on the v8.0 line — **no version bump**, joins v8.0 before tagging.

## What changes on the wire

| Field | Behavior |
|---|---|
| `telemetry_type` | hardcoded `"sdk"` |
| `profile` | from `AXONFLOW_PROFILE` env; `"unknown"` when unset |
| `deployment_mode` | `self_hosted \| community_saas \| unknown` via `ClassifyDeploymentMode` (endpoint host + `AXONFLOW_TRY=1` override) |
| `ClassifyEndpoint` | drops `"community-saas"` return — topology lives on `deployment_mode` in v1 |

## Definition of Done

### 1. Tested
- `go test ./...` PASS, `go vet ./...` clean, `go build ./...` clean.
- New `TestBuildPayload` cases cover try.getaxonflow.com, `AXONFLOW_TRY=1` override, public host, unparseable, empty endpoint, plus `AXONFLOW_PROFILE` env permutations.

### 2. Deep self-reviewed
Hunk-by-hunk per the 5-question protocol:
- `telemetry.go`: payload struct gains 3 fields; new `ClassifyDeploymentMode` + constants; `sendTelemetryPingNow` populates them. `ClassifyEndpoint` doc updated to call out the v8 removal of `"community-saas"`.
- `telemetry_test.go`: assertions on `DeploymentMode == "production"` migrated to the new endpoint-derived behavior; `TestBuildPayload` "mode propagated" subtest replaced with v1-schema endpoint-classifier subtable + profile subtable.
- `CHANGELOG.md`: 2-bullet, 5-line addition at end of v8.0 entry.

### 3. Runtime-proven
The existing `tests/heartbeat-real-stack/` cross-platform CI workflow exercises `NewClient` against a Python fake checkpoint server, captures the actual ping payload, and runs across Ubuntu / macOS / Windows. The new fields ship in that same payload and will be observable in the wire capture.

## Linked
- axonflow-enterprise#2007 — SDK telemetry consolidation umbrella
- axonflow-enterprise#2008 — sibling plugin umbrella (4 plugins MERGED with same v1 schema)

## Skip-runtime-e2e justification

The v1 schema fields (telemetry_type, profile, deployment_mode) are additive payload extensions that flow through the existing telemetry code path. The pre-existing `runtime-e2e/sandbox_telemetry_stream_tag/` test already exercises that code path end-to-end against the deployed checkpoint Lambda, so the new fields will be observable on the wire when that test runs against a v8.0+ Lambda. Adding a near-duplicate runtime-e2e/ wrapper would not increase coverage.

Cross-SDK runtime parity is also validated via the heartbeat-real-stack pattern that the SDK ships in `tests/heartbeat-real-stack/` and that CI runs on every PR.