### PR TITLE
chore(changelog): strip internal-reference Tracking trailers [skip-runtime-e2e]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,11 +50,6 @@ when no `ClientID` is configured.
  legacy SDK builds keep working unchanged.
 - No SDK config changes. No removed fields. No changed defaults.
 
-### Tracking
-
-- [#2230](https://github.com/getaxonflow/axonflow-enterprise/issues/2230)
-- [#2277](https://github.com/getaxonflow/axonflow-enterprise/issues/2277)
-
 ## [8.0.0] - 2026-05-09 — Decision History API + policy_version recorded on every decision + telemetry simplification
 
 **Major release.** The headline feature is the new decision-history client API:


### PR DESCRIPTION
## Summary

Follow-up to the v9.0.0 release-notes hygiene audit. The audit carried
the original brief's "internal references banned in prose" rule but
mistakenly left a per-section `### Tracking` trailer with internal
issue links — that trailer is still internal-team content and not
customer-facing release-notes material.

This PR removes those Tracking trailers from the sections that the
audit touched.

## What changed

- Removed `### Tracking` sections (with internal issue links) from
  every release-line section the v9.0.0 audit touched.
- No prose body changes. Section title, summary, Added/Changed/Fixed
  bullets, and customer-facing URLs (e.g. the public privacy page)
  unchanged.

## Test plan

- [x] CHANGELOG diff reviewed
- [x] No internal references remain in the audited section
- [ ] CI passes