### PR TITLE
chore(ci): cancel orphaned PR runs + prune Go matrix on PR

### DIFF
--- a/.github/workflows/definition-of-done.yml
+++ b/.github/workflows/definition-of-done.yml
@@ -6,11 +6,16 @@ name: Definition of Done
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    # Drop `edited` — re-runs the gate on title/body edits without any code change.
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
   pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint-no-mocks-in-runtime-e2e:

--- a/.github/workflows/heartbeat-real-stack.yml
+++ b/.github/workflows/heartbeat-real-stack.yml
@@ -12,6 +12,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   AXONFLOW_TELEMETRY: 'off'
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,10 +17,11 @@ permissions:
   contents: read
 
 # Avoid spawning parallel docker-compose stacks on back-to-back pushes;
-# also cancels stale PR runs when a new commit lands.
+# also cancels stale PR runs when a new commit lands. Push to main keys on SHA
+# so main runs never queue or cancel each other.
 concurrency:
-  group: integration-${{ github.ref }}
-  cancel-in-progress: true
+  group: integration-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   AXONFLOW_TELEMETRY: 'off'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,26 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  # Aggregator that always reports a single check name regardless of the
+  # matrix shape (PR-time matrix is `['1.22']`; push/dispatch is full).
+  # Branch protection requires `Test Summary`, not the per-version names,
+  # so matrix changes don't strand required checks.
+  test-summary:
+    name: Test Summary
+    needs: [test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Aggregate test matrix result
+      run: |
+        result="${{ needs.test.result }}"
+        echo "test matrix result: $result"
+        if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+          echo "::error::test matrix did not all pass (result: $result)"
+          exit 1
+        fi
+        echo "Test matrix OK"
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   AXONFLOW_TELEMETRY: 'off'
 
@@ -17,25 +21,21 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     strategy:
+      # PR runs only Go 1.22 (current release toolchain). Push to main and
+      # workflow_dispatch run the full matrix to catch version-specific drift.
       matrix:
-        go-version: ['1.21', '1.22', '1.23']
+        go-version: ${{ fromJson(github.event_name == 'pull_request' && '["1.22"]' || '["1.21", "1.22", "1.23"]') }}
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    # setup-go@v5 caches the module + build cache by default when go.sum
+    # exists at the repo root — no manual `actions/cache@v4` step needed.
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
-
-    - name: Cache Go modules
-      uses: actions/cache@v4
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
 
     - name: Download dependencies
       run: go mod download

--- a/.github/workflows/validate-version-alignment.yml
+++ b/.github/workflows/validate-version-alignment.yml
@@ -28,6 +28,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   validate-versions:
     name: Validate Version Alignment


### PR DESCRIPTION
Same shape as axonflow-sdk-{java#176,python#194,typescript#225}. Concurrency on 5 workflows + go matrix prune on test.yml (PR: 1.22; push/dispatch: 1.21+1.22+1.23). Drops the redundant manual go-modules cache step (setup-go@v5 caches by default). Public repo, dev-velocity work.