### PR TITLE
fix: fail-closed on 4xx, gate debug logs, repair examples

### DIFF
--- a/.github/workflows/heartbeat-real-stack.yml
+++ b/.github/workflows/heartbeat-real-stack.yml
@@ -37,7 +37,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          # macos-latest runners abort Go 1.22-built binaries at exec time
+          # ("dyld: missing LC_UUID load command", SIGABRT); newer Go
+          # toolchains emit LC_UUID. 1.22 is EOL and never got the fix.
+          go-version: '1.24.x'
 
       - name: Set up Python (for harness driver)
         uses: actions/setup-python@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.5.1] - 2026-07-09 — Fail-open hardening + debug-log gating + example fixes
+
+Hostile-testing sweep ahead of the BukuWarung integration
+(getaxonflow/axonflow-enterprise#2861).
+
+### Fixed
+
+- **Production-mode fail-open no longer swallows definitive 4xx errors.**
+  `ProxyLLMCall`/`ProxyLLMCallWithMedia` in `Mode:"production"` used to convert
+  an HTTP 401 (invalid credentials / invalid user token) into a synthetic
+  `success=true` "fail-open" response: the retry wrapper's
+  `request failed after N attempts` prefix matched the string-based
+  `isAxonFlowError` check. Fail-open eligibility is now structural
+  (`isFailOpenEligible`): definitive 4xx client errors (400/401/403*/404, …)
+  always surface as errors; availability failures (transport errors, 5xx) and
+  429 remain fail-open eligible. (*402/403 policy envelopes are still parsed
+  as blocked responses before this check, unchanged.) Regression tests:
+  `TestProxyLLMCallDoesNotFailOpenOn4xx`, `TestProxyLLMCallStillFailsOpenOn5xx`;
+  runtime proof: `runtime-e2e/proxy_fail_closed_4xx/`.
+- **`[SDK-DEBUG]` logging is now gated on `Config.Debug`.** The SDK
+  unconditionally logged raw response bodies (up to 500 chars) and result
+  payloads — customer data (LLM output, PII) landed in the logs of every
+  caller. All `[SDK-DEBUG]` lines in the request path now require
+  `Debug: true`.
+- **`examples/explain-decision` and `examples/wcp-retry-idempotency` build
+  again.** Their standalone `go.mod`s still declared the v7 module path
+  (`require …/v7 v7.1.0` resp. the outright-invalid `…/v7 v5.0.0`) while the
+  code imports `…/v8` — both were broken since the v8 major bump. Now
+  `…/v8` + `replace` to the repo root.
+- **Examples pass `AXONFLOW_USER_TOKEN` and fail honestly.** Enterprise
+  stacks (`DEPLOYMENT_MODE=enterprise`) validate user tokens as JWTs; the
+  examples passed `""` (→ `anonymous`) and 401'd. `basic`, `planning`
+  (incl. `ExecutePlan`), `connectors`, `indonesia_compliance` now read
+  `AXONFLOW_USER_TOKEN`. `basic` also exits non-zero on a failed response
+  instead of printing a success checkmark (and no longer prints
+  `%!s(<nil>)` for the result).
+
+### Added
+
+- `runtime-e2e/proxy_fail_closed_4xx/` — live-agent assertion that
+  production-mode fail-open never converts a 401 into an ungoverned success
+  (garbage user token + wrong Basic credentials must error; control call with
+  valid credentials succeeds).
+
 ## [8.5.0] - 2026-06-09 — Decision Mode PEP: decide → fulfill → forward
 
 Ports the Decision Mode PEP (Policy Enforcement Point) contract into the Go

--- a/axonflow.go
+++ b/axonflow.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -773,7 +774,7 @@ func (c *AxonFlowClient) ProxyLLMCall(userToken, query, requestType string, cont
 	}
 
 	// Handle fail-open in production mode
-	if err != nil && c.config.Mode == "production" && c.isAxonFlowError(err) {
+	if err != nil && c.config.Mode == "production" && c.isFailOpenEligible(err) {
 		if c.config.Debug {
 			log.Printf("[AxonFlow] AxonFlow unavailable, failing open: %v", err)
 		}
@@ -846,7 +847,7 @@ func (c *AxonFlowClient) ProxyLLMCallWithMedia(userToken, query, requestType str
 	}
 
 	// Handle fail-open in production mode
-	if err != nil && c.config.Mode == "production" && c.isAxonFlowError(err) {
+	if err != nil && c.config.Mode == "production" && c.isFailOpenEligible(err) {
 		if c.config.Debug {
 			log.Printf("[AxonFlow] AxonFlow unavailable, failing open: %v", err)
 		}
@@ -946,12 +947,16 @@ func (c *AxonFlowClient) executeRequest(req ClientRequest) (*ClientResponse, err
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
-	// [DEBUG] Log raw response body before unmarshaling
-	log.Printf("[SDK-DEBUG] Raw response body size: %d bytes", len(body))
-	if len(body) > 0 && len(body) <= 500 {
-		log.Printf("[SDK-DEBUG] Raw response body (full): %s", string(body))
-	} else if len(body) > 500 {
-		log.Printf("[SDK-DEBUG] Raw response body (first 500 chars): %s...", string(body[:500]))
+	// [DEBUG] Log raw response body before unmarshaling. Gated on Debug:
+	// response bodies can carry customer data (LLM output, PII) and must
+	// never land in logs of a production caller that didn't opt in.
+	if c.config.Debug {
+		log.Printf("[SDK-DEBUG] Raw response body size: %d bytes", len(body))
+		if len(body) > 0 && len(body) <= 500 {
+			log.Printf("[SDK-DEBUG] Raw response body (full): %s", string(body))
+		} else if len(body) > 500 {
+			log.Printf("[SDK-DEBUG] Raw response body (first 500 chars): %s...", string(body[:500]))
+		}
 	}
 
 	// For 402 (Payment Required) or 403 (Forbidden), the request was blocked - parse the response body
@@ -986,7 +991,9 @@ func (c *AxonFlowClient) executeRequest(req ClientRequest) (*ClientResponse, err
 			if dataSuccess, hasSuccess := dataMap["success"].(bool); hasSuccess && !dataSuccess {
 				// Orchestrator execution failed - extract error message
 				if errorMsg, hasError := dataMap["error"].(string); hasError {
-					log.Printf("[SDK-DEBUG] Detected orchestrator failure in data.error: %s", errorMsg)
+					if c.config.Debug {
+						log.Printf("[SDK-DEBUG] Detected orchestrator failure in data.error: %s", errorMsg)
+					}
 					// Surface the error by setting the Error field and marking success as false
 					clientResp.Error = errorMsg
 					clientResp.Success = false
@@ -995,24 +1002,32 @@ func (c *AxonFlowClient) executeRequest(req ClientRequest) (*ClientResponse, err
 			// Also check if data.result or data.data exists and use it if Result is empty
 			if clientResp.Result == "" {
 				if dataResult, hasResult := dataMap["result"].(string); hasResult && dataResult != "" {
-					log.Printf("[SDK-DEBUG] Using data.result field (length: %d)", len(dataResult))
+					if c.config.Debug {
+						log.Printf("[SDK-DEBUG] Using data.result field (length: %d)", len(dataResult))
+					}
 					clientResp.Result = dataResult
 				} else if dataData, hasData := dataMap["data"].(string); hasData && dataData != "" {
-					log.Printf("[SDK-DEBUG] Using data.data field (length: %d)", len(dataData))
+					if c.config.Debug {
+						log.Printf("[SDK-DEBUG] Using data.data field (length: %d)", len(dataData))
+					}
 					clientResp.Result = dataData
 				}
 			}
 			// Check if data.plan_id exists and use it if PlanID is empty
 			if clientResp.PlanID == "" {
 				if dataPlanID, hasPlanID := dataMap["plan_id"].(string); hasPlanID && dataPlanID != "" {
-					log.Printf("[SDK-DEBUG] Using data.plan_id field: %s", dataPlanID)
+					if c.config.Debug {
+						log.Printf("[SDK-DEBUG] Using data.plan_id field: %s", dataPlanID)
+					}
 					clientResp.PlanID = dataPlanID
 				}
 			}
 			// Check if data.metadata exists and use it if Metadata is empty
 			if clientResp.Metadata == nil {
 				if dataMetadata, hasMetadata := dataMap["metadata"].(map[string]interface{}); hasMetadata {
-					log.Printf("[SDK-DEBUG] Using data.metadata field")
+					if c.config.Debug {
+						log.Printf("[SDK-DEBUG] Using data.metadata field")
+					}
 					clientResp.Metadata = dataMetadata
 				}
 			}
@@ -1020,18 +1035,20 @@ func (c *AxonFlowClient) executeRequest(req ClientRequest) (*ClientResponse, err
 	}
 
 	// [DEBUG] Log unmarshaled response details
-	log.Printf("[SDK-DEBUG] Unmarshaled - Success: %v, Blocked: %v, BlockReason: %s, Result length: %d, PlanID: %s",
-		clientResp.Success, clientResp.Blocked, clientResp.BlockReason, len(clientResp.Result), clientResp.PlanID)
-	if len(clientResp.Result) > 0 {
-		if len(clientResp.Result) <= 100 {
-			log.Printf("[SDK-DEBUG] Result (full): %s", clientResp.Result)
+	if c.config.Debug {
+		log.Printf("[SDK-DEBUG] Unmarshaled - Success: %v, Blocked: %v, BlockReason: %s, Result length: %d, PlanID: %s",
+			clientResp.Success, clientResp.Blocked, clientResp.BlockReason, len(clientResp.Result), clientResp.PlanID)
+		if len(clientResp.Result) > 0 {
+			if len(clientResp.Result) <= 100 {
+				log.Printf("[SDK-DEBUG] Result (full): %s", clientResp.Result)
+			} else {
+				log.Printf("[SDK-DEBUG] Result (first 100 chars): %s...", clientResp.Result[:100])
+			}
 		} else {
-			log.Printf("[SDK-DEBUG] Result (first 100 chars): %s...", clientResp.Result[:100])
+			log.Printf("[SDK-DEBUG] Result is empty!")
 		}
-	} else {
-		log.Printf("[SDK-DEBUG] Result is empty!")
+		log.Printf("[SDK-DEBUG] Metadata keys: %v", getMetadataKeys(clientResp.Metadata))
 	}
-	log.Printf("[SDK-DEBUG] Metadata keys: %v", getMetadataKeys(clientResp.Metadata))
 
 	// If we detected an error in the data field, log it prominently
 	if clientResp.Error != "" {
@@ -1052,6 +1069,25 @@ func (c *AxonFlowClient) isAxonFlowError(err error) bool {
 		strings.Contains(errMsg, "governance") ||
 		strings.Contains(errMsg, "request failed") ||
 		strings.Contains(errMsg, "connection refused")
+}
+
+// isFailOpenEligible reports whether an error may trigger production-mode
+// fail-open. Fail-open exists for AVAILABILITY failures only (agent
+// unreachable, timeout, 5xx). A definitive 4xx from the agent — 401 bad
+// credentials, 400 malformed request, 404 — is not an availability failure:
+// failing open there silently converts an auth/config error into an
+// ungoverned success (the retry wrapper's "request failed after N attempts"
+// prefix used to make isAxonFlowError match exactly that). 429 stays
+// eligible: rate limiting is a capacity condition, same class as 5xx.
+func (c *AxonFlowClient) isFailOpenEligible(err error) bool {
+	var httpErr *httpError
+	if errors.As(err, &httpErr) {
+		if httpErr.statusCode >= 400 && httpErr.statusCode < 500 && httpErr.statusCode != http.StatusTooManyRequests {
+			return false
+		}
+		return true
+	}
+	return c.isAxonFlowError(err)
 }
 
 // HealthCheck checks if AxonFlow Agent is healthy

--- a/axonflow.go
+++ b/axonflow.go
@@ -1050,8 +1050,11 @@ func (c *AxonFlowClient) executeRequest(req ClientRequest) (*ClientResponse, err
 		log.Printf("[SDK-DEBUG] Metadata keys: %v", getMetadataKeys(clientResp.Metadata))
 	}
 
-	// If we detected an error in the data field, log it prominently
-	if clientResp.Error != "" {
+	// If we detected an error in the data field, log it (Debug-gated): the
+	// server-provided error string is customer-derived and can echo query
+	// fragments, so it must not log in production — same leak class as the
+	// raw-body [SDK-DEBUG] lines above.
+	if clientResp.Error != "" && c.config.Debug {
 		log.Printf("[SDK-DEBUG] Error field set: %s", clientResp.Error)
 	}
 

--- a/axonflow_http_test.go
+++ b/axonflow_http_test.go
@@ -215,6 +215,83 @@ func TestProxyLLMCallFailOpen(t *testing.T) {
 	}
 }
 
+// TestProxyLLMCallDoesNotFailOpenOn4xx pins the fail-open eligibility
+// boundary: a definitive 4xx from the agent (401 bad credentials, 400 bad
+// request) must surface as an error in production mode, never convert into
+// an ungoverned success=true. Regression for the bug where the retry
+// wrapper's "request failed after N attempts" prefix made isAxonFlowError
+// match a wrapped 401 and fail open.
+func TestProxyLLMCallDoesNotFailOpenOn4xx(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+	}{
+		{"401 unauthorized", http.StatusUnauthorized},
+		{"400 bad request", http.StatusBadRequest},
+		{"404 not found", http.StatusNotFound},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(`{"success":false,"error":"Invalid user token: invalid token: token is malformed","blocked":false}`))
+			}))
+			defer server.Close()
+
+			// Retry enabled: the wrapper's "request failed after N attempts"
+			// prefix is exactly what used to trip the string-match fail-open.
+			client := NewClient(AxonFlowConfig{
+				Endpoint: server.URL,
+				ClientID: "test",
+				Mode:     "production",
+				Retry: RetryConfig{
+					Enabled:      true,
+					MaxAttempts:  2,
+					InitialDelay: 1 * time.Millisecond,
+				},
+				Timeout: 2 * time.Second,
+				Cache:   CacheConfig{Enabled: false},
+			})
+
+			resp, err := client.ProxyLLMCall("user", "query", "chat", nil)
+			if err == nil {
+				t.Fatalf("expected error for HTTP %d in production mode, got success resp: %+v", tc.status, resp)
+			}
+		})
+	}
+}
+
+// TestProxyLLMCallStillFailsOpenOn5xx pins that availability failures (5xx)
+// remain fail-open eligible in production mode after the 4xx fix.
+func TestProxyLLMCallStillFailsOpenOn5xx(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"success":false,"error":"upstream down"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{
+		Endpoint: server.URL,
+		ClientID: "test",
+		Mode:     "production",
+		Retry: RetryConfig{
+			Enabled:      true,
+			MaxAttempts:  2,
+			InitialDelay: 1 * time.Millisecond,
+		},
+		Timeout: 2 * time.Second,
+		Cache:   CacheConfig{Enabled: false},
+	})
+
+	resp, err := client.ProxyLLMCall("user", "query", "chat", nil)
+	if err != nil {
+		t.Fatalf("expected fail-open on 503, got error: %v", err)
+	}
+	if !resp.Success {
+		t.Error("expected fail-open to return success=true on 503")
+	}
+}
+
 func TestProxyLLMCallEmptyUserTokenDefaultsToAnonymous(t *testing.T) {
 	var receivedUserToken string
 

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -14,6 +14,11 @@ func main() {
 	agentURL := getEnv("AXONFLOW_AGENT_URL", "http://localhost:8080")
 	clientID := getEnv("AXONFLOW_CLIENT_ID", "")
 	clientSecret := getEnv("AXONFLOW_CLIENT_SECRET", "")
+	// Enterprise stacks (DEPLOYMENT_MODE=enterprise) validate user tokens as
+	// JWTs. Export AXONFLOW_USER_TOKEN (see scripts/generate-jwt.sh in the
+	// platform repo). Community stacks skip JWT validation, so leaving it
+	// empty ("anonymous") is fine there.
+	userToken := getEnv("AXONFLOW_USER_TOKEN", "")
 
 	if clientID == "" || clientSecret == "" {
 		log.Fatal("AXONFLOW_CLIENT_ID and AXONFLOW_CLIENT_SECRET must be set")
@@ -34,7 +39,7 @@ func main() {
 	// Execute a simple query
 	fmt.Println("\nExecuting governed query...")
 	resp, err := client.ProxyLLMCall(
-		"", // SDK auto-populates user_token (defaults to "anonymous" if no JWT). Don't pass a literal — JWT-validating stacks reject it.
+		userToken,
 		"What is the capital of France?",
 		"chat",
 		map[string]interface{}{
@@ -57,13 +62,12 @@ func main() {
 
 	// Check if request succeeded
 	if !resp.Success {
-		fmt.Printf("❌ Query failed: %s\n", resp.Error)
-		return
+		log.Fatalf("❌ Query failed: %s", resp.Error)
 	}
 
 	// Display result
 	fmt.Println("✓ Query executed successfully")
-	fmt.Printf("Result: %s\n", resp.Data)
+	fmt.Printf("Result: %v\n", resp.Data)
 
 	// Display governance metadata
 	fmt.Println("\nGovernance Metadata:")
@@ -79,22 +83,23 @@ func main() {
 	fmt.Println(strings.Repeat("=", 60))
 
 	resp2, err := client.ProxyLLMCall(
-		"", // SDK auto-populates user_token (defaults to "anonymous" if no JWT). Don't pass a literal — JWT-validating stacks reject it.
+		userToken,
 		"My email is john.doe@example.com and my SSN is 123-45-6789",
 		"chat",
 		map[string]interface{}{},
 	)
 
 	if err != nil {
-		log.Printf("Warning: PII test query failed: %v", err)
-		return
+		log.Fatalf("PII test query failed: %v", err)
 	}
 
 	if resp2.Blocked {
 		fmt.Printf("✓ PII detected and request blocked\n")
 		fmt.Printf("  Reason: %s\n", resp2.BlockReason)
+	} else if !resp2.Success {
+		log.Fatalf("❌ PII test query failed: %s", resp2.Error)
 	} else {
-		fmt.Printf("✓ PII handled: %s\n", resp2.Data)
+		fmt.Printf("✓ PII handled: %v\n", resp2.Data)
 	}
 }
 

--- a/examples/connectors/main.go
+++ b/examples/connectors/main.go
@@ -14,6 +14,9 @@ func main() {
 	agentURL := getEnv("AXONFLOW_AGENT_URL", "http://localhost:8080")
 	clientID := getEnv("AXONFLOW_CLIENT_ID", "")
 	clientSecret := getEnv("AXONFLOW_CLIENT_SECRET", "")
+	// Enterprise stacks (DEPLOYMENT_MODE=enterprise) validate user tokens as
+	// JWTs — export AXONFLOW_USER_TOKEN. Community stacks skip JWT validation.
+	userToken := getEnv("AXONFLOW_USER_TOKEN", "")
 
 	if clientID == "" || clientSecret == "" {
 		log.Fatal("AXONFLOW_CLIENT_ID and AXONFLOW_CLIENT_SECRET must be set")
@@ -93,7 +96,7 @@ func main() {
 		fmt.Println("Querying Amadeus connector for flights...")
 
 		resp, err := client.QueryConnector(
-			"", // SDK auto-populates user_token (defaults to "anonymous"). Don't hardcode a non-JWT literal — JWT-validating stacks reject it.
+			userToken, // AXONFLOW_USER_TOKEN (JWT) on enterprise stacks; empty ("anonymous") is fine on community stacks.
 			"amadeus-prod",
 			"Find flights from Paris to Amsterdam on 2025-12-15",
 			map[string]interface{}{
@@ -118,7 +121,7 @@ func main() {
 	fmt.Println("\nQuerying Redis connector...")
 
 	redisResp, err := client.QueryConnector(
-		"", // SDK auto-populates user_token (defaults to "anonymous"). Don't hardcode a non-JWT literal — JWT-validating stacks reject it.
+		userToken, // AXONFLOW_USER_TOKEN (JWT) on enterprise stacks; empty ("anonymous") is fine on community stacks.
 		"redis-cache",
 		"Get cached user preferences for user-123",
 		map[string]interface{}{

--- a/examples/explain-decision/go.mod
+++ b/examples/explain-decision/go.mod
@@ -1,7 +1,7 @@
-module github.com/getaxonflow/axonflow-sdk-go/v7/examples/explain-decision
+module github.com/getaxonflow/axonflow-sdk-go/v8/examples/explain-decision
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v7 v7.1.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0
 
-replace github.com/getaxonflow/axonflow-sdk-go/v7 => ../..
+replace github.com/getaxonflow/axonflow-sdk-go/v8 => ../..

--- a/examples/explain-decision/go.mod
+++ b/examples/explain-decision/go.mod
@@ -2,6 +2,6 @@ module github.com/getaxonflow/axonflow-sdk-go/v8/examples/explain-decision
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.1
 
 replace github.com/getaxonflow/axonflow-sdk-go/v8 => ../..

--- a/examples/indonesia_compliance/main.go
+++ b/examples/indonesia_compliance/main.go
@@ -14,6 +14,9 @@ func main() {
 	agentURL := getEnv("AXONFLOW_AGENT_URL", "http://localhost:8080")
 	clientID := getEnv("AXONFLOW_CLIENT_ID", "")
 	clientSecret := getEnv("AXONFLOW_CLIENT_SECRET", "")
+	// Enterprise stacks (DEPLOYMENT_MODE=enterprise) validate user tokens as
+	// JWTs — export AXONFLOW_USER_TOKEN. Community stacks skip JWT validation.
+	userToken := getEnv("AXONFLOW_USER_TOKEN", "")
 
 	if clientID == "" || clientSecret == "" {
 		log.Fatal("AXONFLOW_CLIENT_ID and AXONFLOW_CLIENT_SECRET must be set")
@@ -30,7 +33,7 @@ func main() {
 	// 2. Send a request containing an Indonesian NIK (national ID number)
 	fmt.Println("\nSending governed request with NIK...")
 	resp, err := client.ProxyLLMCall(
-		"",
+		userToken,
 		"Customer NIK is 3204110507900003 and their name is Budi Santoso",
 		"chat",
 		map[string]interface{}{

--- a/examples/planning/main.go
+++ b/examples/planning/main.go
@@ -15,6 +15,9 @@ func main() {
 	agentURL := getEnv("AXONFLOW_AGENT_URL", "http://localhost:8080")
 	clientID := getEnv("AXONFLOW_CLIENT_ID", "")
 	clientSecret := getEnv("AXONFLOW_CLIENT_SECRET", "")
+	// Enterprise stacks (DEPLOYMENT_MODE=enterprise) validate user tokens as
+	// JWTs — export AXONFLOW_USER_TOKEN. Community stacks skip JWT validation.
+	userToken := getEnv("AXONFLOW_USER_TOKEN", "")
 
 	if clientID == "" || clientSecret == "" {
 		log.Fatal("AXONFLOW_CLIENT_ID and AXONFLOW_CLIENT_SECRET must be set")
@@ -55,7 +58,7 @@ func main() {
 	fmt.Printf("Goal: %s\n\n", planGoal)
 	fmt.Println("Generating plan...")
 
-	plan, err := client.GeneratePlan(planGoal, "travel")
+	plan, err := client.GeneratePlan(planGoal, "travel", userToken)
 	if err != nil {
 		log.Fatalf("Plan generation failed: %v", err)
 	}
@@ -95,7 +98,7 @@ func main() {
 	fmt.Println("Executing plan...")
 	startTime := time.Now()
 
-	execResp, err := client.ExecutePlan(plan.PlanID)
+	execResp, err := client.ExecutePlan(plan.PlanID, userToken)
 	if err != nil {
 		log.Fatalf("Plan execution failed: %v", err)
 	}
@@ -164,7 +167,7 @@ func main() {
 	fmt.Printf("Goal: %s\n\n", complexGoal)
 	fmt.Println("Generating complex plan...")
 
-	complexPlan, err := client.GeneratePlan(complexGoal, "research")
+	complexPlan, err := client.GeneratePlan(complexGoal, "research", userToken)
 	if err != nil {
 		log.Printf("Complex plan generation failed: %v", err)
 		return

--- a/examples/wcp-retry-idempotency/go.mod
+++ b/examples/wcp-retry-idempotency/go.mod
@@ -1,7 +1,7 @@
-module github.com/getaxonflow/axonflow-sdk-go/v7/examples/wcp-retry-idempotency
+module github.com/getaxonflow/axonflow-sdk-go/v8/examples/wcp-retry-idempotency
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v7 v5.0.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0
 
-replace github.com/getaxonflow/axonflow-sdk-go/v7 => ../..
+replace github.com/getaxonflow/axonflow-sdk-go/v8 => ../..

--- a/examples/wcp-retry-idempotency/go.mod
+++ b/examples/wcp-retry-idempotency/go.mod
@@ -2,6 +2,6 @@ module github.com/getaxonflow/axonflow-sdk-go/v8/examples/wcp-retry-idempotency
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.1
 
 replace github.com/getaxonflow/axonflow-sdk-go/v8 => ../..

--- a/examples/wcp-retry-idempotency/go.sum
+++ b/examples/wcp-retry-idempotency/go.sum
@@ -1,0 +1,2 @@
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/runtime-e2e/proxy_fail_closed_4xx/main.go
+++ b/runtime-e2e/proxy_fail_closed_4xx/main.go
@@ -1,0 +1,133 @@
+//go:build ignore
+
+// runtime-e2e/proxy_fail_closed_4xx/main.go
+//
+// Real-stack assertion: production-mode fail-open must NOT swallow definitive
+// 4xx responses from the agent (getaxonflow/axonflow-enterprise#2861).
+//
+// Per CLAUDE.md HARD RULE #0 this driver MUST hit a real running AxonFlow
+// agent — no httptest, no fixture servers.
+//
+// Regression background: ProxyLLMCall in Mode="production" used to convert an
+// HTTP 401 (invalid credentials / invalid user token) into a synthetic
+// success=true "fail-open" response, because the retry wrapper's
+// "request failed after N attempts" prefix matched the string-based
+// isAxonFlowError check. An auth failure silently became an ungoverned
+// success. Fail-open is for AVAILABILITY failures (agent down, 5xx), never
+// for definitive client errors.
+//
+// Assertions against a live agent:
+//
+//  1. ProxyLLMCall with syntactically valid Basic credentials but a garbage
+//     user token returns an ERROR in production mode (HTTP 401 surfaces; no
+//     fail-open success).
+//  2. ProxyLLMCall with wrong Basic credentials returns an ERROR in
+//     production mode (HTTP 401 surfaces; no fail-open success).
+//  3. With valid credentials + valid JWT the same call succeeds, proving the
+//     failure in (1)/(2) is the auth path, not the stack.
+//
+// Run locally (after `source /tmp/axonflow-e2e-env.sh` from the enterprise
+// setup script):
+//
+//	AXONFLOW_AGENT_URL=http://localhost:8080 \
+//	AXONFLOW_CLIENT_ID="$AXONFLOW_CLIENT_ID" \
+//	AXONFLOW_CLIENT_SECRET="$AXONFLOW_CLIENT_SECRET" \
+//	AXONFLOW_USER_TOKEN="$AXONFLOW_USER_TOKEN" \
+//	go run runtime-e2e/proxy_fail_closed_4xx/main.go
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	axonflow "github.com/getaxonflow/axonflow-sdk-go/v8"
+)
+
+func env(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func newClient(agentURL, clientID, clientSecret string) *axonflow.AxonFlowClient {
+	return axonflow.NewClient(axonflow.AxonFlowConfig{
+		Endpoint:     agentURL,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		Mode:         "production", // fail-open enabled — the surface under test
+		Retry: axonflow.RetryConfig{
+			Enabled:      true, // retry wrapper prefix is what used to trip fail-open
+			MaxAttempts:  2,
+			InitialDelay: 50 * time.Millisecond,
+		},
+		Timeout: 30 * time.Second,
+		Cache:   axonflow.CacheConfig{Enabled: false},
+	})
+}
+
+func main() {
+	agentURL := env("AXONFLOW_AGENT_URL", "http://localhost:8080")
+	clientID := os.Getenv("AXONFLOW_CLIENT_ID")
+	clientSecret := os.Getenv("AXONFLOW_CLIENT_SECRET")
+	userToken := os.Getenv("AXONFLOW_USER_TOKEN")
+	if clientID == "" || clientSecret == "" || userToken == "" {
+		fmt.Println("FAIL: AXONFLOW_CLIENT_ID, AXONFLOW_CLIENT_SECRET and AXONFLOW_USER_TOKEN must be set (source /tmp/axonflow-e2e-env.sh)")
+		os.Exit(1)
+	}
+
+	failures := 0
+
+	// 1. Valid Basic auth, garbage user token → 401 must surface as error.
+	{
+		client := newClient(agentURL, clientID, clientSecret)
+		resp, err := client.ProxyLLMCall("not-a-jwt", "What is 2+2?", "chat", nil)
+		if err == nil {
+			failures++
+			fmt.Printf("FAIL [1] garbage user token: expected error, got success resp (fail-open leak): %+v\n", resp)
+		} else if !strings.Contains(err.Error(), "401") {
+			failures++
+			fmt.Printf("FAIL [1] garbage user token: expected HTTP 401 in error, got: %v\n", err)
+		} else {
+			fmt.Println("PASS [1] garbage user token surfaces HTTP 401 error in production mode (no fail-open)")
+		}
+	}
+
+	// 2. Wrong Basic credentials → 401 must surface as error.
+	{
+		client := newClient(agentURL, "demo-org", "demo-license-not-real")
+		resp, err := client.ProxyLLMCall(userToken, "What is 2+2?", "chat", nil)
+		if err == nil {
+			failures++
+			fmt.Printf("FAIL [2] wrong Basic creds: expected error, got success resp (fail-open leak): %+v\n", resp)
+		} else if !strings.Contains(err.Error(), "401") {
+			failures++
+			fmt.Printf("FAIL [2] wrong Basic creds: expected HTTP 401 in error, got: %v\n", err)
+		} else {
+			fmt.Println("PASS [2] wrong Basic credentials surface HTTP 401 error in production mode (no fail-open)")
+		}
+	}
+
+	// 3. Control: valid creds + valid JWT succeeds on the same stack.
+	{
+		client := newClient(agentURL, clientID, clientSecret)
+		resp, err := client.ProxyLLMCall(userToken, "What is 2+2?", "chat", nil)
+		if err != nil {
+			failures++
+			fmt.Printf("FAIL [3] control call with valid creds errored: %v\n", err)
+		} else if !resp.Success {
+			failures++
+			fmt.Printf("FAIL [3] control call returned success=false: %s\n", resp.Error)
+		} else {
+			fmt.Println("PASS [3] control call with valid credentials + JWT succeeds")
+		}
+	}
+
+	if failures > 0 {
+		fmt.Printf("RESULT: FAIL (%d)\n", failures)
+		os.Exit(1)
+	}
+	fmt.Println("RESULT: PASS (3/3)")
+}

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package axonflow
 
 // Version is the current SDK version.
-const Version = "8.5.0"
+const Version = "8.5.1"


### PR DESCRIPTION
## Summary

Hostile-testing sweep TEST-SDK ahead of the BukuWarung integration — tracking getaxonflow/axonflow-enterprise#2861.

- **Production-mode fail-open swallowed HTTP 401.** `ProxyLLMCall` with `Mode:"production"` converted a definitive 401 (invalid credentials / invalid user token) into a synthetic `success=true` fail-open response: `executeWithRetry` wraps every error as `request failed after N attempts: …`, which the string-based `isAxonFlowError` matched. Observed live: the `basic` example printed `✓ Query executed successfully` against an enterprise stack that rejected its credentials. Fail-open eligibility is now structural (`isFailOpenEligible`): definitive 4xx always surfaces as an error; transport failures, 5xx and 429 remain eligible.
- **`[SDK-DEBUG]` logs leaked response bodies unconditionally.** Raw bodies (≤500 chars) + result payloads were logged regardless of `Config.Debug` — customer data (LLM output, PII) in every caller's logs. All request-path debug lines are now gated on `Debug: true`.
- **Two example modules didn't build at all.** `examples/explain-decision/go.mod` and `examples/wcp-retry-idempotency/go.mod` still declared the v7 module path (the latter with the outright-invalid `require …/v7 v5.0.0`) while the code imports `…/v8` — broken since the v8 major bump. Rewritten to `…/v8` + local `replace`.
- **Examples now pass on enterprise (JWT-validating) stacks.** They passed `""` as user token (→ `anonymous`) and 401'd on `DEPLOYMENT_MODE=enterprise`. `basic`, `planning` (incl. `ExecutePlan`), `connectors`, `indonesia_compliance` read `AXONFLOW_USER_TOKEN`; `basic` exits non-zero on a failed response and no longer prints `%!s(<nil>)`.

Version 8.5.0 → 8.5.1 + CHANGELOG.

## Testing

- New `TestProxyLLMCallDoesNotFailOpenOn4xx` (401/400/404, retry enabled) — mutation-verified: fails with the fix reverted. `TestProxyLLMCallStillFailsOpenOn5xx` pins that 503 stays fail-open.
- New `runtime-e2e/proxy_fail_closed_4xx/` against a LIVE enterprise stack (v9.6.1, `./scripts/setup-e2e-testing.sh enterprise`): garbage user token → 401 error, wrong Basic creds → 401 error, control call with valid creds+JWT succeeds — PASS 3/3.
- All 7 examples re-run green against the live enterprise stack (basic, connectors, indonesia_compliance, list_decisions, planning, explain-decision, wcp-retry-idempotency), exit 0 with meaningful output.
- Full `go test ./...` green.

## Related Issues

- getaxonflow/axonflow-enterprise#2861