### PR TITLE
feat(pep): decide -> fulfill -> forward Decision Mode PEP (#2571)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.5.0] - 2026-06-09 — Decision Mode PEP: decide → fulfill → forward
+
+Ports the Decision Mode PEP (Policy Enforcement Point) contract into the Go
+SDK: a single blessed path of **decide → fulfill → forward** (ADR-056, epic
+getaxonflow/axonflow-enterprise#2563, tracking #2571). Cross-SDK parity with
+the canonical Python SDK and the `platform/shared/pep` Go reference PEP.
+
+The structural guarantee #2563 demands: this SDK contains **no redaction logic
+of its own**. The only way it can discharge a `redact_pii` obligation is by
+round-tripping the source content through the engine endpoint the obligation
+names (`/api/v1/mcp/check-input`) and forwarding what the engine returns. If an
+obligation arrives without a fulfillable engine endpoint — or the engine reports
+the redactor did not run — `FulfillRequest` **fails closed** rather than
+forwarding unredacted content.
+
+### Added
+
+- **`(*AxonFlowClient) Decide(ctx, DecideRequest) (*DecideResponse, error)`.**
+  Asks the PDP (`POST /api/v1/decide`) for a verdict. Uses the SDK's existing
+  HTTP Basic (org:license) auth; demo / wrong credentials are refused with HTTP
+  401, surfaced as the SDK's `*httpError`. A deny verdict is returned in the
+  body (HTTP 200), not as an error.
+- **`(*AxonFlowClient) FulfillRequest(ctx, *DecideResponse, statement) (string, bool, error)`.**
+  Discharges every request-phase `redact_pii` obligation by POSTing the
+  statement to the obligation's engine endpoint and returning engine-redacted
+  content. Returns `ErrObligationNotFulfillable` (fail-closed) on every
+  unfulfillable condition: no request-phase fulfillment, a `content_types` set
+  that excludes `text/plain`, a foreign endpoint, an engine error / non-200, or
+  `redaction_evaluated == false`. Never returns the original statement on an
+  unfulfillable condition; never redacts locally.
+- **`(*AxonFlowClient) DecideAndFulfill(ctx, DecideRequest) (verdict, content string, *DecideResponse, error)`.**
+  One-call path: decide, then fulfill any request-phase obligation. Returns
+  empty content on the not-fulfillable path so a caller that ignores the error
+  cannot forward the unredacted query.
+- **`HasRequestRedaction([]Obligation) bool`** — branch helper.
+- **`ErrObligationNotFulfillable`** sentinel error (match with `errors.Is`).
+- **Decision API wire DTOs**: `DecideRequest`, `DecideResponse`, `Obligation`,
+  `ObligationFulfillment`, `DecisionCallerIdentity`, `DecisionTarget`.
+- **Constants**: `ObligationRedactPII`, `PhaseRequest`, `PhaseResponse`,
+  `ContentTypeText`, `VerdictAllow`, `VerdictDeny`, `VerdictNeedsApproval`.
+- **`ContentType` field on `MCPCheckInputRequest`** (`content_type`,
+  `omitempty`) — selects the request-redaction detector.
+- **`Redacted` / `RedactedStatement` / `RedactionEvaluated` on
+  `MCPCheckInputResponse`** — the engine-redacted statement and the
+  did-the-redactor-run flag that makes a `redact_pii` obligation
+  engine-fulfillable.
+- **`RedactionEvaluated` on `MCPCheckOutputResponse`** — response-phase
+  fail-closed parity with check-input.
+
 ## [8.4.0] - 2026-05-30 — Decision request context + Pasal 56(b) transfer basis
 
 Targets AxonFlow platform **v8.5.0**.

--- a/axonflow.go
+++ b/axonflow.go
@@ -1667,6 +1667,13 @@ type MCPCheckInputRequest struct {
 	Statement     string                 `json:"statement"`
 	Parameters    map[string]interface{} `json:"parameters,omitempty"`
 	Operation     string                 `json:"operation,omitempty"`
+
+	// ContentType selects the request-redaction detector (ADR-056 / #2563
+	// addendum). Empty defaults to "text/plain" server-side. A content_type with
+	// no registered detector is rejected (415) so a PEP fulfilling a redact_pii
+	// obligation fails closed rather than forwarding content the engine cannot
+	// govern. Source of truth: platform/agent/mcp_handler.go MCPCheckInputRequest.
+	ContentType string `json:"content_type,omitempty"`
 }
 
 // MCPCheckInputResponse represents the result of input policy evaluation.
@@ -1685,6 +1692,20 @@ type MCPCheckInputResponse struct {
 	PolicyMatches      []ExplainPolicy `json:"policy_matches,omitempty"`
 	OverrideAvailable  *bool           `json:"override_available,omitempty"`
 	OverrideExistingID string          `json:"override_existing_id,omitempty"`
+
+	// Request-phase redaction (ADR-056 / #2563). When an allowed statement
+	// carries PII under a redact (not block) policy, the engine returns the
+	// masked statement in RedactedStatement so a PEP can forward redacted
+	// content WITHOUT hand-rolling its own patterns — this is what makes a
+	// /decide redact_pii obligation engine-fulfillable. RedactionEvaluated
+	// reports whether the redaction detector actually RAN (regardless of whether
+	// it masked anything); a PEP fulfilling a redact_pii obligation MUST fail
+	// closed when it is false, because "Redacted:false" is then indistinguishable
+	// from "looked, found nothing" (#2563 B1). Source of truth:
+	// platform/agent/mcp_handler.go MCPCheckInputResponse.
+	Redacted           bool   `json:"redacted,omitempty"`
+	RedactedStatement  string `json:"redacted_statement,omitempty"`
+	RedactionEvaluated bool   `json:"redaction_evaluated,omitempty"`
 }
 
 // MCPCheckOutputRequest represents a request to validate output against MCP policies.
@@ -1718,6 +1739,14 @@ type MCPCheckOutputResponse struct {
 	// MCPCheckInputResponse fields on the same call site).
 	DecisionID    string          `json:"decision_id,omitempty"`
 	PolicyMatches []ExplainPolicy `json:"policy_matches,omitempty"`
+
+	// RedactionEvaluated mirrors the check-input field for the response phase
+	// (ADR-056 / #2563). A PEP fulfilling a response-phase redact_pii obligation
+	// MUST fail closed when this is false — the redactor did not run, so absence
+	// of redacted output cannot be trusted as "nothing to mask". The agent does
+	// not populate this on every path today; default false keeps a PEP fail-closed
+	// when the platform predates the field. Source of truth: platform/agent/mcp_handler.go.
+	RedactionEvaluated bool `json:"redaction_evaluated,omitempty"`
 }
 
 // MCPCheckInput validates an MCP request against configured policies without executing it.

--- a/pep.go
+++ b/pep.go
@@ -1,0 +1,332 @@
+// Decision Mode PEP (Policy Enforcement Point) contract for the AxonFlow Go SDK.
+//
+// A PEP follows one path: decide -> fulfill -> forward (ADR-056, epic #2563).
+//
+//   - decide:  ask the PDP (POST /api/v1/decide) for a verdict on a request.
+//   - fulfill: for every obligation the verdict carries, call the ENGINE
+//     endpoint named in the obligation's Fulfillment block to obtain
+//     engine-redacted content.
+//   - forward: forward the (possibly redacted) content, or block, per verdict.
+//
+// The structural guarantee #2563 demands: this SDK contains NO redaction logic
+// of its own. There is no regex, no pattern table, no masking branch. The ONLY
+// way it can discharge a redact_pii obligation is by POSTing the source content
+// to the engine endpoint the obligation names (via the existing MCPCheckInput)
+// and forwarding what the engine returns. If an obligation arrives without a
+// fulfillable engine endpoint — or the engine reports the redactor did not run —
+// FulfillRequest fails CLOSED (returns ErrObligationNotFulfillable) rather than
+// forwarding unredacted content.
+//
+// This mirrors platform/shared/pep (the Go reference PEP) so the SDK PEP cannot
+// reimplement redaction the way a hand-rolled regex would.
+package axonflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Obligation contract constants (mirror platform/agent/decision_handler.go).
+const (
+	// ObligationRedactPII is the obligation a PEP discharges by replacing
+	// request content with engine-redacted content before forwarding.
+	ObligationRedactPII = "redact_pii"
+
+	// PhaseRequest / PhaseResponse are the fulfillment phases. /decide runs
+	// pre-call so it only emits request-phase obligations; the response-phase
+	// value is part of the contract for PEP helpers that fan out to the
+	// response-redaction endpoint after the backend call.
+	PhaseRequest  = "request"
+	PhaseResponse = "response"
+
+	// ContentTypeText is the only redaction content-type wired today. The
+	// contract is content-type agnostic — a PEP holding content of a type not
+	// advertised by an obligation's ContentTypes must fail closed rather than
+	// forward it unredacted.
+	ContentTypeText = "text/plain"
+)
+
+// Verdict values returned by the PDP.
+const (
+	VerdictAllow         = "allow"
+	VerdictDeny          = "deny"
+	VerdictNeedsApproval = "needs_approval"
+)
+
+// Engine endpoints + the decide path. An obligation whose fulfillment endpoint
+// is not one of these is rejected — a PEP must not be steered into calling an
+// arbitrary URL by a malformed verdict.
+const (
+	decidePath            = "/api/v1/decide"
+	requestRedactionPath  = "/api/v1/mcp/check-input"
+	responseRedactionPath = "/api/v1/mcp/check-output"
+)
+
+// ErrObligationNotFulfillable means a Decision Mode obligation could not be
+// discharged through the engine — it named no request-phase fulfillment, named
+// an endpoint this client will not call, advertised a content-type the PEP is
+// not holding, the engine endpoint failed, or the engine reported the redactor
+// did not run (redaction_evaluated=false).
+//
+// This is a FAIL-CLOSED signal (ADR-056 / #2563): the caller MUST block the
+// request, never forward unredacted content. The SDK contains no local
+// redaction path, so it cannot silently substitute its own masking. Match it
+// with errors.Is.
+var ErrObligationNotFulfillable = errors.New("axonflow: obligation not engine-fulfillable")
+
+// --- Decision API wire DTOs (mirror platform/agent/decision_handler.go) ---
+
+// DecideRequest is the POST /api/v1/decide body. Required: Stage (one of "llm" |
+// "tool" | "agent") and Query.
+type DecideRequest struct {
+	Stage          string                 `json:"stage"`
+	Query          string                 `json:"query"`
+	CallerIdentity DecisionCallerIdentity `json:"caller_identity"`
+	Target         DecisionTarget         `json:"target"`
+	UserToken      string                 `json:"user_token,omitempty"`
+	Context        map[string]interface{} `json:"context,omitempty"`
+}
+
+// DecisionCallerIdentity is the gateway-asserted identity for a /decide request.
+// OrgID / TenantID are optional in the body — the auth-derived identity is
+// authoritative; body-supplied values are accepted only when they match.
+type DecisionCallerIdentity struct {
+	GatewayID string `json:"gateway_id,omitempty"`
+	OrgID     string `json:"org_id,omitempty"`
+	TenantID  string `json:"tenant_id,omitempty"`
+}
+
+// DecisionTarget describes what the gateway is about to call.
+type DecisionTarget struct {
+	Type     string `json:"type,omitempty"`     // "llm" | "tool" | "agent"
+	Model    string `json:"model,omitempty"`    // when type=llm
+	Provider string `json:"provider,omitempty"` // when type=llm
+	Tool     string `json:"tool,omitempty"`     // when type=tool
+}
+
+// DecideResponse is the PDP verdict returned by POST /api/v1/decide. Obligations
+// is always a slice so PEP code can iterate without a nil-check. TraceID is
+// W3C-format (32 lowercase hex chars). Error is set on the deny path when the
+// request was malformed.
+type DecideResponse struct {
+	Verdict           string       `json:"verdict"`
+	DecisionID        string       `json:"decision_id,omitempty"`
+	TraceID           string       `json:"trace_id,omitempty"`
+	Reasons           []string     `json:"reasons,omitempty"`
+	Obligations       []Obligation `json:"obligations"`
+	EvaluatedPolicies []string     `json:"evaluated_policies"`
+	Stage             string       `json:"stage,omitempty"`
+	ExpiresAt         time.Time    `json:"expires_at,omitempty"`
+	Error             string       `json:"error,omitempty"`
+}
+
+// Obligation is a self-describing, engine-fulfillable PEP requirement on an
+// allow verdict. /decide is a pure PDP and never mutates content, so a
+// redact_pii obligation is "call the AxonFlow engine endpoint named in
+// Fulfillment to obtain engine-redacted content" — not "redact this yourself".
+// Client-side redaction is forbidden.
+type Obligation struct {
+	Type        string                 `json:"type"`
+	Detail      string                 `json:"detail,omitempty"`
+	Fulfillment *ObligationFulfillment `json:"fulfillment,omitempty"`
+}
+
+// ObligationFulfillment names the engine call a PEP makes to discharge an
+// obligation. ContentTypes advertises the mime-types the endpoint's detectors
+// can handle today; a PEP holding content of a type NOT in this list must fail
+// closed rather than forward it unredacted (ADR-056 / #2563 addendum).
+type ObligationFulfillment struct {
+	Endpoint     string   `json:"endpoint"`
+	Method       string   `json:"method,omitempty"`
+	Phase        string   `json:"phase"`
+	ContentTypes []string `json:"content_types,omitempty"`
+}
+
+// Decide asks the PDP for a verdict on a request (POST /api/v1/decide).
+//
+// This is the PDP step of a PEP. /decide is a pure decision point: it NEVER
+// mutates content. When an allow verdict carries a redact_pii obligation,
+// discharge it with FulfillRequest (or use the one-call DecideAndFulfill) —
+// never by redacting locally.
+//
+// Decision Mode auth is HTTP Basic (org:license), which this client already
+// sends via addAuthHeaders; demo / wrong credentials are refused with HTTP 401,
+// surfaced as the SDK's *httpError (StatusCode 401). A deny verdict is returned
+// in the body with HTTP 200, not as an error.
+func (c *AxonFlowClient) Decide(ctx context.Context, req DecideRequest) (*DecideResponse, error) {
+	// Stamp the configured identity when the caller didn't set one explicitly.
+	if req.CallerIdentity.OrgID == "" {
+		req.CallerIdentity.OrgID = c.config.ClientID
+	}
+
+	fullURL := c.config.Endpoint + decidePath
+	var result DecideResponse
+	if err := c.makeJSONRequest(ctx, "POST", fullURL, req, &result); err != nil {
+		return nil, err
+	}
+	if result.Obligations == nil {
+		result.Obligations = []Obligation{}
+	}
+	return &result, nil
+}
+
+// FulfillRequest discharges every request-phase redact_pii obligation on
+// decision by calling the engine endpoint the obligation names, and returns the
+// engine-redacted statement to forward.
+//
+// Contract:
+//   - No obligations (or none that mutate the request): returns (statement,
+//     false, nil) — forward the original.
+//   - A redact_pii obligation with a valid request-phase Fulfillment: POSTs
+//     statement to that endpoint and returns (engineRedacted, true, nil).
+//   - A redact_pii obligation that names no request-phase fulfillment, advertises
+//     a content-type the PEP is not holding, names an endpoint this client will
+//     not call, whose engine call fails, or whose engine reported the redactor
+//     did not run: returns ErrObligationNotFulfillable. The caller MUST treat
+//     this as fail-closed (block) — never forward unredacted content.
+//
+// didRedact reflects whether the ENGINE actually changed the content, not merely
+// that an obligation was present. There is no code path in which this method
+// redacts locally — fulfillment is always the engine round-trip.
+func (c *AxonFlowClient) FulfillRequest(ctx context.Context, decision *DecideResponse, statement string) (string, bool, error) {
+	if decision == nil {
+		return statement, false, nil
+	}
+	redacted := statement
+	didRedact := false
+	for _, ob := range decision.Obligations {
+		if ob.Type != ObligationRedactPII {
+			// redact_pii is the only content-mutating obligation today; other
+			// types are pass-through by contract.
+			continue
+		}
+		if ob.Fulfillment == nil || ob.Fulfillment.Phase != PhaseRequest {
+			// A redact_pii obligation with no request-phase fulfillment cannot
+			// be discharged here — fail closed rather than forward unredacted.
+			return statement, false, fmt.Errorf("%w: redact_pii missing request-phase fulfillment", ErrObligationNotFulfillable)
+		}
+		// Content-type-agnostic check: this client submits text. If the endpoint
+		// advertises content types and text is not one of them, fail closed
+		// rather than forward — never assume the endpoint can handle our content.
+		if len(ob.Fulfillment.ContentTypes) > 0 && !containsPEPString(ob.Fulfillment.ContentTypes, ContentTypeText) {
+			return statement, false, fmt.Errorf("%w: endpoint does not advertise a %s detector", ErrObligationNotFulfillable, ContentTypeText)
+		}
+		if !isAllowedFulfillmentEndpoint(ob.Fulfillment.Endpoint, requestRedactionPath) {
+			return statement, false, fmt.Errorf("%w: endpoint %q is not the request-redaction endpoint", ErrObligationNotFulfillable, ob.Fulfillment.Endpoint)
+		}
+		out, err := c.fulfillViaCheckInput(ctx, redacted)
+		if err != nil {
+			return statement, false, err
+		}
+		// didRedact reflects whether the ENGINE actually changed the content,
+		// not merely that an obligation was present — the engine may report
+		// nothing to mask (fulfillViaCheckInput returns the statement unchanged).
+		if out != redacted {
+			didRedact = true
+		}
+		redacted = out
+	}
+	return redacted, didRedact, nil
+}
+
+// fulfillViaCheckInput POSTs statement to the request-redaction engine endpoint
+// (the existing MCPCheckInput) and returns the engine-masked statement. It fails
+// closed (returns ErrObligationNotFulfillable) when the engine call errors, the
+// engine returns non-200, or redaction_evaluated is false — never returns
+// unredacted content under an unfulfillable condition.
+func (c *AxonFlowClient) fulfillViaCheckInput(ctx context.Context, statement string) (string, error) {
+	result, err := c.MCPCheckInput(ctx, MCPCheckInputRequest{
+		ConnectorType: "gateway",
+		Statement:     statement,
+		ContentType:   ContentTypeText,
+		Operation:     "execute",
+	})
+	if err != nil {
+		return "", fmt.Errorf("%w: request-redaction engine call failed: %v", ErrObligationNotFulfillable, err)
+	}
+	// FAIL CLOSED if the redactor did not actually run (#2563 B1). Without this
+	// the PEP cannot distinguish "engine looked, found nothing" (safe to forward
+	// the original) from "engine wasn't looking" (would leak PII) — both arrive
+	// as redacted:false. The endpoint sets redaction_evaluated=true on every
+	// evaluated allow path; its absence means the redactor was disabled and we
+	// must NOT forward.
+	if !result.RedactionEvaluated {
+		return "", fmt.Errorf("%w: engine reported the redactor did not run (redaction disabled)", ErrObligationNotFulfillable)
+	}
+	if result.Redacted && result.RedactedStatement != "" {
+		return result.RedactedStatement, nil
+	}
+	// Redactor ran and found nothing to mask — forward the statement unchanged.
+	return statement, nil
+}
+
+// DecideAndFulfill is the blessed one-call PEP path: decide, then fulfill any
+// request-phase obligation. It returns the verdict, the content to forward
+// (engine-redacted when an obligation applied), and the raw decision.
+//
+// Callers branch on verdict: forward content on allow; block on deny /
+// needs_approval. On the not-fulfillable path it returns ErrObligationNotFulfillable
+// with empty content (computed after fulfillment failed) so a caller that
+// ignores the error cannot accidentally forward the unredacted query — fail-closed
+// by construction (#2563 L2).
+func (c *AxonFlowClient) DecideAndFulfill(ctx context.Context, req DecideRequest) (verdict, content string, decision *DecideResponse, err error) {
+	decision, err = c.Decide(ctx, req)
+	if err != nil {
+		return "", req.Query, nil, err
+	}
+	if decision.Verdict != VerdictAllow {
+		return decision.Verdict, req.Query, decision, nil
+	}
+	redacted, _, ferr := c.FulfillRequest(ctx, decision, req.Query)
+	if ferr != nil {
+		return decision.Verdict, "", decision, ferr
+	}
+	return decision.Verdict, redacted, decision, nil
+}
+
+// HasRequestRedaction reports whether any obligation requires request-phase PII
+// redaction. Exposed so a PEP can branch ("does this verdict carry work for
+// me?") before calling FulfillRequest.
+func HasRequestRedaction(obligations []Obligation) bool {
+	for _, o := range obligations {
+		if o.Type == ObligationRedactPII && o.Fulfillment != nil && o.Fulfillment.Phase == PhaseRequest {
+			return true
+		}
+	}
+	return false
+}
+
+// containsPEPString reports whether v is in s.
+func containsPEPString(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+// isAllowedFulfillmentEndpoint reports whether endpoint is the expected engine
+// path. It tolerates an absolute URL whose path component matches (some PDPs
+// return a fully-qualified obligation endpoint); a blank endpoint never matches.
+func isAllowedFulfillmentEndpoint(endpoint, expected string) bool {
+	e := strings.TrimSpace(endpoint)
+	if e == expected {
+		return true
+	}
+	// Accept an absolute URL whose path is the expected engine path.
+	if i := strings.Index(e, "://"); i >= 0 {
+		rest := e[i+3:]
+		if slash := strings.IndexByte(rest, '/'); slash >= 0 {
+			path := rest[slash:]
+			if q := strings.IndexByte(path, '?'); q >= 0 {
+				path = path[:q]
+			}
+			return path == expected
+		}
+	}
+	return false
+}

--- a/pep.go
+++ b/pep.go
@@ -256,7 +256,13 @@ func (c *AxonFlowClient) fulfillViaCheckInput(ctx context.Context, statement str
 	if !result.RedactionEvaluated {
 		return "", fmt.Errorf("%w: engine reported the redactor did not run (redaction disabled)", ErrObligationNotFulfillable)
 	}
-	if result.Redacted && result.RedactedStatement != "" {
+	if result.Redacted {
+		// FAIL CLOSED on a self-contradictory engine response: redacted=true with
+		// no redacted_statement means the engine claims it masked something but
+		// gave us nothing to forward — never fall back to the unredacted original.
+		if result.RedactedStatement == "" {
+			return "", fmt.Errorf("%w: engine reported redacted=true but returned no redacted_statement", ErrObligationNotFulfillable)
+		}
 		return result.RedactedStatement, nil
 	}
 	// Redactor ran and found nothing to mask — forward the statement unchanged.

--- a/pep_test.go
+++ b/pep_test.go
@@ -1,0 +1,580 @@
+package axonflow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The exact obligation the real agent emits on /decide for a request carrying
+// PII under a redact policy (verified live against an enterprise agent).
+func redactObligation() Obligation {
+	return Obligation{
+		Type: ObligationRedactPII,
+		Fulfillment: &ObligationFulfillment{
+			Endpoint:     requestRedactionPath,
+			Method:       "POST",
+			Phase:        PhaseRequest,
+			ContentTypes: []string{ContentTypeText},
+		},
+	}
+}
+
+func decideAllow(obs []Obligation) DecideResponse {
+	return DecideResponse{
+		Verdict:           VerdictAllow,
+		DecisionID:        "dec-1",
+		TraceID:           "04110a0b50577bbbdda23a00dcbaf6da",
+		Obligations:       obs,
+		EvaluatedPolicies: []string{"sys_pii_email"},
+		Stage:             "tool",
+	}
+}
+
+// newPEPClient builds a client pointed at srv with Basic-auth creds.
+func newPEPClient(endpoint string) *AxonFlowClient {
+	return &AxonFlowClient{
+		config: AxonFlowConfig{
+			Endpoint:     endpoint,
+			ClientID:     "org-test",
+			ClientSecret: "license-test",
+		},
+		httpClient: &http.Client{},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+func TestHasRequestRedaction(t *testing.T) {
+	if !HasRequestRedaction([]Obligation{redactObligation()}) {
+		t.Error("HasRequestRedaction = false, want true for request-phase redact_pii")
+	}
+	respPhase := []Obligation{{
+		Type:        ObligationRedactPII,
+		Fulfillment: &ObligationFulfillment{Endpoint: responseRedactionPath, Phase: PhaseResponse},
+	}}
+	if HasRequestRedaction(respPhase) {
+		t.Error("HasRequestRedaction = true, want false for response-phase obligation")
+	}
+	if HasRequestRedaction(nil) {
+		t.Error("HasRequestRedaction = true, want false for empty obligations")
+	}
+	noFul := []Obligation{{Type: ObligationRedactPII}}
+	if HasRequestRedaction(noFul) {
+		t.Error("HasRequestRedaction = true, want false for obligation with no fulfillment")
+	}
+}
+
+func TestIsAllowedFulfillmentEndpoint(t *testing.T) {
+	cases := []struct {
+		endpoint string
+		expected string
+		want     bool
+	}{
+		{"/api/v1/mcp/check-input", requestRedactionPath, true},
+		{"https://pdp:8443/api/v1/mcp/check-input", requestRedactionPath, true},
+		{"https://pdp/api/v1/mcp/check-input?x=1", requestRedactionPath, true},
+		{"", requestRedactionPath, false},
+		{"/api/v1/other", requestRedactionPath, false},
+		{"https://evil.example.com/steal", requestRedactionPath, false},
+		{"  /api/v1/mcp/check-input  ", requestRedactionPath, true}, // trimmed
+	}
+	for _, tc := range cases {
+		if got := isAllowedFulfillmentEndpoint(tc.endpoint, tc.expected); got != tc.want {
+			t.Errorf("isAllowedFulfillmentEndpoint(%q, %q) = %v, want %v", tc.endpoint, tc.expected, got, tc.want)
+		}
+	}
+}
+
+func TestContainsPEPString(t *testing.T) {
+	if !containsPEPString([]string{"a", ContentTypeText}, ContentTypeText) {
+		t.Error("containsPEPString = false, want true")
+	}
+	if containsPEPString([]string{"a", "b"}, ContentTypeText) {
+		t.Error("containsPEPString = true, want false")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Decide
+// ---------------------------------------------------------------------------
+
+func TestDecide_ParsesObligations(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != decidePath {
+			t.Errorf("got %s %s, want POST %s", r.Method, r.URL.Path, decidePath)
+		}
+		// The SDK must send HTTP Basic org:license on /decide.
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "org-test" || pass != "license-test" {
+			t.Errorf("BasicAuth = (%q,%q,%v), want (org-test,license-test,true)", user, pass, ok)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(decideAllow([]Obligation{redactObligation()}))
+	}))
+	defer srv.Close()
+
+	c := newPEPClient(srv.URL)
+	resp, err := c.Decide(context.Background(), DecideRequest{
+		Stage:  "tool",
+		Query:  "Email a@b.com",
+		Target: DecisionTarget{Type: "tool"},
+	})
+	if err != nil {
+		t.Fatalf("Decide error: %v", err)
+	}
+	if resp.Verdict != VerdictAllow {
+		t.Errorf("Verdict = %q, want allow", resp.Verdict)
+	}
+	if resp.TraceID != "04110a0b50577bbbdda23a00dcbaf6da" {
+		t.Errorf("TraceID = %q", resp.TraceID)
+	}
+	if len(resp.Obligations) != 1 {
+		t.Fatalf("len(Obligations) = %d, want 1", len(resp.Obligations))
+	}
+	ob := resp.Obligations[0]
+	if ob.Type != ObligationRedactPII || ob.Fulfillment == nil {
+		t.Fatalf("obligation = %+v", ob)
+	}
+	if ob.Fulfillment.Endpoint != requestRedactionPath || ob.Fulfillment.Phase != PhaseRequest {
+		t.Errorf("fulfillment = %+v", ob.Fulfillment)
+	}
+	if len(ob.Fulfillment.ContentTypes) != 1 || ob.Fulfillment.ContentTypes[0] != ContentTypeText {
+		t.Errorf("content_types = %v", ob.Fulfillment.ContentTypes)
+	}
+}
+
+func TestDecide_StampsOrgID(t *testing.T) {
+	var captured DecideRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &captured)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(decideAllow(nil))
+	}))
+	defer srv.Close()
+
+	c := newPEPClient(srv.URL)
+	if _, err := c.Decide(context.Background(), DecideRequest{Stage: "tool", Query: "hi"}); err != nil {
+		t.Fatalf("Decide error: %v", err)
+	}
+	if captured.CallerIdentity.OrgID != "org-test" {
+		t.Errorf("caller_identity.org_id = %q, want org-test (stamped from ClientID)", captured.CallerIdentity.OrgID)
+	}
+}
+
+func TestDecide_EmptyObligationsIsNonNilSlice(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// platform always sends [], but be defensive: omit it entirely.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"verdict":"allow","decision_id":"d1","evaluated_policies":[]}`)
+	}))
+	defer srv.Close()
+
+	c := newPEPClient(srv.URL)
+	resp, err := c.Decide(context.Background(), DecideRequest{Stage: "tool", Query: "hi"})
+	if err != nil {
+		t.Fatalf("Decide error: %v", err)
+	}
+	if resp.Obligations == nil {
+		t.Error("Obligations is nil, want non-nil empty slice")
+	}
+	if len(resp.Obligations) != 0 {
+		t.Errorf("len(Obligations) = %d, want 0", len(resp.Obligations))
+	}
+}
+
+func TestDecide_401SurfacesHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":"unauthorized"}`)
+	}))
+	defer srv.Close()
+
+	c := newPEPClient(srv.URL)
+	_, err := c.Decide(context.Background(), DecideRequest{Stage: "tool", Query: "hi"})
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	var he *httpError
+	if !errors.As(err, &he) {
+		t.Fatalf("error type = %T, want *httpError", err)
+	}
+	if he.statusCode != http.StatusUnauthorized {
+		t.Errorf("statusCode = %d, want 401", he.statusCode)
+	}
+}
+
+func TestDecide_OmitsEmptyFieldsOnWire(t *testing.T) {
+	var raw map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &raw)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(decideAllow(nil))
+	}))
+	defer srv.Close()
+
+	c := newPEPClient(srv.URL)
+	if _, err := c.Decide(context.Background(), DecideRequest{Stage: "tool", Query: "hi"}); err != nil {
+		t.Fatalf("Decide error: %v", err)
+	}
+	if raw["stage"] != "tool" {
+		t.Errorf("stage = %v, want tool", raw["stage"])
+	}
+	if _, ok := raw["user_token"]; ok {
+		t.Error("user_token present on wire, want omitted when empty")
+	}
+	if _, ok := raw["context"]; ok {
+		t.Error("context present on wire, want omitted when empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FulfillRequest — the fail-closed core
+// ---------------------------------------------------------------------------
+
+// checkInputServer returns a server that answers /api/v1/mcp/check-input with
+// the given JSON body and records the captured request body.
+func checkInputServer(t *testing.T, respBody string, captured *map[string]interface{}) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != requestRedactionPath {
+			t.Errorf("path = %q, want %q", r.URL.Path, requestRedactionPath)
+		}
+		if captured != nil {
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, captured)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, respBody)
+	}))
+}
+
+func TestFulfillRequest_EngineRedactsAndForwards(t *testing.T) {
+	var captured map[string]interface{}
+	srv := checkInputServer(t, `{"allowed":true,"policies_evaluated":1,"redacted":true,"redacted_statement":"Email jo****om","redaction_evaluated":true}`, &captured)
+	defer srv.Close()
+
+	c := newPEPClient(srv.URL)
+	decision := decideAllow([]Obligation{redactObligation()})
+	content, did, err := c.FulfillRequest(context.Background(), &decision, "Email john@x.com")
+	if err != nil {
+		t.Fatalf("FulfillRequest error: %v", err)
+	}
+	if content != "Email jo****om" {
+		t.Errorf("content = %q, want engine-redacted", content)
+	}
+	if !did {
+		t.Error("didRedact = false, want true")
+	}
+	// The PEP submitted the source content to the engine with text/plain.
+	if captured["statement"] != "Email john@x.com" {
+		t.Errorf("statement = %v, want original", captured["statement"])
+	}
+	if captured["content_type"] != ContentTypeText {
+		t.Errorf("content_type = %v, want %q", captured["content_type"], ContentTypeText)
+	}
+	if captured["connector_type"] != "gateway" {
+		t.Errorf("connector_type = %v, want gateway", captured["connector_type"])
+	}
+}
+
+func TestFulfillRequest_NoObligationsPassthrough(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("engine was called, but no obligation should trigger a call")
+	}))
+	defer srv.Close()
+
+	c := newPEPClient(srv.URL)
+	decision := decideAllow(nil)
+	content, did, err := c.FulfillRequest(context.Background(), &decision, "nothing to mask")
+	if err != nil {
+		t.Fatalf("FulfillRequest error: %v", err)
+	}
+	if content != "nothing to mask" || did {
+		t.Errorf("content=%q did=%v, want passthrough", content, did)
+	}
+}
+
+func TestFulfillRequest_NilDecisionPassthrough(t *testing.T) {
+	c := newPEPClient("http://unused")
+	content, did, err := c.FulfillRequest(context.Background(), nil, "x")
+	if err != nil || content != "x" || did {
+		t.Errorf("got (%q,%v,%v), want passthrough", content, did, err)
+	}
+}
+
+func TestFulfillRequest_EngineFoundNothingForwardsOriginal(t *testing.T) {
+	// Redactor ran (redaction_evaluated:true) but masked nothing → forward original.
+	srv := checkInputServer(t, `{"allowed":true,"redacted":false,"redaction_evaluated":true}`, nil)
+	defer srv.Close()
+
+	c := newPEPClient(srv.URL)
+	decision := decideAllow([]Obligation{redactObligation()})
+	content, did, err := c.FulfillRequest(context.Background(), &decision, "clean text")
+	if err != nil {
+		t.Fatalf("FulfillRequest error: %v", err)
+	}
+	if content != "clean text" {
+		t.Errorf("content = %q, want original forwarded", content)
+	}
+	if did {
+		t.Error("didRedact = true, want false (engine masked nothing)")
+	}
+}
+
+func TestFulfillRequest_NonRedactObligationIsPassthrough(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("engine was called for a non-redact obligation")
+	}))
+	defer srv.Close()
+
+	c := newPEPClient(srv.URL)
+	decision := decideAllow([]Obligation{{Type: "log_only"}})
+	content, did, err := c.FulfillRequest(context.Background(), &decision, "x")
+	if err != nil {
+		t.Fatalf("FulfillRequest error: %v", err)
+	}
+	if content != "x" || did {
+		t.Errorf("got (%q,%v), want passthrough", content, did)
+	}
+}
+
+// --- fail-closed branches ---
+
+func TestFulfillRequest_FailClosed_NoRequestPhaseFulfillment(t *testing.T) {
+	cases := map[string]Obligation{
+		"nil fulfillment": {Type: ObligationRedactPII, Fulfillment: nil},
+		"response phase":  {Type: ObligationRedactPII, Fulfillment: &ObligationFulfillment{Endpoint: requestRedactionPath, Phase: PhaseResponse}},
+	}
+	for name, ob := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := newPEPClient("http://unused")
+			decision := decideAllow([]Obligation{ob})
+			_, did, err := c.FulfillRequest(context.Background(), &decision, "secret email a@b.com")
+			// The error IS the fail-closed signal — a correct caller never
+			// forwards on a non-nil err. didRedact must be false.
+			if !errors.Is(err, ErrObligationNotFulfillable) {
+				t.Fatalf("err = %v, want ErrObligationNotFulfillable", err)
+			}
+			if did {
+				t.Error("didRedact = true on fail-closed path")
+			}
+		})
+	}
+}
+
+func TestFulfillRequest_FailClosed_UnadvertisedContentType(t *testing.T) {
+	c := newPEPClient("http://unused")
+	ob := Obligation{Type: ObligationRedactPII, Fulfillment: &ObligationFulfillment{
+		Endpoint:     requestRedactionPath,
+		Phase:        PhaseRequest,
+		ContentTypes: []string{"image/png"}, // text/plain not advertised
+	}}
+	decision := decideAllow([]Obligation{ob})
+	_, did, err := c.FulfillRequest(context.Background(), &decision, "secret a@b.com")
+	// The error IS the fail-closed signal; a correct caller never forwards on a
+	// non-nil err. didRedact must be false on every fail-closed path.
+	if !errors.Is(err, ErrObligationNotFulfillable) {
+		t.Fatalf("err = %v, want ErrObligationNotFulfillable", err)
+	}
+	if did {
+		t.Error("didRedact = true on fail-closed path")
+	}
+}
+
+func TestFulfillRequest_FailClosed_ForeignEndpoint(t *testing.T) {
+	c := newPEPClient("http://unused")
+	ob := Obligation{Type: ObligationRedactPII, Fulfillment: &ObligationFulfillment{
+		Endpoint: "https://evil.example.com/steal",
+		Phase:    PhaseRequest,
+	}}
+	decision := decideAllow([]Obligation{ob})
+	_, did, err := c.FulfillRequest(context.Background(), &decision, "secret a@b.com")
+	// The error IS the fail-closed signal; a correct caller never forwards on a
+	// non-nil err. didRedact must be false on every fail-closed path.
+	if !errors.Is(err, ErrObligationNotFulfillable) {
+		t.Fatalf("err = %v, want ErrObligationNotFulfillable", err)
+	}
+	if did {
+		t.Error("didRedact = true on fail-closed path")
+	}
+}
+
+func TestFulfillRequest_FailClosed_EngineError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, `boom`)
+	}))
+	defer srv.Close()
+
+	c := newPEPClient(srv.URL)
+	decision := decideAllow([]Obligation{redactObligation()})
+	_, did, err := c.FulfillRequest(context.Background(), &decision, "secret a@b.com")
+	// The error IS the fail-closed signal; a correct caller never forwards on a
+	// non-nil err. didRedact must be false on every fail-closed path.
+	if !errors.Is(err, ErrObligationNotFulfillable) {
+		t.Fatalf("err = %v, want ErrObligationNotFulfillable", err)
+	}
+	if did {
+		t.Error("didRedact = true on fail-closed path")
+	}
+}
+
+func TestFulfillRequest_FailClosed_RedactionEvaluatedFalse(t *testing.T) {
+	// Engine returned 200 with redaction_evaluated:false → redactor did not run.
+	srv := checkInputServer(t, `{"allowed":true,"redacted":false,"redaction_evaluated":false}`, nil)
+	defer srv.Close()
+
+	c := newPEPClient(srv.URL)
+	decision := decideAllow([]Obligation{redactObligation()})
+	_, did, err := c.FulfillRequest(context.Background(), &decision, "secret a@b.com")
+	// The error IS the fail-closed signal; a correct caller never forwards on a
+	// non-nil err. didRedact must be false on every fail-closed path.
+	if !errors.Is(err, ErrObligationNotFulfillable) {
+		t.Fatalf("err = %v, want ErrObligationNotFulfillable", err)
+	}
+	if did {
+		t.Error("didRedact = true on fail-closed path")
+	}
+}
+
+func TestFulfillRequest_FailClosed_RedactionEvaluatedAbsent(t *testing.T) {
+	// Engine response predates the field → defaults false → fail closed.
+	srv := checkInputServer(t, `{"allowed":true}`, nil)
+	defer srv.Close()
+
+	c := newPEPClient(srv.URL)
+	decision := decideAllow([]Obligation{redactObligation()})
+	_, did, err := c.FulfillRequest(context.Background(), &decision, "secret a@b.com")
+	// The error IS the fail-closed signal; a correct caller never forwards on a
+	// non-nil err. didRedact must be false on every fail-closed path.
+	if !errors.Is(err, ErrObligationNotFulfillable) {
+		t.Fatalf("err = %v, want ErrObligationNotFulfillable", err)
+	}
+	if did {
+		t.Error("didRedact = true on fail-closed path")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DecideAndFulfill
+// ---------------------------------------------------------------------------
+
+func TestDecideAndFulfill_AllowRedacts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case decidePath:
+			_ = json.NewEncoder(w).Encode(decideAllow([]Obligation{redactObligation()}))
+		case requestRedactionPath:
+			_, _ = io.WriteString(w, `{"allowed":true,"redacted":true,"redacted_statement":"Email jo****om","redaction_evaluated":true}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := newPEPClient(srv.URL)
+	verdict, content, decision, err := c.DecideAndFulfill(context.Background(), DecideRequest{Stage: "tool", Query: "Email john@x.com"})
+	if err != nil {
+		t.Fatalf("DecideAndFulfill error: %v", err)
+	}
+	if verdict != VerdictAllow {
+		t.Errorf("verdict = %q, want allow", verdict)
+	}
+	if content != "Email jo****om" {
+		t.Errorf("content = %q, want engine-redacted", content)
+	}
+	if decision == nil || decision.DecisionID != "dec-1" {
+		t.Errorf("decision = %+v", decision)
+	}
+}
+
+func TestDecideAndFulfill_DenyReturnsOriginalQueryNoFulfill(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == requestRedactionPath {
+			t.Error("engine called on a deny verdict")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(DecideResponse{Verdict: VerdictDeny, DecisionID: "dec-d", Error: "blocked"})
+	}))
+	defer srv.Close()
+
+	c := newPEPClient(srv.URL)
+	verdict, content, decision, err := c.DecideAndFulfill(context.Background(), DecideRequest{Stage: "tool", Query: "the original query"})
+	if err != nil {
+		t.Fatalf("DecideAndFulfill error: %v", err)
+	}
+	if verdict != VerdictDeny {
+		t.Errorf("verdict = %q, want deny", verdict)
+	}
+	if content != "the original query" {
+		t.Errorf("content = %q, want original query on deny", content)
+	}
+	if decision == nil || decision.Verdict != VerdictDeny {
+		t.Errorf("decision = %+v", decision)
+	}
+}
+
+func TestDecideAndFulfill_UnfulfillableReturnsEmptyContent(t *testing.T) {
+	// Allow verdict carries a redact_pii obligation, but the engine reports the
+	// redactor did not run → unfulfillable → empty content (fail-closed by
+	// construction so a caller ignoring err cannot forward the raw query).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case decidePath:
+			_ = json.NewEncoder(w).Encode(decideAllow([]Obligation{redactObligation()}))
+		case requestRedactionPath:
+			_, _ = io.WriteString(w, `{"allowed":true,"redaction_evaluated":false}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := newPEPClient(srv.URL)
+	verdict, content, _, err := c.DecideAndFulfill(context.Background(), DecideRequest{Stage: "tool", Query: "secret a@b.com"})
+	if !errors.Is(err, ErrObligationNotFulfillable) {
+		t.Fatalf("err = %v, want ErrObligationNotFulfillable", err)
+	}
+	if content != "" {
+		t.Errorf("content = %q, want empty on unfulfillable (no PII leak path)", content)
+	}
+	if strings.Contains(content, "a@b.com") {
+		t.Error("FAIL-CLOSED VIOLATION: PII leaked into DecideAndFulfill content")
+	}
+	if verdict != VerdictAllow {
+		t.Errorf("verdict = %q, want allow (verdict still returned)", verdict)
+	}
+}
+
+func TestDecideAndFulfill_DecideErrorPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := newPEPClient(srv.URL)
+	verdict, content, decision, err := c.DecideAndFulfill(context.Background(), DecideRequest{Stage: "tool", Query: "q"})
+	if err == nil {
+		t.Fatal("expected error when Decide fails")
+	}
+	if verdict != "" || decision != nil {
+		t.Errorf("got verdict=%q decision=%+v, want zero values on decide error", verdict, decision)
+	}
+	// content is the original query per the reference contract, but the error is
+	// non-nil so the caller must not forward.
+	if content != "q" {
+		t.Errorf("content = %q", content)
+	}
+}

--- a/pep_test.go
+++ b/pep_test.go
@@ -465,6 +465,53 @@ func TestFulfillRequest_FailClosed_RedactionEvaluatedAbsent(t *testing.T) {
 	}
 }
 
+func TestFulfillRequest_FailClosed_RedactedTrueNoStatement(t *testing.T) {
+	// Self-contradictory engine response: redacted=true but no redacted_statement.
+	// Must fail closed rather than forward the unredacted original.
+	srv := checkInputServer(t, `{"allowed":true,"redacted":true,"redaction_evaluated":true}`, nil)
+	defer srv.Close()
+
+	c := newPEPClient(srv.URL)
+	decision := decideAllow([]Obligation{redactObligation()})
+	// The error IS the fail-closed signal (FulfillRequest returns the original
+	// statement alongside it; a correct caller never forwards on a non-nil err,
+	// and DecideAndFulfill yields empty content on this path — see its test).
+	_, did, err := c.FulfillRequest(context.Background(), &decision, "secret a@b.com")
+	if !errors.Is(err, ErrObligationNotFulfillable) {
+		t.Fatalf("err = %v, want ErrObligationNotFulfillable", err)
+	}
+	if did {
+		t.Error("didRedact = true on fail-closed path")
+	}
+}
+
+// TestDecideAndFulfill_RedactedTrueNoStatement asserts the one-call path yields
+// EMPTY content (never the original) when the engine returns the
+// self-contradictory redacted=true / no-statement response.
+func TestDecideAndFulfill_RedactedTrueNoStatement(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == decidePath {
+			d := decideAllow([]Obligation{redactObligation()})
+			_ = json.NewEncoder(w).Encode(d)
+			return
+		}
+		_, _ = io.WriteString(w, `{"allowed":true,"redacted":true,"redaction_evaluated":true}`)
+	}))
+	defer srv.Close()
+
+	c := newPEPClient(srv.URL)
+	verdict, content, _, err := c.DecideAndFulfill(context.Background(), DecideRequest{Stage: "tool", Query: "secret a@b.com"})
+	if !errors.Is(err, ErrObligationNotFulfillable) {
+		t.Fatalf("err = %v, want ErrObligationNotFulfillable", err)
+	}
+	if verdict != VerdictAllow {
+		t.Errorf("verdict = %q, want allow", verdict)
+	}
+	if content != "" {
+		t.Errorf("content = %q, want empty (fail-closed; never the original)", content)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // DecideAndFulfill
 // ---------------------------------------------------------------------------

--- a/runtime-e2e/decide_fulfill_obligation/README.md
+++ b/runtime-e2e/decide_fulfill_obligation/README.md
@@ -1,0 +1,29 @@
+# runtime-e2e: Decision Mode PEP — decide → fulfill → forward
+
+Real-stack assertion for the Decision Mode PEP contract
+(getaxonflow/axonflow-enterprise#2571 / epic #2563).
+
+Proves end-to-end, against a **real** running AxonFlow agent (no mocks):
+
+1. `client.Decide(...)` on a PII-bearing request returns `verdict=allow` with a
+   self-describing `redact_pii` obligation whose fulfillment names the
+   `check-input` engine endpoint (request phase, `text/plain`).
+2. `client.FulfillRequest(...)` discharges it by round-tripping the statement
+   through that engine endpoint and returns ENGINE-redacted content — the
+   original email (`john.doe@example.com`) and card (`4111111111111111`) no
+   longer appear. The SDK contains no local redaction path.
+3. `client.DecideAndFulfill(...)` does both in one call.
+4. Demo / wrong credentials are refused (HTTP 401).
+
+## Run
+
+```sh
+source /tmp/axonflow-e2e-env.sh   # provides AXONFLOW_CLIENT_ID + AXONFLOW_CLIENT_SECRET
+
+AXONFLOW_AGENT_URL=http://localhost:8080 \
+AXONFLOW_CLIENT_ID="$AXONFLOW_CLIENT_ID" \
+AXONFLOW_CLIENT_SECRET="$AXONFLOW_CLIENT_SECRET" \
+go run runtime-e2e/decide_fulfill_obligation/main.go
+```
+
+Exit 0 + `PASS:` line = success. Any `FAIL:` line on stderr = failure (exit 1).

--- a/runtime-e2e/decide_fulfill_obligation/main.go
+++ b/runtime-e2e/decide_fulfill_obligation/main.go
@@ -1,0 +1,178 @@
+//go:build ignore
+
+// runtime-e2e/decide_fulfill_obligation/main.go
+//
+// Real-stack assertion: Decision Mode PEP decide -> fulfill -> forward
+// (getaxonflow/axonflow-enterprise#2571 / epic #2563).
+//
+// Per CLAUDE.md HARD RULE #0 this driver MUST hit a real running AxonFlow agent
+// — no httptest, no fixture servers. It proves the engine-fulfillable obligation
+// contract end to end through a real net/http round-trip:
+//
+//  1. client.Decide(...) on a PII-bearing request returns verdict=allow with a
+//     self-describing redact_pii obligation whose fulfillment names the
+//     check-input engine endpoint (request phase, text/plain).
+//  2. client.FulfillRequest(...) discharges it by round-tripping the statement
+//     through that engine endpoint and returns ENGINE-redacted content — the
+//     original email + card no longer appear, and the masking is the engine's
+//     (the SDK contains no local redaction path).
+//  3. client.DecideAndFulfill(...) does both in one call.
+//  4. Demo / wrong credentials are refused (HTTP 401); the PEP cannot decide with
+//     credentials the enterprise PDP does not accept.
+//
+// Enterprise auth is HTTP Basic (org:license) — the SDK builds it from
+// ClientID + ClientSecret.
+//
+// Run locally (after `source /tmp/axonflow-e2e-env.sh` from the enterprise
+// setup script):
+//
+//	AXONFLOW_AGENT_URL=http://localhost:8080 \
+//	AXONFLOW_CLIENT_ID="$AXONFLOW_CLIENT_ID" \
+//	AXONFLOW_CLIENT_SECRET="$AXONFLOW_CLIENT_SECRET" \
+//	go run runtime-e2e/decide_fulfill_obligation/main.go
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	axonflow "github.com/getaxonflow/axonflow-sdk-go/v8"
+)
+
+// The PII the request carries. The engine's redactor must mask the email + card;
+// neither raw value may survive into the fulfilled content.
+const (
+	rawEmail = "john.doe@example.com"
+	rawCard  = "4111111111111111"
+)
+
+var query = fmt.Sprintf("Send the receipt to %s and charge card %s", rawEmail, rawCard)
+
+func fail(msg string) {
+	fmt.Fprintf(os.Stderr, "FAIL: %s\n", msg)
+	os.Exit(1)
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func main() {
+	endpoint := envOr("AXONFLOW_AGENT_URL", "http://localhost:8080")
+	clientID := os.Getenv("AXONFLOW_CLIENT_ID")
+	clientSecret := os.Getenv("AXONFLOW_CLIENT_SECRET")
+	if clientID == "" || clientSecret == "" {
+		fmt.Fprintln(os.Stderr, "required env not set: AXONFLOW_CLIENT_ID + AXONFLOW_CLIENT_SECRET; see file header")
+		os.Exit(2)
+	}
+
+	ctx := context.Background()
+	client := axonflow.NewClient(axonflow.AxonFlowConfig{
+		Endpoint:     endpoint,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		Mode:         "production",
+	})
+
+	// 1. Decide() surfaces the engine-fulfillable redact_pii obligation.
+	decision, err := client.Decide(ctx, axonflow.DecideRequest{
+		Stage:          "tool",
+		Query:          query,
+		Target:         axonflow.DecisionTarget{Type: "tool", Tool: "send_receipt"},
+		CallerIdentity: axonflow.DecisionCallerIdentity{GatewayID: "sdk-runtime-e2e"},
+	})
+	if err != nil {
+		fail(fmt.Sprintf("Decide returned error: %v", err))
+	}
+	fmt.Printf("decide -> verdict=%s obligations=%d trace_id=%s\n", decision.Verdict, len(decision.Obligations), decision.TraceID)
+	if decision.Verdict != axonflow.VerdictAllow {
+		fail(fmt.Sprintf("expected allow, got %s (%s)", decision.Verdict, decision.Error))
+	}
+	if decision.TraceID == "" {
+		fail("decide response did not surface a trace_id")
+	}
+	if !axonflow.HasRequestRedaction(decision.Obligations) {
+		fail(fmt.Sprintf("no request-phase redact_pii obligation on a PII request; got %+v", decision.Obligations))
+	}
+	var ful *axonflow.ObligationFulfillment
+	for _, o := range decision.Obligations {
+		if o.Type == axonflow.ObligationRedactPII {
+			ful = o.Fulfillment
+			break
+		}
+	}
+	if ful == nil || ful.Phase != axonflow.PhaseRequest {
+		fail(fmt.Sprintf("obligation not request-phase engine-fulfillable: %+v", ful))
+	}
+	if !strings.Contains(ful.Endpoint, "check-input") {
+		fail(fmt.Sprintf("fulfillment endpoint is not the request-redaction endpoint: %s", ful.Endpoint))
+	}
+	fmt.Printf("  obligation fulfillment -> %s phase=%s types=%v\n", ful.Endpoint, ful.Phase, ful.ContentTypes)
+
+	// 2. FulfillRequest() returns ENGINE-redacted content; raw PII is gone.
+	content, didRedact, err := client.FulfillRequest(ctx, decision, query)
+	if err != nil {
+		if errors.Is(err, axonflow.ErrObligationNotFulfillable) {
+			fail(fmt.Sprintf("obligation unexpectedly not fulfillable against real agent: %v", err))
+		}
+		fail(fmt.Sprintf("FulfillRequest returned error: %v", err))
+	}
+	fmt.Printf("fulfill_request -> did_redact=%v content=%q\n", didRedact, content)
+	if !didRedact {
+		fail("engine reported no redaction on a request that carries PII")
+	}
+	if strings.Contains(content, rawEmail) {
+		fail(fmt.Sprintf("raw email survived fulfillment — PII leak: %q", content))
+	}
+	if strings.Contains(content, rawCard) {
+		fail(fmt.Sprintf("raw card survived fulfillment — PII leak: %q", content))
+	}
+	if content == query {
+		fail("fulfilled content is byte-identical to the unredacted query")
+	}
+
+	// 3. DecideAndFulfill() one-call path yields the same masked content.
+	verdict, oneCall, _, err := client.DecideAndFulfill(ctx, axonflow.DecideRequest{
+		Stage:  "tool",
+		Query:  query,
+		Target: axonflow.DecisionTarget{Type: "tool", Tool: "send_receipt"},
+	})
+	if err != nil {
+		fail(fmt.Sprintf("DecideAndFulfill returned error: %v", err))
+	}
+	fmt.Printf("decide_and_fulfill -> verdict=%s content=%q\n", verdict, oneCall)
+	if verdict != axonflow.VerdictAllow {
+		fail(fmt.Sprintf("decide_and_fulfill verdict %s, expected allow", verdict))
+	}
+	if strings.Contains(oneCall, rawEmail) || strings.Contains(oneCall, rawCard) {
+		fail(fmt.Sprintf("decide_and_fulfill leaked PII: %q", oneCall))
+	}
+	if oneCall == query {
+		fail("decide_and_fulfill content is byte-identical to the unredacted query")
+	}
+
+	// 4. Demo / wrong credentials are refused by the enterprise PDP.
+	badClient := axonflow.NewClient(axonflow.AxonFlowConfig{
+		Endpoint:     endpoint,
+		ClientID:     "demo-org",
+		ClientSecret: "demo-license-not-real",
+		Mode:         "production",
+	})
+	_, err = badClient.Decide(ctx, axonflow.DecideRequest{Stage: "tool", Query: "hi"})
+	if err == nil {
+		fail("demo credentials were NOT refused by the PDP")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		fail(fmt.Sprintf("demo creds error did not surface a 401: %v", err))
+	}
+	fmt.Println("demo creds -> 401 (refused) OK")
+
+	fmt.Println("PASS: decide -> fulfill -> forward verified against real agent")
+}

--- a/testdata/wire_shape_baseline.json
+++ b/testdata/wire_shape_baseline.json
@@ -405,7 +405,9 @@
       "spec_only": []
     },
     "MCPCheckInputRequest": {
-      "sdk_only": [],
+      "sdk_only": [
+        "content_type"
+      ],
       "spec_only": [
         "client_id",
         "tenant_id",
@@ -413,6 +415,14 @@
         "user_role",
         "user_token"
       ]
+    },
+    "MCPCheckInputResponse": {
+      "sdk_only": [
+        "redacted",
+        "redacted_statement",
+        "redaction_evaluated"
+      ],
+      "spec_only": []
     },
     "MCPCheckOutputRequest": {
       "sdk_only": [],
@@ -422,6 +432,12 @@
         "user_id",
         "user_token"
       ]
+    },
+    "MCPCheckOutputResponse": {
+      "sdk_only": [
+        "redaction_evaluated"
+      ],
+      "spec_only": []
     },
     "MCPExecuteRequest": {
       "sdk_only": [

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package axonflow
 
-// Version is the SDK version.
-const Version = "8.4.0"
+// Version is the current SDK version.
+const Version = "8.5.0"


### PR DESCRIPTION
Ports the Decision Mode PEP (Policy Enforcement Point) contract into the Go SDK — a single blessed path of **decide → fulfill → forward** (ADR-056, epic getaxonflow/axonflow-enterprise#2563, tracking #2571). Cross-SDK parity with the canonical Python SDK (PR #211) and the `platform/shared/pep` Go reference PEP.

## The structural guarantee (#2563)

This SDK contains **no redaction logic of its own** — no regex, no pattern table, no masking branch. The only way it can discharge a `redact_pii` obligation is by round-tripping the source content through the engine endpoint the obligation names (`/api/v1/mcp/check-input`) and forwarding what the engine returns. If an obligation arrives without a fulfillable engine endpoint — or the engine reports the redactor did not run — `FulfillRequest` **fails closed** rather than forwarding unredacted content.

## New surface (`pep.go`)

- `(*AxonFlowClient) Decide(ctx, DecideRequest) (*DecideResponse, error)` — `POST /api/v1/decide` using the SDK's existing HTTP Basic (org:license) auth. Demo / wrong credentials surface as the SDK's `*httpError` (401). A deny verdict is returned in the body (HTTP 200), not as an error.
- `(*AxonFlowClient) FulfillRequest(ctx, *DecideResponse, statement) (string, bool, error)` — discharges every request-phase `redact_pii` obligation via the engine. Returns `ErrObligationNotFulfillable` (fail-closed) on every unfulfillable condition; never redacts locally.
- `(*AxonFlowClient) DecideAndFulfill(ctx, DecideRequest) (verdict, content string, *DecideResponse, error)` — one-call path; returns empty content on the not-fulfillable path so a caller that ignores the error cannot forward the raw query.
- `HasRequestRedaction([]Obligation) bool` branch helper + `ErrObligationNotFulfillable` sentinel (match with `errors.Is`).
- Wire DTOs: `DecideRequest`, `DecideResponse`, `Obligation`, `ObligationFulfillment`, `DecisionCallerIdentity`, `DecisionTarget`.
- Constants: `ObligationRedactPII`, `PhaseRequest`/`PhaseResponse`, `ContentTypeText`, `VerdictAllow`/`VerdictDeny`/`VerdictNeedsApproval`.

## MCP type additions (`axonflow.go`)

- `MCPCheckInputRequest.ContentType` (`content_type`)
- `MCPCheckInputResponse.Redacted` / `RedactedStatement` / `RedactionEvaluated`
- `MCPCheckOutputResponse.RedactionEvaluated`

## Tests

- **`pep_test.go`** (httptest): decide parse + Basic-auth assertion; every fail-closed branch (no request-phase fulfillment, response phase, unadvertised content-type, foreign endpoint, engine error, `redaction_evaluated` false, `redaction_evaluated` absent); passthrough (no obligation, engine-found-nothing); `DecideAndFulfill` allow/deny/unfulfillable/decide-error. **100% statement coverage on every `pep.go` function.**
- **`runtime-e2e/decide_fulfill_obligation/main.go`** (real agent, no mocks): proves decide → fulfill → masked against a live enterprise agent; `john.doe@example.com` + `4111111111111111` do not survive; demo creds → 401.

runtime-e2e PASS output:
```
decide -> verdict=allow obligations=1 trace_id=0384545ef3ad1414db7f9d68c43e77a7
  obligation fulfillment -> /api/v1/mcp/check-input phase=request types=[text/plain]
fulfill_request -> did_redact=true content="Send the receipt to jo****************om and charge card 4**************1"
decide_and_fulfill -> verdict=allow content="Send the receipt to jo****************om and charge card 4**************1"
demo creds -> 401 (refused) OK
PASS: decide -> fulfill -> forward verified against real agent
```

## Wire-shape

Baseline regenerated at the **same pinned community SHA** (`8c8d6c9c…`, unchanged — no SHA-bump). The three MCP field additions are acknowledged SDK supersets; `DecideRequest`/`DecideResponse`/`Obligation` are not in the spec at the pinned SHA so they carry no drift entries.

## Version

Bumped to **8.5.0** (minor; SDK semver decoupled from platform). CHANGELOG updated.

Refs #2571, #2563.