### PR TITLE
fix: cover the unknown no-identity default in caller_name e2e proof (#2912)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`runtime-e2e/caller_name_audit/` now also covers the no-identity
+  default (#2903).** getaxonflow/axonflow-enterprise#2953 merged and
+  shipped in platform v9.11.0; folded into that same merge, #2903 changed
+  the server's fallback default — when a caller supplies neither
+  `CallerName` nor the legacy `ToolType` — from `"claude_code"` to
+  `"unknown"`. The runtime proof now asserts `policy_details.caller_name
+  == "unknown"` for that case against a real running stack, alongside the
+  existing `CallerName` round-trip assertion. No SDK code changes; `#2912`'s
+  `CallerName` field already worked correctly — this closes a coverage gap
+  in the runtime proof and doc wording that assumed the old default.
+
 ## [9.0.0] - 2026-07-18
 
 ### Changed (BREAKING)
@@ -67,9 +80,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   identify which client made the tool call — not any property of the tool
   itself. `CallerName` is the correctly-named field for that purpose and is
   preferred going forward. The server resolves caller identity as: `CallerName`
-  if supplied -> legacy `ToolType` if supplied -> a default. `ToolType` is kept
-  as a deprecated input fallback for backward compatibility — it is not being
-  removed or renamed.
+  if supplied -> legacy `ToolType` if supplied -> `"unknown"` when neither is
+  supplied (#2903 — an unidentified caller is no longer silently attributed to
+  the specific client `"claude_code"`, the pre-#2903 default). `ToolType` is
+  kept as a deprecated input fallback for backward compatibility — it is not
+  being removed or renamed. Both #2912 (`caller_name`) and #2903 (the
+  `"unknown"` default) shipped together in
+  getaxonflow/axonflow-enterprise#2953, merged and released in platform
+  v9.11.0.
 
 ## [8.5.1] - 2026-07-09 — Fail-open hardening + debug-log gating + example fixes
 

--- a/runtime-e2e/caller_name_audit/main.go
+++ b/runtime-e2e/caller_name_audit/main.go
@@ -5,26 +5,37 @@
 // Real-wire test of AuditToolCallRequest.CallerName (#2912, sub-issue of
 // epic #2905) against a real running agent+orchestrator stack.
 //
-// getaxonflow/axonflow-enterprise PR #2953 added a `caller_name` field to
-// the orchestrator's tool-call audit path alongside the legacy `tool_type`
-// field (kept as a deprecated input fallback). The server resolves caller
-// identity as: caller_name if supplied -> legacy tool_type if supplied ->
-// a default. This test proves the SDK's new CallerName field on
-// AuditToolCallRequest actually reaches policy_details.caller_name on a
-// real audit_logs row — not just that it marshals correctly (that's
-// covered by the httptest-based unit tests in audit_test.go).
+// getaxonflow/axonflow-enterprise PR #2953 (merged, shipped in platform
+// v9.11.0) added a `caller_name` field to the orchestrator's tool-call
+// audit path alongside the legacy `tool_type` field (kept as a deprecated
+// input fallback). The server resolves caller identity as: caller_name if
+// supplied -> legacy tool_type if supplied -> a default. #2903 (folded
+// into the same #2953 merge) changed that default from the earlier
+// "claude_code" to "unknown" — an unidentified caller must not be
+// silently attributed to a specific client. This test proves both:
+//
+//   - the SDK's CallerName field on AuditToolCallRequest actually reaches
+//     policy_details.caller_name on a real audit_logs row (not just that
+//     it marshals correctly — that's covered by the httptest-based unit
+//     tests in audit_test.go);
+//   - when a caller supplies NEITHER CallerName nor the legacy ToolType,
+//     the persisted row resolves policy_details.caller_name to "unknown"
+//     (#2903), not the old "claude_code" default.
 //
 // Steps:
 //  1. Call the real SDK's client.AuditToolCall with CallerName set to a
 //     distinctive, non-default value ("e2e-caller-name-probe") and a
 //     unique WorkflowID so we can find the resulting row.
-//  2. The orchestrator's AuditLogger batches writes (flush every 10s), so
+//  2. Call it again with neither CallerName nor ToolType set, using a
+//     second unique WorkflowID.
+//  3. The orchestrator's AuditLogger batches writes (flush every 10s), so
 //     poll GET /api/v1/audit/tenant/{tenantID} (the same route
-//     GetAuditLogsByTenant hits) until the row lands.
-//  3. The SDK's typed AuditLogEntry does not surface policy_details (it's
+//     GetAuditLogsByTenant hits) until each row lands.
+//  4. The SDK's typed AuditLogEntry does not surface policy_details (it's
 //     an internal JSONB blob), so this step reads the raw JSON body
 //     directly — the only way to observe policy_details.caller_name from
-//     outside the platform — and asserts it equals what we sent.
+//     outside the platform — and asserts it equals what's expected for
+//     each case.
 //
 // Run via:
 //
@@ -34,6 +45,16 @@
 //	go run runtime-e2e/caller_name_audit/main.go
 //
 // See ../README.md for how to register a tenant against a local stack.
+//
+// Deployment-mode caveat: step 3's poll reads GET /api/v1/audit/tenant/{id}.
+// In non-community deployment modes that route is scoped by the caller's
+// role/identity (resolveCallerReadScope in platform/orchestrator/run.go),
+// so a bare Basic-Auth machine caller with no per-user identity sees an
+// empty page and this test will time out waiting for its own row — even
+// though the row was written correctly. Run this against a stack with
+// DEPLOYMENT_MODE=community (isCommunityMode() short-circuits the
+// role-scoping), or against an enterprise stack with a per-user identity
+// header wired in, to see the assertions actually pass end to end.
 
 package main
 
@@ -61,42 +82,23 @@ func main() {
 		ClientSecret: secret,
 	})
 
-	workflowID := fmt.Sprintf("e2e-caller-name-%d", time.Now().UnixNano())
+	// ---- Case 1: CallerName supplied -> policy_details.caller_name echoes it.
 	const wantCallerName = "e2e-caller-name-probe"
+	workflowIDWithCaller := fmt.Sprintf("e2e-caller-name-%d", time.Now().UnixNano())
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
 	resp, err := client.AuditToolCall(ctx, axonflow.AuditToolCallRequest{
 		ToolName:   "e2eCallerNameTool",
 		CallerName: wantCallerName,
-		WorkflowID: workflowID,
+		WorkflowID: workflowIDWithCaller,
 	})
+	cancel()
 	if err != nil {
-		fail("SDK AuditToolCall: %v", err)
+		fail("SDK AuditToolCall (with CallerName): %v", err)
 	}
 	fmt.Printf("SDK AuditToolCall recorded → audit_id=%s status=%s\n", resp.AuditID, resp.Status)
 
-	// The orchestrator's AuditLogger batch-writes every 10s; poll the
-	// tenant-audit route (the same one GetAuditLogsByTenant hits) using a
-	// raw HTTP call so we can inspect policy_details, which the SDK's
-	// typed AuditLogEntry does not expose.
-	var policyDetails map[string]interface{}
-	deadline := time.Now().Add(25 * time.Second)
-	for {
-		found, pd, findErr := findAuditRowRaw(endpoint, clientID, secret, workflowID)
-		if findErr != nil {
-			fail("raw audit/tenant lookup: %v", findErr)
-		}
-		if found {
-			policyDetails = pd
-			break
-		}
-		if time.Now().After(deadline) {
-			fail("audit row for workflow_id=%s did not appear within %s (batch flush may not have fired)", workflowID, 25*time.Second)
-		}
-		time.Sleep(2 * time.Second)
-	}
+	policyDetails := pollForPolicyDetails(endpoint, clientID, secret, workflowIDWithCaller)
 
 	gotCallerName, ok := policyDetails["caller_name"]
 	if !ok {
@@ -108,9 +110,63 @@ func main() {
 	if _, hasToolType := policyDetails["tool_type"]; hasToolType {
 		fail("policy_details.tool_type should no longer be written for new rows once caller_name resolves, but found: %v", policyDetails["tool_type"])
 	}
-
 	fmt.Printf("PASS: policy_details.caller_name = %q reached the audit_logs row via the real agent+orchestrator stack\n", gotCallerName)
 	fmt.Printf("Wire policy_details: %v\n", policyDetails)
+
+	// ---- Case 2 (#2903): neither CallerName nor ToolType supplied ->
+	// policy_details.caller_name resolves to "unknown", NOT the old
+	// "claude_code" default. #2903 was folded into the same #2953 merge
+	// that shipped CallerName (platform v9.11.0).
+	workflowIDNeither := fmt.Sprintf("e2e-caller-name-neither-%d", time.Now().UnixNano())
+
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 15*time.Second)
+	resp2, err := client.AuditToolCall(ctx2, axonflow.AuditToolCallRequest{
+		ToolName:   "e2eCallerNameDefaultTool",
+		WorkflowID: workflowIDNeither,
+	})
+	cancel2()
+	if err != nil {
+		fail("SDK AuditToolCall (neither CallerName nor ToolType): %v", err)
+	}
+	fmt.Printf("SDK AuditToolCall recorded → audit_id=%s status=%s\n", resp2.AuditID, resp2.Status)
+
+	defaultPolicyDetails := pollForPolicyDetails(endpoint, clientID, secret, workflowIDNeither)
+
+	const wantDefaultCallerName = "unknown"
+	gotDefaultCallerName, ok := defaultPolicyDetails["caller_name"]
+	if !ok {
+		fail("policy_details missing caller_name key entirely on the no-identity row: %v", defaultPolicyDetails)
+	}
+	if gotDefaultCallerName != wantDefaultCallerName {
+		fail("policy_details.caller_name (neither CallerName nor ToolType supplied) = %q, want %q (#2903) — full policy_details: %v",
+			gotDefaultCallerName, wantDefaultCallerName, defaultPolicyDetails)
+	}
+	fmt.Printf("PASS: policy_details.caller_name defaults to %q (#2903) when neither CallerName nor ToolType is supplied\n", gotDefaultCallerName)
+	fmt.Printf("Wire policy_details: %v\n", defaultPolicyDetails)
+
+	fmt.Println("ALL PASS: CallerName round-trips to policy_details.caller_name, and the no-identity default is \"unknown\" (#2903), not \"claude_code\"")
+}
+
+// pollForPolicyDetails polls GET /api/v1/audit/tenant/{tenantID} (the exact
+// route GetAuditLogsByTenant uses) until a row with the given workflowID
+// (request_id) appears, then returns its policy_details. The orchestrator's
+// AuditLogger batch-writes every 10s, so this can take up to that long plus
+// write latency. Fails the process on timeout or transport error.
+func pollForPolicyDetails(endpoint, clientID, secret, workflowID string) map[string]interface{} {
+	deadline := time.Now().Add(25 * time.Second)
+	for {
+		found, pd, findErr := findAuditRowRaw(endpoint, clientID, secret, workflowID)
+		if findErr != nil {
+			fail("raw audit/tenant lookup for workflow_id=%s: %v", workflowID, findErr)
+		}
+		if found {
+			return pd
+		}
+		if time.Now().After(deadline) {
+			fail("audit row for workflow_id=%s did not appear within %s (batch flush may not have fired)", workflowID, 25*time.Second)
+		}
+		time.Sleep(2 * time.Second)
+	}
 }
 
 // findAuditRowRaw hits GET /api/v1/audit/tenant/{tenantID} directly (the


### PR DESCRIPTION
## Summary

Small follow-up to #190 (merged). getaxonflow/axonflow-enterprise#2953
has since merged and shipped in platform v9.11.0. Folded into that same
merge, #2903 changed the server's fallback default — when a caller
supplies neither `CallerName` nor the legacy `ToolType` — from
`"claude_code"` to `"unknown"`, so an unidentified caller is no longer
silently attributed to a specific client.

The Go SDK's `CallerName` field itself needed **no code change** — #2912
was already correct and complete. The gap was purely in the runtime-e2e
proof and CHANGELOG wording, which still described/assumed the old
`"claude_code"` default (accurately reflecting the situation at the time
#190 was written, before #2953/#2903 merged).

- `runtime-e2e/caller_name_audit/main.go` — extended to also assert
  `policy_details.caller_name == "unknown"` for the case where neither
  `CallerName` nor `ToolType` is supplied, alongside the existing
  `CallerName` round-trip assertion.
- `CHANGELOG.md` — corrected wording to name the concrete default
  (`"unknown"`, not `"claude_code"`) and note that #2912 + #2903 shipped
  together in #2953 (merged, platform v9.11.0).

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` (full suite, cache cleared) — all packages pass
- [x] `gofmt -l .` — clean
- [x] `runtime-e2e/caller_name_audit/main.go` — ran twice against a
      **freshly rebuilt** agent+orchestrator stack built from
      axonflow-enterprise's actual current merged `main` (not a branch),
      confirming both:
      - `CallerName` supplied → `policy_details.caller_name` echoes it
      - neither `CallerName` nor `ToolType` supplied →
        `policy_details.caller_name == "unknown"` (#2903)
      Both PASS, both runs.
- [x] Wire-shape contract gate re-run against the exact pinned
      `openapi_specs_sha` from `testdata/wire_shape_baseline.json`
      (extracted via `git archive` from axonflow-community at that SHA) —
      all 8 `TestWireShape*` tests PASS. This file wasn't touched by this
      PR; re-confirmed still consistent.

Related: #2912 (sub-issue of epic #2905), getaxonflow/axonflow-enterprise#2953, getaxonflow/axonflow-enterprise#2903