### PR TITLE
feat(telemetry): include org_id in heartbeat payload (v9.1 #2277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,36 @@ when no `ClientID` is configured.
  value, so caller-supplied values are harmless (no spoofing surface).
  Set in `addAuthHeaders` (`audit.go`), the canonical funnel for all
  SDK HTTP requests.
+- **`org_id` field in the telemetry heartbeat body (v9.1 preflight, #2277).**
+ Brings SDK telemetry up to parity with the platform's `startup_telemetry.go`
+ emitter — every heartbeat now identifies which deployment-organization
+ emitted it. Two sources in precedence order:
+ 1. The `ORG_ID` env var when set (the operator's explicit configuration on
+    self-hosted deployments, or the `cs_<uuid>` tenant identifier on
+    Community SaaS).
+ 2. Otherwise the `local-dev-org` sentinel (default-config Community-mode
+    developers).
+ The receiver (`ee/platform/checkpoint-service/pkg/telemetry/telemetry.go`)
+ already accepts the field with `omitempty` for backward compat with
+ pre-v8.1 SDKs that don't send it. New SDKs always send it. Honors
+ `AXONFLOW_TELEMETRY=off` like every other heartbeat field. See
+ `axonflow-landing/content/privacy.html` for the customer-facing
+ commitment that covers this field.
+
+### Changed
+
+- **Telemetry-enabled log line** softened from "Anonymous telemetry enabled"
+ to "Telemetry enabled" to stay coherent with the v9.1 `org_id` addition
+ (the operator-supplied `ORG_ID` on self-hosted is not anonymized; only
+ the `instance_id` and `cs_<uuid>` Community SaaS identifier remain
+ anonymous-by-design).
 
 ### Compatibility
 
 - Backward-compatible against v8 and v9 platforms: v8 agents ignore the
  unknown header; v9 agents derive identity from Basic Auth regardless.
+- `org_id` is an additive field — the receiver's `omitempty` allows
+ legacy SDK builds to keep working unchanged.
 - No SDK config changes. No removed fields. No changed defaults.
 
 ## [8.0.0] - 2026-05-09 — Decision History API + policy_version recorded on every decision + telemetry simplification

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -16,9 +16,9 @@ import (
 // tests can override them — the test files in this package back up the
 // original values and restore them on cleanup.
 var (
-	// heartbeatInterval bounds how often a single machine sends an anonymous
+	// heartbeatInterval bounds how often a single machine sends a
 	// telemetry ping. Aligned with the plugin "7-day heartbeat" contract:
-	// "at most one anonymous heartbeat per environment every 7 days during
+	// "at most one heartbeat per environment every 7 days during
 	// SDK activity."
 	heartbeatInterval = 7 * 24 * time.Hour
 
@@ -65,8 +65,8 @@ func newHeartbeatState() *heartbeatState {
 // sharedHeartbeat is the process-global heartbeat singleton. ALL AxonFlow
 // clients in this process consult the same gate, so concurrent NewClient
 // calls before any stamp exists coalesce onto a single ping (per the
-// "at most one anonymous heartbeat per environment" contract). Tests
-// override via replaceHeartbeatStateForTest.
+// "at most one heartbeat per environment" contract). Tests override via
+// replaceHeartbeatStateForTest.
 var (
 	sharedHeartbeat   = newHeartbeatState()
 	sharedHeartbeatMu sync.Mutex // guards swapping the singleton in tests

--- a/runtime-e2e/sandbox_telemetry_stream_tag/README.md
+++ b/runtime-e2e/sandbox_telemetry_stream_tag/README.md
@@ -1,8 +1,8 @@
 # Runtime proof — Sandbox-mode telemetry fires with stream=sandbox (v8)
 
-Verifies the v8 contract: a `Sandbox()`-constructed client produces an
-anonymous heartbeat ping that lands in checkpoint DynamoDB with the row
-tagged `stream="sandbox"`.
+Verifies the v8 contract: a `Sandbox()`-constructed client produces a
+heartbeat ping that lands in checkpoint DynamoDB with the row tagged
+`stream="sandbox"`.
 
 ## When to run
 

--- a/runtime-e2e/v91_org_id_telemetry/README.md
+++ b/runtime-e2e/v91_org_id_telemetry/README.md
@@ -1,0 +1,65 @@
+# Runtime proof — `org_id` in SDK telemetry payload (v9.1)
+
+Verifies the v9.1 contract: every SDK telemetry ping body carries an
+`org_id` field, populated from the `ORG_ID` env var with a
+`local-dev-org` sentinel fallback. Issue #2277.
+
+## When to run
+
+- **Local development** — single-binary `go run`, no infrastructure
+  prerequisites. The proof spins up its own in-process HTTP listener
+  to receive the SDK's outgoing telemetry POST and inspects the wire
+  body.
+
+- **CI** — covered by the unit/functional tests in
+  `telemetry_test.go::TestSendTelemetryPing_OrgIDOnWire` and
+  `TestSendTelemetryPing_OrgIDAlwaysPresent`. This runtime proof is a
+  redundant real-stack confirmation, not a CI gate.
+
+## Usage
+
+```sh
+# ORG_ID set — operator-supplied (self-hosted) or cs_<uuid> (Community SaaS):
+ORG_ID=acme-corp go run runtime-e2e/v91_org_id_telemetry/main.go
+
+# ORG_ID unset — local-dev-org sentinel:
+unset ORG_ID && go run runtime-e2e/v91_org_id_telemetry/main.go
+```
+
+Expected output:
+
+```
+PASS: telemetry wire payload carries org_id="acme-corp" (expected="acme-corp")
+Wire body: {"telemetry_type":"sdk", ... ,"org_id":"acme-corp"}
+```
+
+## What it asserts
+
+1. The SDK constructed under any config emits a telemetry POST within
+   2 seconds of `NewClient`.
+2. The POST body is valid JSON.
+3. The body has an `org_id` key.
+4. The value matches `$ORG_ID` (when set) or `local-dev-org` (when
+   unset).
+
+## Mutation proof
+
+Remove the `OrgID: telemetryOrgID(),` line from `telemetry.go`'s
+`payload := telemetryPayload{...}` block and rerun. The proof exits 1
+with `FAIL: telemetry org_id = "", want "local-dev-org"`.
+
+## Cross-SDK parity
+
+Companion runtime-e2e tests will land in the other 4 SDKs under the
+same `runtime-e2e/v91_org_id_telemetry/` subdirectory as part of the
+#2277 cross-repo rollout:
+
+- `axonflow-sdk-python/runtime-e2e/v91_org_id_telemetry/`
+- `axonflow-sdk-typescript/runtime-e2e/v91_org_id_telemetry/`
+- `axonflow-sdk-java/runtime-e2e/v91_org_id_telemetry/`
+- `axonflow-sdk-rust/runtime-e2e/v91_org_id_telemetry/`
+
+All five SDKs send the field with the same wire name (`org_id`),
+same sentinel value (`local-dev-org`), and the same precedence
+(env > sentinel). The captured-payload transcript across the five
+will be posted as the delivery comment on Epic #2230.

--- a/runtime-e2e/v91_org_id_telemetry/main.go
+++ b/runtime-e2e/v91_org_id_telemetry/main.go
@@ -1,0 +1,119 @@
+//go:build ignore
+
+// runtime-e2e/v91_org_id_telemetry/main.go
+//
+// Real-wire test of the SDK's v9.1 org_id telemetry field (#2277). The
+// SDK does not expose its internal http.Client, so we run a tiny
+// in-process HTTP server that pretends to be the checkpoint receiver,
+// inspects the raw JSON body for the org_id field, and exits with the
+// verdict. Bytes flow real → real through net/http on both sides.
+//
+// Run via:
+//
+//	# ORG_ID set — operator-supplied or cs_<uuid>:
+//	ORG_ID=acme-corp go run runtime-e2e/v91_org_id_telemetry/main.go
+//
+//	# ORG_ID unset — sentinel:
+//	unset ORG_ID && go run runtime-e2e/v91_org_id_telemetry/main.go
+//
+// This proof goes alongside the unit-test wire assertions in
+// telemetry_test.go. Both paths run against the same SDK build; this
+// one additionally exercises the real net.Listen / http.Serve stack
+// rather than httptest.Server (which is functionally equivalent but
+// less faithful to a production-shaped wire path).
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+
+	axonflow "github.com/getaxonflow/axonflow-sdk-go/v8"
+)
+
+func main() {
+	expectedOrgID := os.Getenv("ORG_ID")
+	if expectedOrgID == "" {
+		expectedOrgID = "local-dev-org"
+	}
+
+	// The SDK gates pings to once per 7 days via a stamp file at
+	// os.UserCacheDir + axonflow/go-telemetry-last-sent. Nuke that
+	// stamp file at the same path the SDK resolves — env var injection
+	// here is too late (sharedHeartbeat is a package var initialized
+	// before main() runs). This makes the proof self-contained on
+	// any host without manual cleanup between runs.
+	if cacheDir, cdErr := os.UserCacheDir(); cdErr == nil {
+		stampPath := filepath.Join(cacheDir, "axonflow", "go-telemetry-last-sent")
+		_ = os.Remove(stampPath) // ignore: stamp may not exist on first run
+	}
+
+	var capturedBody atomic.Value
+	capturedBody.Store([]byte{})
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedBody.Store(body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"latest_version": "8.1.0"})
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "listen: %v\n", err)
+		os.Exit(2)
+	}
+	defer listener.Close()
+
+	srv := &http.Server{Handler: handler}
+	go func() { _ = srv.Serve(listener) }()
+	defer srv.Shutdown(context.Background())
+
+	checkpointURL := "http://" + listener.Addr().String() + "/v1/ping"
+	_ = os.Setenv("AXONFLOW_CHECKPOINT_URL", checkpointURL)
+	_ = os.Setenv("AXONFLOW_TELEMETRY", "")
+
+	client := axonflow.NewClient(axonflow.AxonFlowConfig{
+		Endpoint:     "https://example.invalid",
+		ClientID:     "rt-e2e",
+		ClientSecret: "rt-e2e",
+		Mode:         "production",
+	})
+	_ = client
+
+	// SDK fires telemetry on startup goroutine — give it a beat to land.
+	time.Sleep(2 * time.Second)
+
+	got := capturedBody.Load().([]byte)
+	if len(got) == 0 {
+		fmt.Fprintln(os.Stderr, "FAIL: no telemetry body captured (did SDK try to ping?)")
+		os.Exit(1)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(got, &payload); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: telemetry body not valid JSON: %v\n%s\n", err, string(got))
+		os.Exit(1)
+	}
+
+	orgID, ok := payload["org_id"].(string)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "FAIL: telemetry body missing org_id field; body: %s\n", string(got))
+		os.Exit(1)
+	}
+	if orgID != expectedOrgID {
+		fmt.Fprintf(os.Stderr, "FAIL: telemetry org_id = %q, want %q\n", orgID, expectedOrgID)
+		os.Exit(1)
+	}
+
+	fmt.Printf("PASS: telemetry wire payload carries org_id=%q (expected=%q)\n", orgID, expectedOrgID)
+	fmt.Printf("Wire body: %s\n", string(got))
+}

--- a/telemetry.go
+++ b/telemetry.go
@@ -49,6 +49,13 @@ type telemetryPayload struct {
 	// and the server defaults to "heartbeat". The wire-allowlist is enforced
 	// server-side — see checkpoint-service IsValidIncomingStream.
 	Stream string `json:"stream,omitempty"`
+	// OrgID identifies the deployment's organization (#2277). Two sources,
+	// in precedence order: the ORG_ID env var when set (the operator's
+	// explicit configuration on self-hosted deployments, or the cs_<uuid>
+	// tenant identifier on Community SaaS); otherwise the "local-dev-org"
+	// sentinel. Always emitted. See axonflow-landing/content/privacy.html
+	// for the customer-facing commitment that covers this field.
+	OrgID string `json:"org_id"`
 }
 
 // DeploymentMode classifications for telemetry (v1 schema, axonflow-enterprise#2008).
@@ -80,6 +87,22 @@ func ClassifyDeploymentMode(endpoint string) string {
 		return DeploymentModeCommunitySaaS
 	}
 	return DeploymentModeSelfHosted
+}
+
+// OrgIDLocalDevSentinel is emitted on the telemetry wire when ORG_ID is
+// unset — the default-config Community-mode developer case. See #2277.
+const OrgIDLocalDevSentinel = "local-dev-org"
+
+// telemetryOrgID returns the org_id value to emit on the next telemetry
+// ping. Reads ORG_ID from the environment (the operator's explicit
+// configuration for self-hosted deployments, or the cs_<uuid> tenant
+// identifier on Community SaaS) and falls back to OrgIDLocalDevSentinel
+// when unset. Always returns a non-empty string. See #2277.
+func telemetryOrgID() string {
+	if v := os.Getenv("ORG_ID"); v != "" {
+		return v
+	}
+	return OrgIDLocalDevSentinel
 }
 
 // EndpointType classifications for telemetry.
@@ -246,7 +269,7 @@ func (c *AxonFlowClient) sendTelemetryPing() {
 // the total blocking time is bounded by ctx — no stacked sub-timeouts.
 // See issue #1693 for the original short-lived-process delivery fix.
 func (c *AxonFlowClient) sendTelemetryPingNow(ctx context.Context) error {
-	log.Printf("[AxonFlow] Anonymous telemetry enabled. Opt out: AXONFLOW_TELEMETRY=off | https://docs.getaxonflow.com/docs/telemetry")
+	log.Printf("[AxonFlow] Telemetry enabled. Opt out: AXONFLOW_TELEMETRY=off | https://docs.getaxonflow.com/docs/telemetry")
 
 	// Determine the checkpoint URL.
 	checkpointURL := os.Getenv("AXONFLOW_CHECKPOINT_URL")
@@ -286,6 +309,7 @@ func (c *AxonFlowClient) sendTelemetryPingNow(ctx context.Context) error {
 		Features:        []string{},
 		InstanceID:      generateInstanceID(),
 		Stream:          stream,
+		OrgID:           telemetryOrgID(),
 	}
 
 	body, err := json.Marshal(payload)

--- a/telemetry_test.go
+++ b/telemetry_test.go
@@ -3,6 +3,7 @@ package axonflow
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -122,6 +123,7 @@ func TestGenerateInstanceID(t *testing.T) {
 
 func TestSendTelemetryPing_Success(t *testing.T) {
 	t.Setenv("AXONFLOW_TELEMETRY", "")
+	t.Setenv("ORG_ID", "") // exercise sentinel path
 	var received telemetryPayload
 	var called atomic.Int32
 
@@ -192,6 +194,9 @@ func TestSendTelemetryPing_Success(t *testing.T) {
 	}
 	if received.InstanceID == "" {
 		t.Error("expected instance_id to be non-empty")
+	}
+	if received.OrgID != OrgIDLocalDevSentinel {
+		t.Errorf("expected org_id=%q (sentinel, ORG_ID unset), got %q", OrgIDLocalDevSentinel, received.OrgID)
 	}
 }
 
@@ -555,5 +560,108 @@ func TestSendTelemetryPing_ProductionNoCreds(t *testing.T) {
 
 	if called.Load() != 1 {
 		t.Errorf("expected exactly 1 HTTP request for production mode without credentials, got %d", called.Load())
+	}
+}
+
+// TestTelemetryOrgID_HelperUnit asserts the env→sentinel fallback. Issue #2277.
+func TestTelemetryOrgID_HelperUnit(t *testing.T) {
+	t.Run("ORG_ID set wins", func(t *testing.T) {
+		t.Setenv("ORG_ID", "acme-corp")
+		if got := telemetryOrgID(); got != "acme-corp" {
+			t.Errorf("expected ORG_ID env to win, got %q", got)
+		}
+	})
+	t.Run("ORG_ID unset returns local-dev-org sentinel", func(t *testing.T) {
+		t.Setenv("ORG_ID", "")
+		if got := telemetryOrgID(); got != OrgIDLocalDevSentinel {
+			t.Errorf("expected sentinel %q, got %q", OrgIDLocalDevSentinel, got)
+		}
+	})
+	t.Run("cs_-prefixed Community SaaS shape", func(t *testing.T) {
+		t.Setenv("ORG_ID", "cs_abc12345-6789-4def-9012-345678901234")
+		if got := telemetryOrgID(); got != "cs_abc12345-6789-4def-9012-345678901234" {
+			t.Errorf("expected ORG_ID to pass through, got %q", got)
+		}
+	})
+}
+
+// TestSendTelemetryPing_OrgIDOnWire asserts the org_id field actually
+// reaches the wire payload — the functional end-to-end check that
+// closes #2277 R2. Uses httptest.Server (the same pattern existing
+// tests use) which is the real net/http stack on both sides.
+func TestSendTelemetryPing_OrgIDOnWire(t *testing.T) {
+	t.Setenv("AXONFLOW_TELEMETRY", "")
+
+	cases := []struct {
+		name     string
+		orgIDEnv string
+		want     string
+	}{
+		{"operator-supplied ORG_ID (self-hosted)", "acme-corp", "acme-corp"},
+		{"cs_-prefixed tenant identifier (Community SaaS)", "cs_e3a4b5c6-d7e8-4f90-a1b2-c3d4e5f6a7b8", "cs_e3a4b5c6-d7e8-4f90-a1b2-c3d4e5f6a7b8"},
+		{"unset becomes local-dev-org sentinel", "", OrgIDLocalDevSentinel},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("ORG_ID", tc.orgIDEnv)
+
+			var received telemetryPayload
+			// Capture the raw JSON too so we can prove the field is
+			// physically on the wire (not just decoded by our local
+			// struct tag — a mutation that drops the json tag would
+			// be silently re-attached by Go's struct-name fallback).
+			var rawBody []byte
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				rawBody, _ = io.ReadAll(r.Body)
+				_ = json.Unmarshal(rawBody, &received)
+				json.NewEncoder(w).Encode(telemetryResponse{LatestVersion: Version})
+			}))
+			defer srv.Close()
+			t.Setenv("AXONFLOW_CHECKPOINT_URL", srv.URL)
+
+			client := &AxonFlowClient{
+				config: AxonFlowConfig{Mode: "production", ClientID: "id", ClientSecret: "sec"},
+			}
+			client.sendTelemetryPing()
+
+			if received.OrgID != tc.want {
+				t.Errorf("decoded OrgID = %q, want %q", received.OrgID, tc.want)
+			}
+
+			// Wire-level assertion: the literal JSON field name "org_id"
+			// must appear in the body alongside the expected value. Defends
+			// against tag-removal mutations.
+			if !strings.Contains(string(rawBody), `"org_id":"`+tc.want+`"`) {
+				t.Errorf("wire JSON missing literal \"org_id\":%q field; got body: %s", tc.want, string(rawBody))
+			}
+		})
+	}
+}
+
+// TestSendTelemetryPing_OrgIDAlwaysPresent guards against a future
+// refactor accidentally tagging the field with omitempty + emitting an
+// empty value. Mutation-test trigger: remove the OrgID population line
+// in payload construction → this test fails because the literal
+// "org_id" string is absent from the wire body.
+func TestSendTelemetryPing_OrgIDAlwaysPresent(t *testing.T) {
+	t.Setenv("AXONFLOW_TELEMETRY", "")
+	t.Setenv("ORG_ID", "")
+
+	var rawBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawBody, _ = io.ReadAll(r.Body)
+		json.NewEncoder(w).Encode(telemetryResponse{LatestVersion: Version})
+	}))
+	defer srv.Close()
+	t.Setenv("AXONFLOW_CHECKPOINT_URL", srv.URL)
+
+	client := &AxonFlowClient{
+		config: AxonFlowConfig{Mode: "production", ClientID: "id", ClientSecret: "sec"},
+	}
+	client.sendTelemetryPing()
+
+	if !strings.Contains(string(rawBody), `"org_id":"local-dev-org"`) {
+		t.Errorf("expected wire body to ALWAYS contain org_id (sentinel when env unset), got: %s", string(rawBody))
 	}
 }


### PR DESCRIPTION
## Summary

Adds an `org_id` field to the Go SDK telemetry heartbeat payload, in parity with the platform's `startup_telemetry.go` emitter (Epic #2230, Issue #2277). Every heartbeat now identifies which deployment-organization emitted it.

**Two sources, precedence order:**
1. `ORG_ID` env var when set — operator's configured value on self-hosted, or `cs_<uuid>` tenant identifier on Community SaaS.
2. `local-dev-org` sentinel when unset — default-config Community-mode developers.

Always emitted. Receiver-side `OrgID` field at `axonflow-enterprise/ee/platform/checkpoint-service/pkg/telemetry/telemetry.go:454` already carries `omitempty` for backward compat against pre-v9.1 SDKs.

## DoD

- [x] Code: `telemetry.go` adds `OrgID` field + `telemetryOrgID()` helper + populate
- [x] Unit test: `TestTelemetryOrgID_HelperUnit` (env→sentinel fallback, 3 subtests)
- [x] Functional E2E (CI): `TestSendTelemetryPing_OrgIDOnWire` — real httptest.Server, decoded struct AND wire-literal `"org_id":"..."` JSON checked across 3 modes (operator-supplied / `cs_`-prefixed / sentinel)
- [x] Mutation guard: `TestSendTelemetryPing_OrgIDAlwaysPresent` — defends against the regression where someone removes the `OrgID:` populate line. Verified to fail when mutated (evidence in `/tmp/v91-org-id-telemetry-<UTC>/sdk-go/mutation-test-fails-as-expected.log`)
- [x] Existing `TestSendTelemetryPing_Success` extended to assert sentinel
- [x] Runtime proof: `runtime-e2e/v91_org_id_telemetry/main.go` + README — in-process HTTP listener consumes real telemetry POST, inspects wire body. Three modes exercised at PR time, all PASS
- [x] CHANGELOG entry under existing `[8.1.0]` (no version bump per scope)
- [x] R3 hostile review (fresh agent); HIGH = none after fold, MEDIUM #3+#4+#5+#7 folded inline before push
- [x] Companion wording sweep (`telemetry.go` log line, `heartbeat.go` comments, `sandbox_telemetry_stream_tag/README.md`) to stay coherent with `axonflow-landing#129`

## R2 captured wire bodies

```
ORG_ID=acme-corp:
{"telemetry_type":"sdk","sdk":"go","sdk_version":"8.1.0",...,"org_id":"acme-corp"}

ORG_ID unset:
{"telemetry_type":"sdk","sdk":"go","sdk_version":"8.1.0",...,"org_id":"local-dev-org"}

ORG_ID=cs_f29e9c5c-5c5b-4e0d-8e0d-aabbccddeeff:
{"telemetry_type":"sdk","sdk":"go","sdk_version":"8.1.0",...,"org_id":"cs_f29e9c5c-..."}
```

(Full bodies in `/tmp/v91-org-id-telemetry-<UTC>/sdk-go/r2-*.log`.)

## Test plan

- [ ] CI green across Test (1.21/1.22/1.23), Build, Analyze, CodeQL
- [ ] DCO trailer present (`Signed-off-by: Saurabh Jain <saurabh.jain@getaxonflow.com>`)
- [ ] Commit Lint passes (title 62 chars, under 72-char cap)

## Scope of changes

| File | Purpose |
|------|---------|
| `telemetry.go` | Struct field, helper, populate, softened log line |
| `telemetry_test.go` | 3 new tests + existing test extended |
| `heartbeat.go` | Comment wording softened |
| `CHANGELOG.md` | Added bullet under `[8.1.0]` |
| `runtime-e2e/v91_org_id_telemetry/` | New: in-process proof + README |
| `runtime-e2e/sandbox_telemetry_stream_tag/README.md` | Wording softened |

No version bump (work goes to existing v8.1.0 line per user scope; no registry release).

Refs: getaxonflow/axonflow-enterprise#2230 (Epic v9 identity)
Refs: getaxonflow/axonflow-enterprise#2277 (v9.1 SDK + plugin org_id telemetry)