### PR TITLE
fix(telemetry): drop profile field [skip-runtime-e2e]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.0.1] - 2026-05-08 — Drop telemetry profile field
+
+### Removed
+
+- **`profile` field from telemetry payload** (was added in v8.0.0). The `AXONFLOW_PROFILE` env var collides with the existing governance enforcement env var (allowlist `dev|default|strict|compliance` per ADR-036), so emitting telemetry from a customer's correctly-configured governance profile (e.g. `strict`) would have produced HTTP 400 silent drops on the heartbeat path. The field had no analytics consumers in production yet — removing it is the cleanest fix. `deployment_mode` (`self_hosted | community_saas | unknown`) covers the topology dimension that `profile` was intended to add.
+
+### Migration
+
+- Customers who set `AXONFLOW_PROFILE` for governance enforcement on the agent: no change. The env var continues to be read by the agent for its original purpose.
+- Customers who set `AXONFLOW_PROFILE` solely to influence telemetry: no longer needed. The SDK no longer reads it for telemetry purposes.
+
 ## [8.0.0] - 2026-05-08 — Decision history API + telemetry simplification
 
 **Major release.** The headline feature is the new decision-history client API:

--- a/telemetry.go
+++ b/telemetry.go
@@ -43,10 +43,6 @@ type telemetryPayload struct {
 	EndpointType string   `json:"endpoint_type"`
 	Features     []string `json:"features"`
 	InstanceID   string   `json:"instance_id"`
-	// Profile is the free-form deployment profile from AXONFLOW_PROFILE
-	// (e.g. "production", "staging", "dev"); reports "unknown" when
-	// unset. Analytics dimension only; no behavioural effect.
-	Profile string `json:"profile"`
 	// Stream classifies the heartbeat sub-stream. Sandbox-mode clients emit
 	// "sandbox" so analytics can distinguish dev/test pings from production
 	// pings without conflating them; production-mode clients omit the field
@@ -264,14 +260,6 @@ func (c *AxonFlowClient) sendTelemetryPingNow(ctx context.Context) error {
 	// community_saas | unknown.
 	deploymentMode := ClassifyDeploymentMode(c.config.Endpoint)
 
-	// v1 telemetry-schema profile dimension. Free-form deployment classifier
-	// (e.g. "production", "staging", "dev") sourced from AXONFLOW_PROFILE;
-	// reports "unknown" when unset. Analytics dimension only.
-	profile := strings.TrimSpace(os.Getenv("AXONFLOW_PROFILE"))
-	if profile == "" {
-		profile = "unknown"
-	}
-
 	// Detect platform version from health endpoint (uses the shared deadline).
 	platformVersion := detectPlatformVersion(ctx, c.config.Endpoint)
 
@@ -297,7 +285,6 @@ func (c *AxonFlowClient) sendTelemetryPingNow(ctx context.Context) error {
 		EndpointType:    ClassifyEndpoint(c.config.Endpoint),
 		Features:        []string{},
 		InstanceID:      generateInstanceID(),
-		Profile:         profile,
 		Stream:          stream,
 	}
 

--- a/telemetry_test.go
+++ b/telemetry_test.go
@@ -187,9 +187,6 @@ func TestSendTelemetryPing_Success(t *testing.T) {
 	if received.TelemetryType != "sdk" {
 		t.Errorf("expected telemetry_type=sdk, got %q", received.TelemetryType)
 	}
-	if received.Profile != "unknown" {
-		t.Errorf("expected profile=unknown (AXONFLOW_PROFILE unset), got %q", received.Profile)
-	}
 	if received.Features == nil {
 		t.Error("expected features to be non-nil (empty array)")
 	}
@@ -379,39 +376,6 @@ func TestBuildPayload(t *testing.T) {
 				}
 				if received.TelemetryType != "sdk" {
 					t.Errorf("expected telemetry_type=sdk, got %q", received.TelemetryType)
-				}
-			})
-		}
-	})
-
-	t.Run("profile from AXONFLOW_PROFILE; unknown when unset", func(t *testing.T) {
-		cases := []struct {
-			env  string
-			want string
-		}{
-			{"", "unknown"},
-			{"production", "production"},
-			{"staging", "staging"},
-		}
-		for _, tc := range cases {
-			t.Run(tc.want, func(t *testing.T) {
-				var received telemetryPayload
-				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					json.NewDecoder(r.Body).Decode(&received)
-					json.NewEncoder(w).Encode(telemetryResponse{LatestVersion: Version})
-				}))
-				defer srv.Close()
-
-				t.Setenv("AXONFLOW_CHECKPOINT_URL", srv.URL)
-				t.Setenv("AXONFLOW_PROFILE", tc.env)
-
-				client := &AxonFlowClient{
-					config: AxonFlowConfig{Mode: "production", ClientID: "id", ClientSecret: "sec"},
-				}
-				client.sendTelemetryPing()
-
-				if received.Profile != tc.want {
-					t.Errorf("expected profile=%q, got %q", tc.want, received.Profile)
 				}
 			})
 		}

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package axonflow
 
 // Version is the SDK version.
-const Version = "8.0.0"
+const Version = "8.0.1"


### PR DESCRIPTION
## Summary

Drops the v1 telemetry `profile` field that was added in v8.0.0 (#161 / commit 15a448e). The `AXONFLOW_PROFILE` env var was already in use by the agent for governance enforcement (allowlist `dev|default|strict|compliance` per ADR-036), so emitting telemetry from a customer's correctly-configured governance profile (e.g. `strict`) would have produced HTTP 400 silent drops on the heartbeat path — the v1 telemetry validator accepts only `dev|prod|unknown`.

Refs getaxonflow/axonflow-enterprise#2033.

## Why drop instead of rename

1. **Env-var collision.** `AXONFLOW_PROFILE` is owned by the governance-enforcement layer (`platform/agent/profile.go`, `EnvProfile = "AXONFLOW_PROFILE"`) and has been since ADR-036. The v1 telemetry schema (#2004) picked the same name without grepping; the values do not overlap (`strict|compliance` vs `dev|prod|unknown`), so any customer who set the env var for governance would have started emitting 400-rejected pings.
2. **Zero analytics consumers.** A grep across `platform/`, `ee/`, and the analytics workflows for `Profile.S | .Profile\b | profile.*dimension` (excluding `_test.go` and the checkpoint-service) returns nothing — no aggregator, no daily-report dimension, no dashboard reads the field. Removing it loses no signal in use today.
3. **`deployment_mode` already covers the topology dimension** the field was meant to add: `self_hosted | community_saas | unknown`, single canonical form, no env-var collision, has analytics callers. Untouched by this PR.

Renaming would force a 9-repo coordinated bump just to allowlist-split a value nothing currently reads. Drop is the cleanest fix.

## Validator-vs-caller audit

```bash
$ grep -rn 'AXONFLOW_PROFILE\|Profile\b' --include='*.go' .
(no output)
```

Verified zero `AXONFLOW_PROFILE` / `Profile` references remain across the 4 changed files. `find . -name 'baseline*'` returned `testdata/wire_shape_baseline.json` — `grep -i 'profile'` against it: empty.

## Hunk-by-hunk self-review (HARD RULE #1)

For each of the 4 hunks, the 5-question protocol from `feedback_self_review_is_mandatory_every_pr.md`:

**Hunk 1 — `telemetry.go` struct field removal (3 lines doc + 1 line field).**
1. Does this match the intent in the PR title? Yes — drops the `Profile` field from `telemetryPayload`.
2. Are there any references that are now broken? `grep` confirms no — the only callers were the assignment site (Hunk 3) and tests (Hunks 5-6).
3. Backward-compat consideration? Server-side ignores unknown JSON fields per `json.Unmarshal` semantics; no client crashes from old-server-vs-new-client. Reverse direction (new server, old client emitting `profile`) is also fine — server will validate-and-drop or accept under the JSON unmarshaller.
4. Anything load-bearing about the doc comment? No — purely descriptive, references the field that no longer exists.
5. Does this leave any dead code? No — Hunks 2-3 remove the read + assignment.

**Hunk 2 — `telemetry.go` `os.Getenv("AXONFLOW_PROFILE")` read removal (8 lines).**
1. Intent match? Yes — removes the env-var read that was the collision source.
2. Broken refs? `profile` local var was used only in Hunk 3.
3. Imports unused? `strings` still used (TrimPrefix on runtime.Version, EqualFold + TrimSpace + ToLower elsewhere); `os` still used (Getenv for AXONFLOW_TELEMETRY etc). No orphan imports — `go build` confirms.
4. Side effects? None — pure read of env, no caller behavior change beyond not setting that one struct field.
5. Tests still cover the surrounding paths? Yes — `TestSendTelemetryPing_Success` + `TestBuildPayload` deployment_mode + stream subtests still run.

**Hunk 3 — `telemetry.go` payload literal `Profile: profile` removal (1 line).**
1. Intent match? Yes — removes the payload-side use site.
2. Compiles? `go build ./...` passes.
3. Tests? `go test ./...` passes 7.6s.
4. Field ordering / struct literal validity? Unchanged — Go allows omitting any field in a struct literal.
5. Any other emission site? No — `grep -rn 'telemetryPayload{' --include='*.go'` returns just this one (and tests that decode into the struct).

**Hunk 4 — `telemetry_test.go` removal of `received.Profile` assertion in `TestSendTelemetryPing_Success` (3 lines).**
1. Intent match? Yes — drops the assertion for the removed field.
2. Test still meaningful? Yes — `TestSendTelemetryPing_Success` retains assertions on TelemetryType, DeploymentMode, OS, Arch, RuntimeVersion, Features, InstanceID. Coverage of the heartbeat happy-path remains.
3. Other call sites for the same assertion? Hunks 5-6 cover the dedicated subtest.
4. Helper utilities deleted? None — pure assertion removal.
5. Race / setup change? None — same `t.Setenv` setup.

**Hunks 5-6 — `telemetry_test.go` removal of `t.Run("profile from AXONFLOW_PROFILE; unknown when unset", ...)` subtest (33 lines).**
1. Intent match? Yes — drops the dedicated profile-sourcing subtest entirely.
2. Other coverage? `TestBuildPayload` retains its `deployment_mode classifies from endpoint host` and `stream=sandbox tag emitted only for sandbox mode` subtests; both run independently of the dropped subtest.
3. Compiles? `go test -c ./...` passes.
4. No shared state? The dropped subtest used only `t.Setenv` (per-subtest scoped); no fixture cleanup needed.
5. Closing brace alignment? Verified — the next subtest (`stream=sandbox`) is indented correctly.

## Test results

```
$ go build ./... && go vet ./... && go test ./...
ok  	github.com/getaxonflow/axonflow-sdk-go/v8	7.642s
ok  	github.com/getaxonflow/axonflow-sdk-go/v8/interceptors	12.335s
ok  	github.com/getaxonflow/axonflow-sdk-go/v8/internal/wireshape	0.514s
```

All green. Wire-shape baseline (`testdata/wire_shape_baseline.json`) had no `profile` reference, so no baseline refresh needed.

## Migration notes

- Customers who set `AXONFLOW_PROFILE` for **governance enforcement** on the agent (the original ADR-036 use case): no change. The env var is read by the agent for that purpose unchanged.
- Customers who set `AXONFLOW_PROFILE` solely to **influence telemetry**: no longer needed — the SDK no longer reads it for telemetry. Telemetry's topology dimension lives on `deployment_mode` (auto-derived from endpoint host).

## DO NOT TAG / PUBLISH

This is part of a coordinated train (9 client PRs + server PR per the session-2033 brief). Tagging is operator-gated and happens only after the full train merges. Do not tag `v8.0.1` from this PR.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all green
- [x] `grep -rn 'AXONFLOW_PROFILE\|Profile\b' --include='*.go' .` — zero hits
- [ ] CI green
- [ ] Coordinated merge with the rest of the session-2033 train
- [ ] Runtime proof against `staging-checkpoint.getaxonflow.com` (cross-train step, not gated by this PR alone)

## Skip-runtime-e2e justification

This PR is part of the **#2033 coordinated train** across 1 server + 9 client repos. Per the [session-2033 brief](/tmp/session-2033-drop-profile-field-briefing.md), runtime proof is deferred to the post-server-merge staging-checkpoint deploy:

1. `axonflow-enterprise#2035` (server) merges + `gh workflow run deploy-checkpoint.yml -f environment=staging` deploys the new code to `staging-checkpoint.getaxonflow.com`.
2. Each of the 9 client builds is then driven against staging-checkpoint with verification that (a) POST returns 200 (no validator complaint about missing `profile`) and (b) the resulting DDB row has no `profile` attribute.
3. EVIDENCE lands at `runtime-e2e/profile_field_removal/EVIDENCE/<utc-ts>/` post-deploy.

Adding a same-PR `runtime-e2e/` test here would either:
- exercise a fake checkpoint server (forbidden by `lint-no-mocks-in-runtime-e2e.sh`), or
- run against the live deployed Lambda BEFORE the server PR has deployed, which would either silently pass (ignored field) or fail (depending on deploy ordering) — neither outcome is informative.

The post-deploy proof against staging-checkpoint is the only meaningful runtime test for this train.