### PR TITLE
docs(changelog): scrub profile-field noise [skip-runtime-e2e]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,6 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [8.0.1] - 2026-05-08 — Drop telemetry profile field
-
-### Removed
-
-- **`profile` field from telemetry payload** (was added in v8.0.0). The `AXONFLOW_PROFILE` env var collides with the existing governance enforcement env var (allowlist `dev|default|strict|compliance` per ADR-036), so emitting telemetry from a customer's correctly-configured governance profile (e.g. `strict`) would have produced HTTP 400 silent drops on the heartbeat path. The field had no analytics consumers in production yet — removing it is the cleanest fix. `deployment_mode` (`self_hosted | community_saas | unknown`) covers the topology dimension that `profile` was intended to add.
-
-### Migration
-
-- Customers who set `AXONFLOW_PROFILE` for governance enforcement on the agent: no change. The env var continues to be read by the agent for its original purpose.
-- Customers who set `AXONFLOW_PROFILE` solely to influence telemetry: no longer needed. The SDK no longer reads it for telemetry purposes.
-
 ## [8.0.0] - 2026-05-08 — Decision history API + telemetry simplification
 
 **Major release.** The headline feature is the new decision-history client API:
@@ -65,7 +54,7 @@ the bottom of this entry for that.
 
 ### Telemetry payload (v1 schema, axonflow-enterprise#2008)
 
-- New heartbeat fields: `telemetry_type: "sdk"`, `profile` (from `AXONFLOW_PROFILE`, `unknown` when unset), `deployment_mode` aligned to `self_hosted | community_saas | unknown` via `ClassifyDeploymentMode` (host + `AXONFLOW_TRY=1` override).
+- New heartbeat fields: `telemetry_type: "sdk"`, `deployment_mode` aligned to `self_hosted | community_saas | unknown` via `ClassifyDeploymentMode` (host + `AXONFLOW_TRY=1` override).
 - `ClassifyEndpoint` no longer returns `community-saas` — that value moved off endpoint_type onto deployment_mode; analytics queries on the legacy value must update.
 
 ## [7.1.0] - 2026-05-06 — X-Axonflow-Client header + scope-aware license validation

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package axonflow
 
 // Version is the SDK version.
-const Version = "8.0.1"
+const Version = "8.0.0"


### PR DESCRIPTION
## Summary

Scrub all references to the v1-telemetry `profile` field from CHANGELOG.md and revert the patch version bump. **The `profile` field never reached any tagged customer release** — its CHANGELOG mentions are internal noise.

User direction: *"This never made it to any customer so why it should be in changelog when we removed it already before the release."*

## What changed

- **`CHANGELOG.md`** — deleted the `[8.0.1] - Drop telemetry profile field` section entirely; scrubbed the `profile` mention from the `[8.0.0]` "Telemetry payload (v1 schema, ...)" bullet.
- **`version.go`** — reverted `Version = "8.0.1"` → `Version = "8.0.0"`.

## What is preserved

The remaining v8.0.0 narrative is unchanged: `ListDecisions` client method, `examples/explain-decision/`, the v7→v8 migration guide (module path, `TelemetryEnabled` removal), sandbox-mode telemetry, `telemetry_type: "sdk"` field, `deployment_mode` classification, and the `ClassifyEndpoint` change.

## Skip-runtime-e2e justification

This is a documentation correction with a single matching version-constant revert. The code state was already settled in the prior release train (`ef418ac` dropped the runtime read of `AXONFLOW_PROFILE` for telemetry on `main`). No user-facing behaviour changes; `go build ./...` + `go test ./...` both pass locally.

## References

- getaxonflow/axonflow-enterprise#2033 — original env-var collision bug
- getaxonflow/axonflow-enterprise#2035 — code-side fix (already shipped to `main` via #162 as `ef418ac`)

## Self-review

- Confirmed only the `[8.0.1]` section + the single `profile` clause inside `[8.0.0]`'s "Telemetry payload" bullet were removed.
- Confirmed `version.go` is the only version constant in the repo (no module-versioned shadow).
- `go build ./...` clean; `go test ./...` all packages pass.
- No AI attribution anywhere; DCO sign-off present.