### PR TITLE
feat: add CallerName to AuditToolCallRequest (#2912)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the AxonFlow Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`AuditToolCallRequest.CallerName`** (getaxonflow/axonflow-enterprise#2912,
+  sub-issue of epic #2905). `tool_type` was historically overloaded by every
+  real caller (claude_code/codex/cursor/openclaw) to identify which client
+  made the tool call — not any property of the tool itself. `CallerName` is
+  the correctly-named field for that purpose and is preferred going forward.
+  The server resolves caller identity as: `CallerName` if supplied -> legacy
+  `ToolType` if supplied -> a default. `ToolType` is kept as a deprecated
+  input fallback for backward compatibility — it is not being removed or
+  renamed. Runtime proof: `runtime-e2e/caller_name_audit/`.
+
 ## [8.5.1] - 2026-07-09 — Fail-open hardening + debug-log gating + example fixes
 
 Hostile-testing sweep ahead of the BukuWarung integration

--- a/audit.go
+++ b/audit.go
@@ -132,6 +132,10 @@ type AuditToolCallRequest struct {
 	// deprecated ToolType field for that purpose. The server resolves
 	// caller identity as: CallerName if supplied -> legacy ToolType if
 	// supplied -> a default.
+	//
+	// Requires a platform with caller_name support (v9.11.0+); older
+	// platforms silently drop this field, so also set ToolType if you need
+	// attribution there.
 	CallerName string `json:"caller_name,omitempty"`
 	// Input is the input data passed to the tool
 	Input map[string]interface{} `json:"input,omitempty"`

--- a/audit.go
+++ b/audit.go
@@ -120,7 +120,19 @@ type AuditToolCallRequest struct {
 	// ToolName is the name of the tool that was called (required)
 	ToolName string `json:"tool_name"`
 	// ToolType is the type of tool: "function", "mcp", or "api"
+	//
+	// Deprecated: ToolType was historically overloaded to identify which
+	// client made the call (e.g. "claude_code", "codex", "cursor"). Use
+	// CallerName for that purpose instead. ToolType is kept as a
+	// deprecated input fallback for backward compatibility and is not
+	// being removed.
 	ToolType string `json:"tool_type,omitempty"`
+	// CallerName identifies the client that made the tool call (e.g.
+	// "claude_code", "codex", "cursor", "openclaw"). This supersedes the
+	// deprecated ToolType field for that purpose. The server resolves
+	// caller identity as: CallerName if supplied -> legacy ToolType if
+	// supplied -> a default.
+	CallerName string `json:"caller_name,omitempty"`
 	// Input is the input data passed to the tool
 	Input map[string]interface{} `json:"input,omitempty"`
 	// Output is the output data returned by the tool

--- a/audit_test.go
+++ b/audit_test.go
@@ -246,6 +246,118 @@ func TestAuditToolCall(t *testing.T) {
 	})
 }
 
+// TestAuditToolCallCallerName tests the CallerName field added alongside the
+// deprecated ToolType field (getaxonflow/axonflow-enterprise#2912). CallerName
+// identifies which client made the tool call; ToolType is kept for backward
+// compatibility as a deprecated input fallback.
+func TestAuditToolCallCallerName(t *testing.T) {
+	t.Run("caller_name marshals on its own", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var reqBody map[string]interface{}
+			if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+				t.Fatalf("failed to decode request body: %v", err)
+			}
+
+			if reqBody["caller_name"] != "claude_code" {
+				t.Errorf("expected caller_name claude_code, got %v", reqBody["caller_name"])
+			}
+			if _, exists := reqBody["tool_type"]; exists {
+				t.Errorf("expected tool_type to be omitted, got %v", reqBody["tool_type"])
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]string{
+				"audit_id":  "aud_caller1",
+				"status":    "recorded",
+				"timestamp": "2026-07-16T10:00:00Z",
+			})
+		}))
+		defer server.Close()
+
+		client := NewClient(AxonFlowConfig{Endpoint: server.URL})
+
+		_, err := client.AuditToolCall(context.Background(), AuditToolCallRequest{
+			ToolName:   "getUserInfo",
+			CallerName: "claude_code",
+		})
+		if err != nil {
+			t.Fatalf("AuditToolCall failed: %v", err)
+		}
+	})
+
+	t.Run("legacy tool_type still works standalone", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var reqBody map[string]interface{}
+			if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+				t.Fatalf("failed to decode request body: %v", err)
+			}
+
+			if reqBody["tool_type"] != "mcp" {
+				t.Errorf("expected tool_type mcp, got %v", reqBody["tool_type"])
+			}
+			if _, exists := reqBody["caller_name"]; exists {
+				t.Errorf("expected caller_name to be omitted, got %v", reqBody["caller_name"])
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]string{
+				"audit_id":  "aud_legacy1",
+				"status":    "recorded",
+				"timestamp": "2026-07-16T10:05:00Z",
+			})
+		}))
+		defer server.Close()
+
+		client := NewClient(AxonFlowConfig{Endpoint: server.URL})
+
+		_, err := client.AuditToolCall(context.Background(), AuditToolCallRequest{
+			ToolName: "getUserInfo",
+			ToolType: "mcp",
+		})
+		if err != nil {
+			t.Fatalf("AuditToolCall failed: %v", err)
+		}
+	})
+
+	t.Run("both caller_name and tool_type marshal together", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var reqBody map[string]interface{}
+			if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+				t.Fatalf("failed to decode request body: %v", err)
+			}
+
+			if reqBody["caller_name"] != "codex" {
+				t.Errorf("expected caller_name codex, got %v", reqBody["caller_name"])
+			}
+			if reqBody["tool_type"] != "mcp" {
+				t.Errorf("expected tool_type mcp, got %v", reqBody["tool_type"])
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]string{
+				"audit_id":  "aud_both1",
+				"status":    "recorded",
+				"timestamp": "2026-07-16T10:10:00Z",
+			})
+		}))
+		defer server.Close()
+
+		client := NewClient(AxonFlowConfig{Endpoint: server.URL})
+
+		_, err := client.AuditToolCall(context.Background(), AuditToolCallRequest{
+			ToolName:   "getUserInfo",
+			ToolType:   "mcp",
+			CallerName: "codex",
+		})
+		if err != nil {
+			t.Fatalf("AuditToolCall failed: %v", err)
+		}
+	})
+}
+
 // TestSearchAuditLogs tests the SearchAuditLogs method
 func TestSearchAuditLogs(t *testing.T) {
 	t.Run("successful search with all filters", func(t *testing.T) {

--- a/runtime-e2e/caller_name_audit/main.go
+++ b/runtime-e2e/caller_name_audit/main.go
@@ -1,0 +1,173 @@
+//go:build ignore
+
+// runtime-e2e/caller_name_audit/main.go
+//
+// Real-wire test of AuditToolCallRequest.CallerName (#2912, sub-issue of
+// epic #2905) against a real running agent+orchestrator stack.
+//
+// getaxonflow/axonflow-enterprise PR #2953 added a `caller_name` field to
+// the orchestrator's tool-call audit path alongside the legacy `tool_type`
+// field (kept as a deprecated input fallback). The server resolves caller
+// identity as: caller_name if supplied -> legacy tool_type if supplied ->
+// a default. This test proves the SDK's new CallerName field on
+// AuditToolCallRequest actually reaches policy_details.caller_name on a
+// real audit_logs row — not just that it marshals correctly (that's
+// covered by the httptest-based unit tests in audit_test.go).
+//
+// Steps:
+//  1. Call the real SDK's client.AuditToolCall with CallerName set to a
+//     distinctive, non-default value ("e2e-caller-name-probe") and a
+//     unique WorkflowID so we can find the resulting row.
+//  2. The orchestrator's AuditLogger batches writes (flush every 10s), so
+//     poll GET /api/v1/audit/tenant/{tenantID} (the same route
+//     GetAuditLogsByTenant hits) until the row lands.
+//  3. The SDK's typed AuditLogEntry does not surface policy_details (it's
+//     an internal JSONB blob), so this step reads the raw JSON body
+//     directly — the only way to observe policy_details.caller_name from
+//     outside the platform — and asserts it equals what we sent.
+//
+// Run via:
+//
+//	export AXONFLOW_AGENT_URL=http://localhost:8080
+//	export AXONFLOW_TENANT_ID=<registered tenant/client id>
+//	export AXONFLOW_TENANT_SECRET=<its secret>
+//	go run runtime-e2e/caller_name_audit/main.go
+//
+// See ../README.md for how to register a tenant against a local stack.
+
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	axonflow "github.com/getaxonflow/axonflow-sdk-go/v8"
+)
+
+func main() {
+	endpoint := getenv("AXONFLOW_AGENT_URL", "http://localhost:8080")
+	clientID := getenv("AXONFLOW_TENANT_ID", "buku-e-go-e2e")
+	secret := getenv("AXONFLOW_TENANT_SECRET", "buku-e-secret")
+
+	client := axonflow.NewClient(axonflow.AxonFlowConfig{
+		Endpoint:     endpoint,
+		ClientID:     clientID,
+		ClientSecret: secret,
+	})
+
+	workflowID := fmt.Sprintf("e2e-caller-name-%d", time.Now().UnixNano())
+	const wantCallerName = "e2e-caller-name-probe"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	resp, err := client.AuditToolCall(ctx, axonflow.AuditToolCallRequest{
+		ToolName:   "e2eCallerNameTool",
+		CallerName: wantCallerName,
+		WorkflowID: workflowID,
+	})
+	if err != nil {
+		fail("SDK AuditToolCall: %v", err)
+	}
+	fmt.Printf("SDK AuditToolCall recorded → audit_id=%s status=%s\n", resp.AuditID, resp.Status)
+
+	// The orchestrator's AuditLogger batch-writes every 10s; poll the
+	// tenant-audit route (the same one GetAuditLogsByTenant hits) using a
+	// raw HTTP call so we can inspect policy_details, which the SDK's
+	// typed AuditLogEntry does not expose.
+	var policyDetails map[string]interface{}
+	deadline := time.Now().Add(25 * time.Second)
+	for {
+		found, pd, findErr := findAuditRowRaw(endpoint, clientID, secret, workflowID)
+		if findErr != nil {
+			fail("raw audit/tenant lookup: %v", findErr)
+		}
+		if found {
+			policyDetails = pd
+			break
+		}
+		if time.Now().After(deadline) {
+			fail("audit row for workflow_id=%s did not appear within %s (batch flush may not have fired)", workflowID, 25*time.Second)
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	gotCallerName, ok := policyDetails["caller_name"]
+	if !ok {
+		fail("policy_details missing caller_name key entirely: %v", policyDetails)
+	}
+	if gotCallerName != wantCallerName {
+		fail("policy_details.caller_name = %q, want %q (full policy_details: %v)", gotCallerName, wantCallerName, policyDetails)
+	}
+	if _, hasToolType := policyDetails["tool_type"]; hasToolType {
+		fail("policy_details.tool_type should no longer be written for new rows once caller_name resolves, but found: %v", policyDetails["tool_type"])
+	}
+
+	fmt.Printf("PASS: policy_details.caller_name = %q reached the audit_logs row via the real agent+orchestrator stack\n", gotCallerName)
+	fmt.Printf("Wire policy_details: %v\n", policyDetails)
+}
+
+// findAuditRowRaw hits GET /api/v1/audit/tenant/{tenantID} directly (the
+// exact route GetAuditLogsByTenant uses) and decodes the raw JSON body so
+// we can read policy_details, a field the SDK's AuditLogEntry does not
+// declare. Returns found=false (no error) if the row hasn't landed yet.
+func findAuditRowRaw(endpoint, clientID, secret, workflowID string) (found bool, policyDetails map[string]interface{}, err error) {
+	url := fmt.Sprintf("%s/api/v1/audit/tenant/%s?limit=50", endpoint, clientID)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return false, nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	creds := base64.StdEncoding.EncodeToString([]byte(clientID + ":" + secret))
+	req.Header.Set("Authorization", "Basic "+creds)
+	req.Header.Set("X-Client-ID", clientID)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return false, nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	var parsed struct {
+		Entries []struct {
+			RequestID     string                 `json:"request_id"`
+			PolicyDetails map[string]interface{} `json:"policy_details"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return false, nil, fmt.Errorf("unmarshal audit/tenant response: %w (body: %s)", err, body)
+	}
+
+	for _, e := range parsed.Entries {
+		if e.RequestID == workflowID {
+			return true, e.PolicyDetails, nil
+		}
+	}
+	return false, nil, nil
+}
+
+func getenv(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func fail(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "FAIL: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/testdata/wire_shape_baseline.json
+++ b/testdata/wire_shape_baseline.json
@@ -308,6 +308,12 @@
       ],
       "spec_only": []
     },
+    "AuditToolCallRequest": {
+      "sdk_only": [
+        "caller_name"
+      ],
+      "spec_only": []
+    },
     "Budget": {
       "sdk_only": [
         "enabled"


### PR DESCRIPTION
## Summary

`audit_tool_call`'s `tool_type` field was misleadingly named — every real
caller (claude_code/codex/cursor/openclaw) used it to identify **which
client** made the call, not any property of the tool. This adds a
correctly-named `CallerName` field to `AuditToolCallRequest` alongside it.

- Adds `CallerName string \`json:"caller_name,omitempty"\`` to
  `AuditToolCallRequest` in `audit.go`.
- `ToolType` is **kept, not removed or renamed** — it's now documented
  with a `// Deprecated:` comment pointing callers at `CallerName`, and
  continues to work standalone for backward compatibility.
- No changes needed to `AuditToolCall()` itself — it marshals the whole
  `AuditToolCallRequest` struct via `makeJSONRequest`, so the new field
  is forwarded automatically.

**Update:** the platform side (getaxonflow/axonflow-enterprise#2953) has
since **merged and shipped in platform v9.11.0**. It implements the
resolution — `CallerName` if supplied -> legacy `ToolType` if supplied ->
`"unknown"` when neither is supplied. That last part (the no-identity
default) is getaxonflow/axonflow-enterprise#2903, folded into the same
#2953 merge — it changed the default from an earlier `"claude_code"` to
`"unknown"`. This SDK's `CallerName` field needed no further changes for
that; see follow-up #192, which extends the runtime-e2e proof to also
cover the `"unknown"` case and corrects the CHANGELOG wording (this PR's
description below reflects the original, pre-merge state).

Implements getaxonflow/axonflow-enterprise#2912 (sub-issue of epic #2905)
for the Go SDK.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all packages pass, including new
      `TestAuditToolCallCallerName` (caller_name alone, tool_type alone,
      both together, verified via httptest wire-shape assertions)
- [x] `runtime-e2e/caller_name_audit/main.go` — real end-to-end proof
      against a live agent+orchestrator+postgres stack: calls the real
      SDK's `AuditToolCall` with `CallerName` set, then reads the row
      back and asserts `policy_details.caller_name` matches on the wire
      (ran twice, both PASS)
- [x] Wire-shape contract gate — CI pins this against a specific commit
      of the `getaxonflow/axonflow` **community** mirror
      (`testdata/wire_shape_baseline.json`'s `openapi_specs_sha`), not
      the enterprise repo. Ran the actual gate against that exact pinned
      SHA and it correctly flagged `caller_name` as new drift (the
      community spec doesn't have it yet at that pinned commit — only
      the (then not-yet-merged) enterprise PR #2953 branch does). Added a
      `per_type_drift` baseline entry marking
      `AuditToolCallRequest.caller_name` as known `sdk_only` drift,
      tracked by this issue, regenerated via
      `scripts/refresh_wire_shape_baseline`; gate passes cleanly now with
      no other baseline changes.
- [x] `CHANGELOG.md` — added `[Unreleased]` section (previously had none;
      top entry was released 8.5.1)