### PR TITLE
fix(workflows): MarkStepCompletedRequest gains spec-declared metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,9 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [8.5.1] - 2026-07-09 — Fail-open hardening + debug-log gating + example fixes
+## [Unreleased]
 
-Hostile-testing sweep ahead of the BukuWarung integration
-(getaxonflow/axonflow-enterprise#2861).
-
-### Fixed
+### Added
 
 - **`MarkStepCompletedRequest` gains the spec-declared optional `metadata`
   field.** The community v9.6.1 spec (`orchestrator-api.yaml`,
@@ -21,6 +18,14 @@ Hostile-testing sweep ahead of the BukuWarung integration
   LangGraph adapter's `StepCompletedOptions`/`ToolCompletedOptions`. Treat as
   opaque on the client. Runtime proof:
   `runtime-e2e/mark_step_completed_metadata/`.
+
+## [8.5.1] - 2026-07-09 — Fail-open hardening + debug-log gating + example fixes
+
+Hostile-testing sweep ahead of the BukuWarung integration
+(getaxonflow/axonflow-enterprise#2861).
+
+### Fixed
+
 - **Production-mode fail-open no longer swallows definitive 4xx errors.**
   `ProxyLLMCall`/`ProxyLLMCallWithMedia` in `Mode:"production"` used to convert
   an HTTP 401 (invalid credentials / invalid user token) into a synthetic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ Hostile-testing sweep ahead of the BukuWarung integration
 
 ### Fixed
 
+- **`MarkStepCompletedRequest` gains the spec-declared optional `metadata`
+  field.** The community v9.6.1 spec (`orchestrator-api.yaml`,
+  `MarkStepCompletedRequest`) declares `metadata` as a free-form object
+  captured at step-completion time (audit context the gate-time data didn't
+  have); the platform consumes it at step-completion. Python/TypeScript/Java
+  all model it — Go was the only SDK missing it. Also threaded through the
+  LangGraph adapter's `StepCompletedOptions`/`ToolCompletedOptions`. Treat as
+  opaque on the client. Runtime proof:
+  `runtime-e2e/mark_step_completed_metadata/`.
 - **Production-mode fail-open no longer swallows definitive 4xx errors.**
   `ProxyLLMCall`/`ProxyLLMCallWithMedia` in `Mode:"production"` used to convert
   an HTTP 401 (invalid credentials / invalid user token) into a synthetic

--- a/langgraph_adapter.go
+++ b/langgraph_adapter.go
@@ -89,6 +89,9 @@ type StepCompletedOptions struct {
 	TokensIn  *int
 	TokensOut *int
 	CostUSD   *float64
+	// Metadata is free-form metadata captured at step-completion time
+	// (e.g. audit context). Treat as opaque on the client.
+	Metadata map[string]interface{}
 }
 
 // CheckToolGateOptions contains optional parameters for CheckToolGate.
@@ -108,6 +111,9 @@ type ToolCompletedOptions struct {
 	TokensIn  *int
 	TokensOut *int
 	CostUSD   *float64
+	// Metadata is free-form metadata captured at step-completion time
+	// (e.g. audit context). Treat as opaque on the client.
+	Metadata map[string]interface{}
 }
 
 // LangGraphAdapter wraps LangGraph workflows with AxonFlow governance.
@@ -308,6 +314,7 @@ func (a *LangGraphAdapter) StepCompleted(ctx context.Context, stepName string, o
 		req.TokensIn = opts.TokensIn
 		req.TokensOut = opts.TokensOut
 		req.CostUSD = opts.CostUSD
+		req.Metadata = opts.Metadata
 	}
 
 	if stepID == "" {
@@ -368,6 +375,7 @@ func (a *LangGraphAdapter) ToolCompleted(ctx context.Context, toolName string, o
 			TokensIn:  opts.TokensIn,
 			TokensOut: opts.TokensOut,
 			CostUSD:   opts.CostUSD,
+			Metadata:  opts.Metadata,
 		}
 	}
 

--- a/runtime-e2e/mark_step_completed_metadata/main.go
+++ b/runtime-e2e/mark_step_completed_metadata/main.go
@@ -1,0 +1,145 @@
+//go:build ignore
+
+// runtime-e2e/mark_step_completed_metadata/main.go
+//
+// Real-wire test of MarkStepCompletedRequest.Metadata against a live
+// AxonFlow enterprise stack (community v9.6.1 spec, orchestrator-api.yaml
+// MarkStepCompletedRequest schema: metadata is a free-form object captured
+// at step-completion time, opaque to the client).
+//
+// Drives the full WCP lifecycle through the SDK's real net/http transport:
+//
+//  1. CreateWorkflow registers a workflow.
+//  2. StepGate gates a step (first-call retry_context invariants).
+//  3. MarkStepCompleted sends a body carrying the new metadata field and
+//     must get a 2xx back — proving the live orchestrator accepts the
+//     spec-declared field rather than rejecting the body.
+//  4. Re-gate on the same step must report completion_count=1 /
+//     prior_completion_status=completed — proving the /complete call that
+//     carried metadata was fully processed, not silently dropped.
+//  5. GetWorkflow must show the step recorded.
+//
+// Note: no read endpoint currently echoes step-completion metadata back
+// (the platform treats it as opaque audit context), so presence-on-read
+// cannot be asserted; acceptance + processed-completion is the strongest
+// live evidence available.
+//
+// Run via:
+//
+//	go run runtime-e2e/mark_step_completed_metadata/main.go
+//
+// Prereqs: a running orchestrator (AXONFLOW_ORCHESTRATOR_URL, default
+// http://localhost:8081 — WCP endpoints live on the orchestrator) and
+// enterprise credentials in AXONFLOW_CLIENT_ID / AXONFLOW_CLIENT_SECRET.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	axonflow "github.com/getaxonflow/axonflow-sdk-go/v8"
+)
+
+func main() {
+	endpoint := getenv("AXONFLOW_ORCHESTRATOR_URL", "http://localhost:8081")
+	clientID := os.Getenv("AXONFLOW_CLIENT_ID")
+	clientSecret := os.Getenv("AXONFLOW_CLIENT_SECRET")
+	if clientID == "" || clientSecret == "" {
+		fail("AXONFLOW_CLIENT_ID / AXONFLOW_CLIENT_SECRET are required (source /tmp/axonflow-e2e-env.sh)")
+	}
+
+	client := axonflow.NewClient(axonflow.AxonFlowConfig{
+		Endpoint:     endpoint,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+	})
+
+	// ---- Step 1: register a workflow.
+	wf, err := client.CreateWorkflow(axonflow.CreateWorkflowRequest{
+		WorkflowName: "go-sdk-step-metadata-e2e",
+	})
+	if err != nil {
+		fail("CreateWorkflow: %v", err)
+	}
+	fmt.Printf("workflow created: %s\n", wf.WorkflowID)
+
+	// ---- Step 2: gate the step.
+	gate, err := client.StepGate(wf.WorkflowID, "step-1", axonflow.StepGateRequest{
+		StepName: "metadata-step",
+		StepType: axonflow.StepTypeToolCall,
+	})
+	if err != nil {
+		fail("StepGate: %v", err)
+	}
+	if gate.Decision != axonflow.GateDecisionAllow {
+		fail("StepGate decision = %q, want allow (reason: %s)", gate.Decision, gate.Reason)
+	}
+	if gate.RetryContext.CompletionCount != 0 {
+		fail("first gate completion_count = %d, want 0", gate.RetryContext.CompletionCount)
+	}
+	fmt.Printf("gate: decision=%s gate_count=%d completion_count=%d\n",
+		gate.Decision, gate.RetryContext.GateCount, gate.RetryContext.CompletionCount)
+
+	// ---- Step 3: complete WITH metadata. A non-2xx surfaces as err here.
+	metadata := map[string]interface{}{
+		"ticket":              "JIRA-42",
+		"approved_by":         "ops-lead",
+		"downstream_latency":  183,
+		"retry_attempt_count": 1,
+	}
+	if err := client.MarkStepCompleted(wf.WorkflowID, "step-1", &axonflow.MarkStepCompletedRequest{
+		Output:   map[string]interface{}{"result": "success"},
+		Metadata: metadata,
+	}); err != nil {
+		fail("MarkStepCompleted with metadata: %v", err)
+	}
+	fmt.Printf("PASS: MarkStepCompleted with metadata=%v accepted (2xx)\n", metadata)
+
+	// ---- Step 4: re-gate — the completion carrying metadata must have landed.
+	regate, err := client.StepGate(wf.WorkflowID, "step-1", axonflow.StepGateRequest{
+		StepType: axonflow.StepTypeToolCall,
+	})
+	if err != nil {
+		fail("re-gate after complete: %v", err)
+	}
+	if regate.RetryContext.CompletionCount != 1 {
+		fail("re-gate completion_count = %d, want 1", regate.RetryContext.CompletionCount)
+	}
+	if regate.RetryContext.PriorCompletionStatus != axonflow.PriorCompletionStatusCompleted {
+		fail("re-gate prior_completion_status = %q, want completed", regate.RetryContext.PriorCompletionStatus)
+	}
+	fmt.Printf("PASS: re-gate confirms completion processed (completion_count=%d, prior_completion_status=%s)\n",
+		regate.RetryContext.CompletionCount, regate.RetryContext.PriorCompletionStatus)
+
+	// ---- Step 5: workflow status read-back shows the step recorded.
+	status, err := client.GetWorkflow(wf.WorkflowID)
+	if err != nil {
+		fail("GetWorkflow: %v", err)
+	}
+	var found bool
+	for _, s := range status.Steps {
+		if s.StepID == "step-1" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		fail("GetWorkflow did not list step-1 (steps=%v)", status.Steps)
+	}
+	fmt.Printf("PASS: GetWorkflow lists step-1 (workflow status=%s)\n", status.Status)
+
+	fmt.Println("PASS: MarkStepCompletedRequest.Metadata live round-trip OK")
+}
+
+func getenv(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func fail(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, "FAIL: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/testdata/wire_shape_baseline.json
+++ b/testdata/wire_shape_baseline.json
@@ -471,13 +471,6 @@
         "user_token"
       ]
     },
-    "MarkStepCompletedRequest": {
-      "_note": "New at the v9.6.1 pin: the spec added an optional 'metadata' property that the Go SDK does not expose yet. Real SDK gap surfaced by the getaxonflow/axonflow-enterprise#2861 sweep; needs a targeted SDK field addition in a separate PR (this PR is baseline+pin only).",
-      "sdk_only": [],
-      "spec_only": [
-        "metadata"
-      ]
-    },
     "PlanResponse": {
       "sdk_only": [
         "estimated_duration"

--- a/workflows.go
+++ b/workflows.go
@@ -398,6 +398,10 @@ type MarkStepCompletedRequest struct {
 	// IdempotencyKey must match the key passed on the corresponding gate call, if any.
 	// Mismatch (including empty vs set on either side) yields IdempotencyKeyMismatchError.
 	IdempotencyKey string `json:"idempotency_key,omitempty"`
+
+	// Metadata is free-form metadata captured at step-completion time
+	// (e.g. audit context). Treat as opaque on the client.
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // CreateWorkflow creates a new workflow for governance tracking.

--- a/workflows_test.go
+++ b/workflows_test.go
@@ -1389,12 +1389,51 @@ func TestMarkStepCompleted(t *testing.T) {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
 
-		var req MarkStepCompletedRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		// Decode into a raw map so we can assert exactly what landed on the wire.
+		var wire map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&wire); err != nil {
 			t.Fatalf("Failed to decode request body: %v", err)
 		}
-		if req.Output == nil || req.Output["result"] != "success" {
-			t.Errorf("Expected output with result=success, got %v", req.Output)
+		output, _ := wire["output"].(map[string]interface{})
+		if output == nil || output["result"] != "success" {
+			t.Errorf("Expected output with result=success, got %v", wire["output"])
+		}
+		metadata, _ := wire["metadata"].(map[string]interface{})
+		if metadata == nil || metadata["ticket"] != "JIRA-42" || metadata["approved_by"] != "ops-lead" {
+			t.Errorf("Expected metadata with ticket=JIRA-42 approved_by=ops-lead, got %v", wire["metadata"])
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{
+		Endpoint:     server.URL,
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	err := client.MarkStepCompleted("wf_test123", "step_1", &MarkStepCompletedRequest{
+		Output:   map[string]interface{}{"result": "success"},
+		Metadata: map[string]interface{}{"ticket": "JIRA-42", "approved_by": "ops-lead"},
+	})
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+// TestMarkStepCompletedMetadataOmittedWhenNil tests that a nil Metadata map
+// does not serialize a "metadata" key onto the wire body
+func TestMarkStepCompletedMetadataOmittedWhenNil(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var wire map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&wire); err != nil {
+			t.Fatalf("Failed to decode request body: %v", err)
+		}
+		if _, present := wire["metadata"]; present {
+			t.Errorf("Expected metadata key to be omitted when nil, got %v", wire["metadata"])
 		}
 
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary

Closes the confirmed Go SDK gap from the getaxonflow/axonflow-enterprise#2861 sweep: `MarkStepCompletedRequest` was missing the optional `metadata` field that the community v9.6.1 spec declares (`orchestrator-api.yaml`, `MarkStepCompletedRequest`: `metadata: type object, additionalProperties true` — "Free-form metadata captured at step-completion time … Treat as opaque on the client"). Python/TypeScript/Java SDKs all model it; Go was the only SDK missing it. PR #185's refreshed baseline records it as `MarkStepCompletedRequest.spec_only=["metadata"]` — this PR closes that entry.

**Stacked on #185** (`chore/spec-pin-v961`) — base is that branch; auto-retargets to `main` when #185 merges.

## Changes

- `workflows.go`: `MarkStepCompletedRequest` gains `Metadata map[string]interface{} \`json:"metadata,omitempty"\`` with a doc comment matching the spec wording.
- `langgraph_adapter.go`: `StepCompletedOptions` and `ToolCompletedOptions` gain `Metadata`, threaded through `StepCompleted`/`ToolCompleted` (the existing helper pattern for this request type).
- `workflows_test.go`: `TestMarkStepCompleted` now decodes the raw wire body and asserts `metadata` serializes; new `TestMarkStepCompletedMetadataOmittedWhenNil` asserts the key is absent when nil.
- `runtime-e2e/mark_step_completed_metadata/`: new live-stack leg (see evidence below).
- `testdata/wire_shape_baseline.json`: regenerated at the SAME pin (`openapi_specs_sha` stays `ac1b7cd879cd4143b1205fa697b9686e2f8f6024`). Delta vs `origin/chore/spec-pin-v961` is exactly the `MarkStepCompletedRequest` entry dropping; the curated `_note` keys on `DecideResponse` and `MCPCheckOutputResponse` (which the refresh script strips) were re-added verbatim.
- `CHANGELOG.md`: bullet under the existing un-tagged `## [8.5.1] - 2026-07-09` section. `version.go` untouched.

## Runtime-e2e evidence (live enterprise stack, orchestrator http://localhost:8081)

`go run runtime-e2e/mark_step_completed_metadata/main.go`:

```
workflow created: wf_4c1fc1f4
gate: decision=allow gate_count=1 completion_count=0
PASS: MarkStepCompleted with metadata=map[approved_by:ops-lead downstream_latency:183 retry_attempt_count:1 ticket:JIRA-42] accepted (2xx)
PASS: re-gate confirms completion processed (completion_count=1, prior_completion_status=completed)
PASS: GetWorkflow lists step-1 (workflow status=in_progress)
PASS: MarkStepCompletedRequest.Metadata live round-trip OK
```

The leg drives `CreateWorkflow → StepGate → MarkStepCompleted(metadata) → re-gate → GetWorkflow` through the SDK's real transport against the live stack (enterprise Basic client credentials; a user JWT was minted per the E2E workflow but is not consumed by WCP endpoints — they authenticate via Basic client credentials). No read endpoint currently echoes step-completion metadata back (the platform treats it as opaque), so the strongest live assertions are 2xx acceptance + the re-gate proving the completion that carried metadata was fully processed; on-wire presence of `metadata` is asserted by the unit test.

## Local gate results (stacked-base PRs may only trigger a subset of workflows)

Run with `AXONFLOW_OPENAPI_SPECS_DIR` pointing at a detached checkout of getaxonflow/axonflow @ `ac1b7cd8`:

- `go test ./...` — all packages `ok` (includes the full wire-shape gate: `TestWireShapeNoNewSDKVsSpecDrift` etc. all PASS at the pin)
- `gofmt -l .` — clean
- `go vet ./...` — clean
- `bash scripts/lint-no-mocks-in-runtime-e2e.sh` — exit 0

## Baseline delta confirmation

`git diff origin/chore/spec-pin-v961 -- testdata/wire_shape_baseline.json` shows ONLY the `MarkStepCompletedRequest` entry (with its `_note`) dropping; `openapi_specs_sha` unchanged; both curated `_note` keys preserved verbatim.

Refs getaxonflow/axonflow-enterprise#2861
