### PR TITLE
fix(release): update release.yml v7→v8 paths post module migration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,12 @@ jobs:
             echo "### Installation"
             echo ""
             echo '```bash'
-            echo "go get github.com/getaxonflow/axonflow-sdk-go/v7@v${VERSION}"
+            echo "go get github.com/getaxonflow/axonflow-sdk-go/v8@v${VERSION}"
             echo '```'
             echo ""
             echo "### Documentation"
             echo ""
-            echo "- [pkg.go.dev](https://pkg.go.dev/github.com/getaxonflow/axonflow-sdk-go/v7@v${VERSION})"
+            echo "- [pkg.go.dev](https://pkg.go.dev/github.com/getaxonflow/axonflow-sdk-go/v8@v${VERSION})"
             echo "- [README](https://github.com/getaxonflow/axonflow-sdk-go#readme)"
             echo "- [Examples](https://github.com/getaxonflow/axonflow-sdk-go/tree/main/examples)"
             echo ""
@@ -105,4 +105,4 @@ jobs:
     - name: Trigger pkg.go.dev update
       run: |
         VERSION=${GITHUB_REF#refs/tags/}
-        curl https://proxy.golang.org/github.com/getaxonflow/axonflow-sdk-go/v7/@v/$VERSION.info
+        curl https://proxy.golang.org/github.com/getaxonflow/axonflow-sdk-go/v8/@v/$VERSION.info


### PR DESCRIPTION
The Go module migrated to \`module github.com/getaxonflow/axonflow-sdk-go/v8\` on main, but release.yml still references \`/v7\` in three places. Without this fix, v8.0.0 release notes would tell users \`go get .../v7@v8.0.0\` (404) and the pkg.go.dev pre-warm curl would fetch a non-existent path.

| Line | Before | After |
|---|---|---|
| 39 | \`echo "go get .../v7@v${VERSION}"\` | \`echo "go get .../v8@v${VERSION}"\` |
| 44 | \`echo "- [pkg.go.dev](https://pkg.go.dev/.../v7@v${VERSION})"\` | \`echo "- [pkg.go.dev](https://pkg.go.dev/.../v8@v${VERSION})"\` |
| 108 | \`curl https://proxy.golang.org/.../v7/@v/$VERSION.info\` | \`curl https://proxy.golang.org/.../v8/@v/$VERSION.info\` |

Required prerequisite for the imminent v8.0.0 tag.