### PR TITLE
fix(examples): indonesia_compliance fails loud on auth errors [skip-runtime-e2e]

### DIFF
--- a/examples/indonesia_compliance/main.go
+++ b/examples/indonesia_compliance/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	axonflow "github.com/getaxonflow/axonflow-sdk-go/v9"
@@ -41,6 +42,7 @@ func main() {
 		},
 	)
 	if err != nil {
+		failOnAuthError(err)
 		log.Printf("Request error (expected if no LLM configured): %v", err)
 	} else {
 		fmt.Printf("Response blocked: %v\n", resp.Blocked)
@@ -60,6 +62,7 @@ func main() {
 		Limit:     5,
 	})
 	if err != nil {
+		failOnAuthError(err)
 		log.Printf("Audit search error: %v", err)
 	} else {
 		fmt.Printf("Found %d audit entries\n", len(auditResp.Entries))
@@ -84,6 +87,7 @@ func main() {
 		Category: axonflow.CategoryPIIIndonesia,
 	})
 	if err != nil {
+		failOnAuthError(err)
 		log.Printf("Policy list error: %v", err)
 	} else {
 		fmt.Printf("Found %d Indonesia PII policies\n", len(policies))
@@ -101,4 +105,17 @@ func getEnv(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// failOnAuthError exits non-zero when err is an authentication failure
+// (HTTP 401): bad AXONFLOW_CLIENT_ID/AXONFLOW_CLIENT_SECRET, or an
+// invalid/missing AXONFLOW_USER_TOKEN on an enterprise stack. An auth
+// failure is never a "no LLM configured" situation and must not be
+// swallowed by the tolerant error paths above (getaxonflow/
+// axonflow-enterprise#2861 class; mirrors the Python SDK's
+// AuthenticationError re-raise in its indonesia_compliance example).
+func failOnAuthError(err error) {
+	if err != nil && strings.Contains(err.Error(), "HTTP 401") {
+		log.Fatalf("Authentication failed (check AXONFLOW_CLIENT_ID/AXONFLOW_CLIENT_SECRET and AXONFLOW_USER_TOKEN): %v", err)
+	}
 }


### PR DESCRIPTION
## Summary

Backlog-clearance sweep finding (2026-08-03): `examples/indonesia_compliance/main.go` swallowed authentication failures generically - all three governed calls (`ProxyLLMCall`, `SearchAuditLogs`, `ListStaticPolicies`) logged "expected if no LLM configured" (or "Audit search error" / "Policy list error") and the program exited 0. An HTTP 401 (bad `AXONFLOW_CLIENT_ID`/`AXONFLOW_CLIENT_SECRET`, or an invalid/missing `AXONFLOW_USER_TOKEN` on an enterprise stack) is never a "no LLM" situation - this is the getaxonflow/axonflow-enterprise#2861 class that axonflow-sdk-python#215 and axonflow-sdk-java#194 fixed.

`examples/basic` was checked for the same pattern: it already `log.Fatalf`s on query errors, so it fails loud and needs no change.

## Change

- New `failOnAuthError(err)` helper: exits non-zero with an explicit credentials message when the error carries `HTTP 401` (the SDK's `httpError` format, which all three call paths return). Called ahead of each tolerant error path, so non-auth errors (LLM not configured, connector absent) keep the existing degrade-gracefully behaviour. Mirrors the Python example's `except AuthenticationError: raise`.

## Runtime evidence (real `go run`, real HTTP)

Against an agent answering 401 (`{"error":"Unauthorized: invalid client credentials"}`):
- **origin/main (bug):** prints three swallowed errors including `Policy list error: HTTP 401: ...`, prints `=== Done ===`, **exit 0**.
- **this branch:** `Authentication failed (check AXONFLOW_CLIENT_ID/AXONFLOW_CLIENT_SECRET and AXONFLOW_USER_TOKEN): request failed after 3 attempts: HTTP 401: ...`, **exit 1** at the first governed call.

Positive control against a real live v9.13.0 community stack (isolated local compose build of getaxonflow/axonflow main df027c788): the fixed example still exits 0 on the tolerant paths (no LLM configured; 1 Indonesia PII policy listed) - the fix does not convert environmental degradation into failure.

`gofmt -l`, `go vet`, `go build` clean on the example.

## Skip-runtime-e2e justification

Example-only change; no SDK surface touched. The failure mode this fixes (a 401 from the agent) cannot be manufactured on the community stack CI boots (community mode does not reject client credentials - verified live: a wrong `AXONFLOW_CLIENT_SECRET` is accepted), so a committed runtime-e2e leg would need an enterprise stack that CI does not have. The behaviour was instead demonstrated through the actual runtime both ways as above (real `go run` against a real HTTP agent answering 401, plus a live v9.13.0 stack for the non-auth path).
