### PR TITLE
test(2275): 401-not-retried regression test [skip-runtime-e2e]

### DIFF
--- a/axonflow_http_test.go
+++ b/axonflow_http_test.go
@@ -1174,6 +1174,48 @@ func TestRetryWith4xxError(t *testing.T) {
 	}
 }
 
+// Regression test for issue #2275: 401 must be terminal. The SDK MUST
+// NOT retry an auth failure — retrying with the same invalid token
+// just compounds the storm on the agent. Backstops the cross-SDK
+// audit done in axonflow-enterprise#2275 where a customer's
+// misconfigured deployment caused a tight 401 retry loop against
+// community-saas (~30 401/hour from a single source IP).
+//
+// Go SDK is already safe: executeWithRetry treats all 4xx (including
+// 401) as terminal at axonflow.go:894-900. This test makes the
+// contract explicit for 401 specifically, separate from the generic
+// 4xx coverage in TestRetryWith4xxError above.
+func TestRetryWith401_Issue2275(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("unauthorized"))
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{
+		Endpoint: server.URL,
+		ClientID: "test",
+		Mode:     "sandbox", // sandbox disables fail-open so 401 surfaces
+		Retry: RetryConfig{
+			Enabled:      true,
+			MaxAttempts:  3,
+			InitialDelay: 1 * time.Millisecond,
+		},
+		Cache: CacheConfig{Enabled: false},
+	})
+
+	_, err := client.ProxyLLMCall("user", "query", "chat", nil)
+	if err == nil {
+		t.Error("Expected error on 401")
+	}
+
+	if callCount != 1 {
+		t.Errorf("Expected 1 call (no retry on 401), got %d", callCount)
+	}
+}
+
 func TestAuthHeadersSentWithCredentials(t *testing.T) {
 	receivedAuthHeader := ""
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Adds an explicit regression test asserting HTTP 401 responses are terminal in `executeWithRetry` — the SDK never retries a 401 auth failure.

Backstops issue [getaxonflow/axonflow-enterprise#2275](https://github.com/getaxonflow/axonflow-enterprise/issues/2275), where a customer's misconfigured deployment caused a tight 401 retry loop against `community-saas` — 716 × 401 in 24 hours from a single source IP (~30/hour, not human pacing).

## Audit finding (no code change required)

Go SDK was already safe — `executeWithRetry` at `axonflow.go:894-900` treats all 4xx (including 401) as terminal:

```go
if httpErr, ok := err.(*httpError); ok && httpErr.statusCode >= 400 && httpErr.statusCode < 500 {
    if c.config.Debug {
        log.Printf("[AxonFlow] Client error (4xx), not retrying: %v", err)
    }
    break
}
```

There's an existing `TestRetryWith4xxError` using status 400; this PR adds explicit 401 coverage so the contract for the specific auth status is regression-locked.

## Mutation test (proves the assertion isn't tautological)

Per `feedback_mutation_test_to_prove_assertion_not_tautological.md`: changed the terminal condition from `< 500` to `< 400` (so no status falls into the early-break):

```diff
-if httpErr, ok := err.(*httpError); ok && httpErr.statusCode >= 400 && httpErr.statusCode < 500 {
+if httpErr, ok := err.(*httpError); ok && httpErr.statusCode >= 400 && httpErr.statusCode < 400 {
```

Test result with mutation:
```
axonflow_http_test.go:1215: Expected 1 call (no retry on 401), got 3
--- FAIL: TestRetryWith401_Issue2275
```

→ confirms the assertion distinguishes "401 is terminal" vs "401 retries."

## Companion work in #2275

The other 4 SDKs (Python, Rust, Java, TypeScript) get the same regression test in their respective repos.

## Skip-runtime-e2e justification

Test-only addition; no new SDK feature surface and no wire-protocol change. The existing `runtime-e2e/` runners stay intact.

## Test plan

- [x] `go test -run TestRetryWith401_Issue2275 -v .` passes locally
- [x] Mutation test: narrowing the 4xx terminal condition to `< 400` fails the test
- [ ] CI green on this PR