### PR TITLE
fix(examples): connectors example works against a live enterprise stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,12 @@ Hostile-testing sweep ahead of the BukuWarung integration
   `AXONFLOW_USER_TOKEN`. `basic` also exits non-zero on a failed response
   instead of printing a success checkmark (and no longer prints
   `%!s(<nil>)` for the result).
+- **`UninstallConnector` calls the real platform route.** It issued
+  `DELETE /api/v1/connectors/{id}`, which the platform answers with
+  405 Method Not Allowed — every uninstall through the SDK failed. It now
+  posts to the actual route, `DELETE /api/v1/connectors/{id}/uninstall`.
+  Runtime proof: `runtime-e2e/connector_uninstall_route/`.
+
 ### Added
 
 - `runtime-e2e/proxy_fail_closed_4xx/` — live-agent assertion that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `CallerName` field already worked correctly — this closes a coverage gap
   in the runtime proof and doc wording that assumed the old default.
 
+### Fixed
+
+- **`UninstallConnector` calls the real platform route.** It issued
+  `DELETE /api/v1/connectors/{id}`, which the platform answers with
+  405 Method Not Allowed — every uninstall through the SDK failed. It now
+  posts to the actual route, `DELETE /api/v1/connectors/{id}/uninstall`.
+  Runtime proof: `runtime-e2e/connector_uninstall_route/`.
+
 ## [9.0.0] - 2026-07-18
 
 ### Changed (BREAKING)
@@ -125,11 +133,6 @@ Hostile-testing sweep ahead of the BukuWarung integration
   `AXONFLOW_USER_TOKEN`. `basic` also exits non-zero on a failed response
   instead of printing a success checkmark (and no longer prints
   `%!s(<nil>)` for the result).
-- **`UninstallConnector` calls the real platform route.** It issued
-  `DELETE /api/v1/connectors/{id}`, which the platform answers with
-  405 Method Not Allowed — every uninstall through the SDK failed. It now
-  posts to the actual route, `DELETE /api/v1/connectors/{id}/uninstall`.
-  Runtime proof: `runtime-e2e/connector_uninstall_route/`.
 
 ### Added
 

--- a/axonflow.go
+++ b/axonflow.go
@@ -1582,7 +1582,8 @@ func (c *AxonFlowClient) InstallConnector(req ConnectorInstallRequest) error {
 
 // UninstallConnector removes an installed MCP connector
 func (c *AxonFlowClient) UninstallConnector(connectorName string) error {
-	url := fmt.Sprintf("%s/api/v1/connectors/%s", c.config.Endpoint, connectorName)
+	// Connector uninstall via Agent proxy: DELETE /api/v1/connectors/{id}/uninstall
+	url := fmt.Sprintf("%s/api/v1/connectors/%s/uninstall", c.config.Endpoint, connectorName)
 	httpReq, err := http.NewRequest("DELETE", url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create uninstall request: %w", err)

--- a/axonflow_http_test.go
+++ b/axonflow_http_test.go
@@ -1382,9 +1382,13 @@ func TestOrchestratorHealthCheckUnhealthy(t *testing.T) {
 
 func TestUninstallConnector(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "DELETE" && r.URL.Path == "/api/v1/connectors/postgres" {
+		if r.Method == "DELETE" && r.URL.Path == "/api/v1/connectors/postgres/uninstall" {
 			w.WriteHeader(http.StatusNoContent)
+			return
 		}
+		// Any other path is the regression this guards: the platform
+		// answers DELETE /api/v1/connectors/{id} (no /uninstall) with 405.
+		w.WriteHeader(http.StatusMethodNotAllowed)
 	}))
 	defer server.Close()
 

--- a/examples/connectors/main.go
+++ b/examples/connectors/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/getaxonflow/axonflow-sdk-go/v9"
 )
@@ -17,6 +18,10 @@ func main() {
 	// Enterprise stacks (DEPLOYMENT_MODE=enterprise) validate user tokens as
 	// JWTs — export AXONFLOW_USER_TOKEN. Community stacks skip JWT validation.
 	userToken := getEnv("AXONFLOW_USER_TOKEN", "")
+	// Connector installs are tenant-scoped: the tenant must exist on the
+	// platform (tenants.tenant_id). On local/dev stacks the tenant id matches
+	// the client id (org), so default to that.
+	tenantID := getEnv("AXONFLOW_TENANT_ID", clientID)
 
 	if clientID == "" || clientSecret == "" {
 		log.Fatal("AXONFLOW_CLIENT_ID and AXONFLOW_CLIENT_SECRET must be set")
@@ -67,10 +72,12 @@ func main() {
 
 		err = client.InstallConnector(axonflow.ConnectorInstallRequest{
 			ConnectorID: "amadeus-travel",
-			Name:        "amadeus-prod",
-			TenantID:    "demo-tenant",
+			Name:        "amadeus-travel",
+			TenantID:    tenantID,
 			Options: map[string]interface{}{
-				"environment": "production",
+				// Amadeus issues self-service keys for the "test" environment;
+				// switch to "production" only with production Amadeus keys.
+				"environment": "test",
 				"region":      "europe",
 			},
 			Credentials: map[string]string{
@@ -80,7 +87,11 @@ func main() {
 		})
 
 		if err != nil {
-			log.Printf("Failed to install connector: %v", err)
+			if strings.Contains(err.Error(), "already registered") {
+				fmt.Println("✓ Connector already installed, continuing")
+			} else {
+				log.Printf("Failed to install connector: %v", err)
+			}
 		} else {
 			fmt.Println("✓ Connector installed successfully!")
 		}
@@ -95,15 +106,19 @@ func main() {
 	if amadeusKey != "" {
 		fmt.Println("Querying Amadeus connector for flights...")
 
+		// Amadeus connector operations: search_flights, search_hotels,
+		// lookup_airport (parameters carry the search criteria).
+		departureDate := time.Now().AddDate(0, 1, 0).Format("2006-01-02")
 		resp, err := client.QueryConnector(
 			userToken, // AXONFLOW_USER_TOKEN (JWT) on enterprise stacks; empty ("anonymous") is fine on community stacks.
-			"amadeus-prod",
-			"Find flights from Paris to Amsterdam on 2025-12-15",
+			"amadeus-travel", // query by connector ID (the marketplace ID used at install time)
+			"search_flights",
 			map[string]interface{}{
-				"origin":      "CDG",
-				"destination": "AMS",
-				"date":        "2025-12-15",
-				"adults":      1,
+				"origin":         "CDG",
+				"destination":    "AMS",
+				"departure_date": departureDate,
+				"adults":         1,
+				"max":            2,
 			},
 		)
 
@@ -111,6 +126,10 @@ func main() {
 			log.Printf("Connector query failed: %v", err)
 		} else if !resp.Success {
 			fmt.Printf("Query failed: %s\n", resp.Error)
+		} else if resp.Error != "" || resp.Data == nil {
+			// Success=true with an Error set means the SDK failed open
+			// (production mode, AxonFlow unavailable) — don't report data.
+			fmt.Printf("⚠ No flight data (governed call did not reach the connector): %s\n", resp.Error)
 		} else {
 			fmt.Println("✓ Flight data retrieved:")
 			fmt.Printf("%v\n", resp.Data)
@@ -123,7 +142,9 @@ func main() {
 	redisResp, err := client.QueryConnector(
 		userToken, // AXONFLOW_USER_TOKEN (JWT) on enterprise stacks; empty ("anonymous") is fine on community stacks.
 		"redis-cache",
-		"Get cached user preferences for user-123",
+		// Redis connector queries are command statements: GET, EXISTS, TTL, KEYS
+		// (the key goes in params).
+		"GET",
 		map[string]interface{}{
 			"key": "user:123:preferences",
 		},
@@ -133,6 +154,8 @@ func main() {
 		fmt.Printf("⚠ Redis query failed (expected if not installed): %v\n", err)
 	} else if !redisResp.Success {
 		fmt.Printf("⚠ Redis query failed: %s\n", redisResp.Error)
+	} else if redisResp.Error != "" || redisResp.Data == nil {
+		fmt.Printf("⚠ No Redis data (governed call did not reach the connector): %s\n", redisResp.Error)
 	} else {
 		fmt.Println("✓ Redis data retrieved:")
 		fmt.Printf("%v\n", redisResp.Data)
@@ -152,7 +175,11 @@ func main() {
 	for _, conn := range connectors {
 		if conn.Installed {
 			installedCount++
-			fmt.Printf("✓ %s (installed as '%s')\n", conn.Name, conn.InstanceName)
+			if conn.InstanceName != "" {
+				fmt.Printf("✓ %s (installed as '%s')\n", conn.Name, conn.InstanceName)
+			} else {
+				fmt.Printf("✓ %s\n", conn.Name)
+			}
 		}
 	}
 

--- a/examples/connectors/main.go
+++ b/examples/connectors/main.go
@@ -110,7 +110,7 @@ func main() {
 		// lookup_airport (parameters carry the search criteria).
 		departureDate := time.Now().AddDate(0, 1, 0).Format("2006-01-02")
 		resp, err := client.QueryConnector(
-			userToken, // AXONFLOW_USER_TOKEN (JWT) on enterprise stacks; empty ("anonymous") is fine on community stacks.
+			userToken,        // AXONFLOW_USER_TOKEN (JWT) on enterprise stacks; empty ("anonymous") is fine on community stacks.
 			"amadeus-travel", // query by connector ID (the marketplace ID used at install time)
 			"search_flights",
 			map[string]interface{}{

--- a/runtime-e2e/connector_uninstall_route/main.go
+++ b/runtime-e2e/connector_uninstall_route/main.go
@@ -1,0 +1,170 @@
+//go:build ignore
+
+// runtime-e2e/connector_uninstall_route/main.go
+//
+// Real-stack assertion: UninstallConnector must hit the platform's actual
+// uninstall route (DELETE /api/v1/connectors/{id}/uninstall).
+//
+// Per CLAUDE.md HARD RULE #0 this driver MUST hit a real running AxonFlow
+// agent — no httptest, no fixture servers.
+//
+// Regression background: UninstallConnector used to issue
+// DELETE /api/v1/connectors/{id}, a route the platform does not serve for
+// DELETE — every uninstall through the SDK failed with HTTP 405
+// Method Not Allowed. This driver proves the full marketplace lifecycle
+// against a live stack:
+//
+//  1. Install the redis-cache connector for the caller's tenant (an
+//     "already registered" from a previous run is tolerated — the surface
+//     under test is uninstall).
+//  2. Query it through the governed mcp-query path (proves it is really
+//     installed and serving).
+//  3. Uninstall it — MUST succeed. A 405 here is the exact regression this
+//     leg guards against.
+//  4. Re-install it — MUST succeed cleanly. This only works if step 3
+//     genuinely removed the registration (install fails with
+//     "already registered" otherwise), and it restores the stack state.
+//  5. Query again — proves the reinstalled connector serves.
+//
+// Run locally (after `source /tmp/axonflow-e2e-env.sh` from the enterprise
+// setup script; AXONFLOW_USER_TOKEN must be a JWT whose tenant_id matches
+// the license org):
+//
+//	AXONFLOW_AGENT_URL=http://localhost:8080 \
+//	AXONFLOW_CLIENT_ID="$AXONFLOW_CLIENT_ID" \
+//	AXONFLOW_CLIENT_SECRET="$AXONFLOW_CLIENT_SECRET" \
+//	AXONFLOW_TENANT_ID="$AXONFLOW_TENANT_ID" \
+//	AXONFLOW_USER_TOKEN="$AXONFLOW_USER_TOKEN" \
+//	go run runtime-e2e/connector_uninstall_route/main.go
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	axonflow "github.com/getaxonflow/axonflow-sdk-go/v8"
+)
+
+const connectorID = "redis-cache"
+
+func env(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func install(client *axonflow.AxonFlowClient, tenantID string) error {
+	return client.InstallConnector(axonflow.ConnectorInstallRequest{
+		ConnectorID: connectorID,
+		Name:        connectorID,
+		TenantID:    tenantID,
+		Options: map[string]interface{}{
+			// The docker-compose stack's redis service.
+			"host": env("AXONFLOW_E2E_REDIS_HOST", "redis"),
+			"port": 6379,
+			"db":   0,
+		},
+	})
+}
+
+// query polls the governed mcp-query path until the connector serves. The
+// agent caches per-tenant connector configs for 30s (RuntimeConfigService
+// default CacheTTL), so a query issued right after install can be answered
+// from a pre-install snapshot; poll past that window before failing.
+func query(client *axonflow.AxonFlowClient, userToken, label string) bool {
+	deadline := time.Now().Add(45 * time.Second)
+	for {
+		resp, err := client.QueryConnector(userToken, connectorID, "GET",
+			map[string]interface{}{"key": "user:123:preferences"})
+		switch {
+		case err == nil && resp.Success && resp.Error == "" && resp.Data != nil:
+			fmt.Printf("PASS [%s] governed query served by %s\n", label, connectorID)
+			return true
+		case time.Now().After(deadline):
+			if err != nil {
+				fmt.Printf("FAIL [%s] governed query errored: %v\n", label, err)
+			} else {
+				fmt.Printf("FAIL [%s] governed query did not reach the connector: success=%v error=%q data=%v\n",
+					label, resp.Success, resp.Error, resp.Data)
+			}
+			return false
+		}
+		time.Sleep(3 * time.Second)
+	}
+}
+
+func main() {
+	agentURL := env("AXONFLOW_AGENT_URL", "http://localhost:8080")
+	clientID := os.Getenv("AXONFLOW_CLIENT_ID")
+	clientSecret := os.Getenv("AXONFLOW_CLIENT_SECRET")
+	userToken := os.Getenv("AXONFLOW_USER_TOKEN")
+	tenantID := env("AXONFLOW_TENANT_ID", clientID)
+	if clientID == "" || clientSecret == "" || userToken == "" {
+		fmt.Println("FAIL: AXONFLOW_CLIENT_ID, AXONFLOW_CLIENT_SECRET and AXONFLOW_USER_TOKEN must be set (source /tmp/axonflow-e2e-env.sh)")
+		os.Exit(1)
+	}
+
+	client := axonflow.NewClientSimple(agentURL, clientID, clientSecret)
+	failures := 0
+
+	// 1. Install. A leftover registration from a previous run reports
+	//    "already registered" — converge by uninstalling (the surface under
+	//    test) and installing fresh, so the DB row is known-good for THIS
+	//    tenant regardless of prior state.
+	if err := install(client, tenantID); err != nil {
+		if strings.Contains(err.Error(), "already registered") {
+			fmt.Println("INFO [1] leftover registration from a previous run — uninstalling and installing fresh")
+			if err := client.UninstallConnector(connectorID); err != nil {
+				fmt.Printf("FAIL [1] uninstall of leftover registration: %v\n", err)
+				os.Exit(1)
+			}
+			if err := install(client, tenantID); err != nil {
+				fmt.Printf("FAIL [1] fresh install after uninstall: %v\n", err)
+				os.Exit(1)
+			}
+		} else {
+			fmt.Printf("FAIL [1] install: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("PASS [1] connector installed")
+
+	// 2. Prove it serves.
+	if !query(client, userToken, "2") {
+		failures++
+	}
+
+	// 3. Uninstall — the surface under test. The old SDK route
+	//    (DELETE /api/v1/connectors/{id}) 405s here.
+	if err := client.UninstallConnector(connectorID); err != nil {
+		fmt.Printf("FAIL [3] UninstallConnector: %v\n", err)
+		if strings.Contains(err.Error(), "405") {
+			fmt.Println("      (HTTP 405 = the exact wrong-route regression this leg guards against)")
+		}
+		os.Exit(1)
+	}
+	fmt.Println("PASS [3] UninstallConnector succeeded (real /uninstall route)")
+
+	// 4. Re-install MUST be clean: only possible if step 3 genuinely
+	//    unregistered the connector. Also restores the stack state.
+	if err := install(client, tenantID); err != nil {
+		failures++
+		fmt.Printf("FAIL [4] re-install after uninstall (uninstall did not unregister?): %v\n", err)
+	} else {
+		fmt.Println("PASS [4] re-install clean — uninstall genuinely removed the registration")
+	}
+
+	// 5. Reinstalled connector serves again.
+	if !query(client, userToken, "5") {
+		failures++
+	}
+
+	if failures > 0 {
+		fmt.Printf("connector_uninstall_route: %d failure(s)\n", failures)
+		os.Exit(1)
+	}
+	fmt.Println("connector_uninstall_route: all assertions passed")
+}

--- a/runtime-e2e/connector_uninstall_route/main.go
+++ b/runtime-e2e/connector_uninstall_route/main.go
@@ -44,7 +44,7 @@ import (
 	"strings"
 	"time"
 
-	axonflow "github.com/getaxonflow/axonflow-sdk-go/v8"
+	axonflow "github.com/getaxonflow/axonflow-sdk-go/v9"
 )
 
 const connectorID = "redis-cache"


### PR DESCRIPTION
## What

Smoke-testing the Go SDK examples against a live enterprise stack (release-readiness gate for #2861) surfaced two defects in the connectors path.

### connectors example (`examples/connectors/main.go`)
Previously never actually installed or queried a connector against a real stack:
- Hardcoded `TenantID: "demo-tenant"`, which fails the `connector_configs -> customers` FK on any real deployment. Now reads `AXONFLOW_TENANT_ID` and defaults to the client id (org).
- Installed as a display name (`amadeus-prod`) but the platform keys registration on the marketplace connector ID. Now installs and queries by `amadeus-travel`.
- Used the Amadeus `production` base URL with self-service (test-env) keys. Switched to `environment: "test"`.
- Sent free-text as the connector statement. Now uses supported operations: `search_flights` (with `departure_date`, future date) and redis `GET` (key in params).
- Printed a success checkmark over `<nil>` data when the SDK failed open in production mode. Now surfaces the fail-open case explicitly.

### SDK (`axonflow.go`) — library fix, rides un-tagged 8.5.1
- `UninstallConnector` called `DELETE /api/v1/connectors/{id}`, which the platform serves as 405 Method Not Allowed — every uninstall through the SDK failed. Fixed to `DELETE /api/v1/connectors/{id}/uninstall` (the real route). CHANGELOG bullet added under `[8.5.1] Fixed`; no version bump (8.5.1 is not yet tagged).
- `TestUninstallConnector` now asserts the `/uninstall` route strictly (any other path answers 405 in the mock; previously the handler fell through to an implicit 200, so the test passed regardless of route).

## Runtime E2E

New leg `runtime-e2e/connector_uninstall_route/` — live install → governed query → **uninstall** → re-install → query round-trip against a real enterprise agent. The uninstall assertion is the 405-class regression this PR fixes; the clean re-install proves the uninstall genuinely unregistered the connector. Queries poll past the agent's 30s per-tenant connector-config cache TTL.

Run against a live `DEPLOYMENT_MODE=enterprise` stack (agent :8080 / orchestrator :8081, license + UUID-tenant JWT from the E2E setup script):

```
INFO [1] leftover registration from a previous run — uninstalling and installing fresh
PASS [1] connector installed
PASS [2] governed query served by redis-cache
PASS [3] UninstallConnector succeeded (real /uninstall route)
PASS [4] re-install clean — uninstall genuinely removed the registration
PASS [5] governed query served by redis-cache
connector_uninstall_route: all assertions passed
```

## Example verified live

`examples/connectors` ran end-to-end against the same stack: installed the Amadeus connector via the marketplace API, retrieved **2 real flight offers CDG→AMS from the Amadeus test API** (D8 €110.00, AF €199.80), and read a real value from the Redis connector (`{"theme":"dark","lang":"en"}`).

`go test ./...`, `go vet ./...`, `gofmt -s -l .` all clean locally.