### PR TITLE
fix(workflows): re-land #188 MarkStepCompletedRequest metadata on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `CallerName` field already worked correctly — this closes a coverage gap
   in the runtime proof and doc wording that assumed the old default.
 
+- **`MarkStepCompletedRequest` gains the spec-declared optional `metadata`
+  field.** The community spec from v9.6.1 through v9.13.0 (`orchestrator-api.yaml`,
+  `MarkStepCompletedRequest`) declares `metadata` as a free-form object
+  captured at step-completion time (audit context the gate-time data didn't
+  have); the platform consumes it at step-completion. Python/TypeScript/Java
+  all model it — Go was the only SDK missing it. Also threaded through the
+  LangGraph adapter's `StepCompletedOptions`/`ToolCompletedOptions`. Treat as
+  opaque on the client. Runtime proof:
+  `runtime-e2e/mark_step_completed_metadata/`.
+
 ### Fixed
 
 - **`UninstallConnector` calls the real platform route.** It issued

--- a/langgraph_adapter.go
+++ b/langgraph_adapter.go
@@ -95,6 +95,9 @@ type StepCompletedOptions struct {
 	TokensIn  *int
 	TokensOut *int
 	CostUSD   *float64
+	// Metadata is free-form metadata captured at step-completion time
+	// (e.g. audit context). Treat as opaque on the client.
+	Metadata map[string]interface{}
 }
 
 // CheckToolGateOptions contains optional parameters for CheckToolGate.
@@ -114,6 +117,9 @@ type ToolCompletedOptions struct {
 	TokensIn  *int
 	TokensOut *int
 	CostUSD   *float64
+	// Metadata is free-form metadata captured at step-completion time
+	// (e.g. audit context). Treat as opaque on the client.
+	Metadata map[string]interface{}
 }
 
 // LangGraphAdapter wraps LangGraph workflows with AxonFlow governance.
@@ -314,6 +320,7 @@ func (a *LangGraphAdapter) StepCompleted(ctx context.Context, stepName string, o
 		req.TokensIn = opts.TokensIn
 		req.TokensOut = opts.TokensOut
 		req.CostUSD = opts.CostUSD
+		req.Metadata = opts.Metadata
 	}
 
 	if stepID == "" {
@@ -374,6 +381,7 @@ func (a *LangGraphAdapter) ToolCompleted(ctx context.Context, toolName string, o
 			TokensIn:  opts.TokensIn,
 			TokensOut: opts.TokensOut,
 			CostUSD:   opts.CostUSD,
+			Metadata:  opts.Metadata,
 		}
 	}
 

--- a/runtime-e2e/mark_step_completed_metadata/main.go
+++ b/runtime-e2e/mark_step_completed_metadata/main.go
@@ -1,0 +1,145 @@
+//go:build ignore
+
+// runtime-e2e/mark_step_completed_metadata/main.go
+//
+// Real-wire test of MarkStepCompletedRequest.Metadata against a live
+// AxonFlow enterprise stack (community v9.6.1 spec, orchestrator-api.yaml
+// MarkStepCompletedRequest schema: metadata is a free-form object captured
+// at step-completion time, opaque to the client).
+//
+// Drives the full WCP lifecycle through the SDK's real net/http transport:
+//
+//  1. CreateWorkflow registers a workflow.
+//  2. StepGate gates a step (first-call retry_context invariants).
+//  3. MarkStepCompleted sends a body carrying the new metadata field and
+//     must get a 2xx back — proving the live orchestrator accepts the
+//     spec-declared field rather than rejecting the body.
+//  4. Re-gate on the same step must report completion_count=1 /
+//     prior_completion_status=completed — proving the /complete call that
+//     carried metadata was fully processed, not silently dropped.
+//  5. GetWorkflow must show the step recorded.
+//
+// Note: no read endpoint currently echoes step-completion metadata back
+// (the platform treats it as opaque audit context), so presence-on-read
+// cannot be asserted; acceptance + processed-completion is the strongest
+// live evidence available.
+//
+// Run via:
+//
+//	go run runtime-e2e/mark_step_completed_metadata/main.go
+//
+// Prereqs: a running orchestrator (AXONFLOW_ORCHESTRATOR_URL, default
+// http://localhost:8081 — WCP endpoints live on the orchestrator) and
+// enterprise credentials in AXONFLOW_CLIENT_ID / AXONFLOW_CLIENT_SECRET.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	axonflow "github.com/getaxonflow/axonflow-sdk-go/v9"
+)
+
+func main() {
+	endpoint := getenv("AXONFLOW_ORCHESTRATOR_URL", "http://localhost:8081")
+	clientID := os.Getenv("AXONFLOW_CLIENT_ID")
+	clientSecret := os.Getenv("AXONFLOW_CLIENT_SECRET")
+	if clientID == "" || clientSecret == "" {
+		fail("AXONFLOW_CLIENT_ID / AXONFLOW_CLIENT_SECRET are required (source /tmp/axonflow-e2e-env.sh)")
+	}
+
+	client := axonflow.NewClient(axonflow.AxonFlowConfig{
+		Endpoint:     endpoint,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+	})
+
+	// ---- Step 1: register a workflow.
+	wf, err := client.CreateWorkflow(axonflow.CreateWorkflowRequest{
+		WorkflowName: "go-sdk-step-metadata-e2e",
+	})
+	if err != nil {
+		fail("CreateWorkflow: %v", err)
+	}
+	fmt.Printf("workflow created: %s\n", wf.WorkflowID)
+
+	// ---- Step 2: gate the step.
+	gate, err := client.StepGate(wf.WorkflowID, "step-1", axonflow.StepGateRequest{
+		StepName: "metadata-step",
+		StepType: axonflow.StepTypeToolCall,
+	})
+	if err != nil {
+		fail("StepGate: %v", err)
+	}
+	if gate.Decision != axonflow.GateDecisionAllow {
+		fail("StepGate decision = %q, want allow (reason: %s)", gate.Decision, gate.Reason)
+	}
+	if gate.RetryContext.CompletionCount != 0 {
+		fail("first gate completion_count = %d, want 0", gate.RetryContext.CompletionCount)
+	}
+	fmt.Printf("gate: decision=%s gate_count=%d completion_count=%d\n",
+		gate.Decision, gate.RetryContext.GateCount, gate.RetryContext.CompletionCount)
+
+	// ---- Step 3: complete WITH metadata. A non-2xx surfaces as err here.
+	metadata := map[string]interface{}{
+		"ticket":              "JIRA-42",
+		"approved_by":         "ops-lead",
+		"downstream_latency":  183,
+		"retry_attempt_count": 1,
+	}
+	if err := client.MarkStepCompleted(wf.WorkflowID, "step-1", &axonflow.MarkStepCompletedRequest{
+		Output:   map[string]interface{}{"result": "success"},
+		Metadata: metadata,
+	}); err != nil {
+		fail("MarkStepCompleted with metadata: %v", err)
+	}
+	fmt.Printf("PASS: MarkStepCompleted with metadata=%v accepted (2xx)\n", metadata)
+
+	// ---- Step 4: re-gate — the completion carrying metadata must have landed.
+	regate, err := client.StepGate(wf.WorkflowID, "step-1", axonflow.StepGateRequest{
+		StepType: axonflow.StepTypeToolCall,
+	})
+	if err != nil {
+		fail("re-gate after complete: %v", err)
+	}
+	if regate.RetryContext.CompletionCount != 1 {
+		fail("re-gate completion_count = %d, want 1", regate.RetryContext.CompletionCount)
+	}
+	if regate.RetryContext.PriorCompletionStatus != axonflow.PriorCompletionStatusCompleted {
+		fail("re-gate prior_completion_status = %q, want completed", regate.RetryContext.PriorCompletionStatus)
+	}
+	fmt.Printf("PASS: re-gate confirms completion processed (completion_count=%d, prior_completion_status=%s)\n",
+		regate.RetryContext.CompletionCount, regate.RetryContext.PriorCompletionStatus)
+
+	// ---- Step 5: workflow status read-back shows the step recorded.
+	status, err := client.GetWorkflow(wf.WorkflowID)
+	if err != nil {
+		fail("GetWorkflow: %v", err)
+	}
+	var found bool
+	for _, s := range status.Steps {
+		if s.StepID == "step-1" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		fail("GetWorkflow did not list step-1 (steps=%v)", status.Steps)
+	}
+	fmt.Printf("PASS: GetWorkflow lists step-1 (workflow status=%s)\n", status.Status)
+
+	fmt.Println("PASS: MarkStepCompletedRequest.Metadata live round-trip OK")
+}
+
+func getenv(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func fail(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, "FAIL: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/testdata/wire_shape_baseline.json
+++ b/testdata/wire_shape_baseline.json
@@ -491,6 +491,13 @@
         "user_token"
       ]
     },
+    "MarkStepCompletedRequest": {
+      "_note": "metadata is spec-declared from community v9.6.1 (ac1b7cd8) and unchanged through v9.13.0 (df027c788): type object, additionalProperties true, opaque on the client. The pinned spec here (8c8d6c9c) predates it. Drop this entry when openapi_specs_sha advances past v9.6.1 (tracked by the spec-pin PR #185; field added by #188).",
+      "sdk_only": [
+        "metadata"
+      ],
+      "spec_only": []
+    },
     "PlanResponse": {
       "sdk_only": [
         "complexity",

--- a/workflows.go
+++ b/workflows.go
@@ -398,6 +398,10 @@ type MarkStepCompletedRequest struct {
 	// IdempotencyKey must match the key passed on the corresponding gate call, if any.
 	// Mismatch (including empty vs set on either side) yields IdempotencyKeyMismatchError.
 	IdempotencyKey string `json:"idempotency_key,omitempty"`
+
+	// Metadata is free-form metadata captured at step-completion time
+	// (e.g. audit context). Treat as opaque on the client.
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // CreateWorkflow creates a new workflow for governance tracking.

--- a/workflows_test.go
+++ b/workflows_test.go
@@ -1389,12 +1389,51 @@ func TestMarkStepCompleted(t *testing.T) {
 			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 		}
 
-		var req MarkStepCompletedRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		// Decode into a raw map so we can assert exactly what landed on the wire.
+		var wire map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&wire); err != nil {
 			t.Fatalf("Failed to decode request body: %v", err)
 		}
-		if req.Output == nil || req.Output["result"] != "success" {
-			t.Errorf("Expected output with result=success, got %v", req.Output)
+		output, _ := wire["output"].(map[string]interface{})
+		if output == nil || output["result"] != "success" {
+			t.Errorf("Expected output with result=success, got %v", wire["output"])
+		}
+		metadata, _ := wire["metadata"].(map[string]interface{})
+		if metadata == nil || metadata["ticket"] != "JIRA-42" || metadata["approved_by"] != "ops-lead" {
+			t.Errorf("Expected metadata with ticket=JIRA-42 approved_by=ops-lead, got %v", wire["metadata"])
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	client := NewClient(AxonFlowConfig{
+		Endpoint:     server.URL,
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	err := client.MarkStepCompleted("wf_test123", "step_1", &MarkStepCompletedRequest{
+		Output:   map[string]interface{}{"result": "success"},
+		Metadata: map[string]interface{}{"ticket": "JIRA-42", "approved_by": "ops-lead"},
+	})
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+// TestMarkStepCompletedMetadataOmittedWhenNil tests that a nil Metadata map
+// does not serialize a "metadata" key onto the wire body
+func TestMarkStepCompletedMetadataOmittedWhenNil(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var wire map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&wire); err != nil {
+			t.Fatalf("Failed to decode request body: %v", err)
+		}
+		if _, present := wire["metadata"]; present {
+			t.Errorf("Expected metadata key to be omitted when nil, got %v", wire["metadata"])
 		}
 
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary

Re-lands #188 on main. #188 squash-merged into its stacked base `chore/spec-pin-v961` (PR #185), and #185 is now STOPPED pending an operator decision on the v9.13.0 audit-surface break - which stranded the `MarkStepCompletedRequest.metadata` fix off-main. The field is independent of that decision: the community spec declares it identically (`type: object, additionalProperties: true`, "Treat as opaque on the client") from v9.6.1 (`ac1b7cd8`) through v9.13.0 (`df027c788`), verified against both revisions.

## Changes (same content as #188, two deltas)

- `workflows.go`: `MarkStepCompletedRequest.Metadata map[string]interface{}` with `json:"metadata,omitempty"`.
- `langgraph_adapter.go`: `StepCompletedOptions`/`ToolCompletedOptions` gain `Metadata`, threaded through `StepCompleted`/`ToolCompleted`.
- `workflows_test.go`: wire-body assertion that `metadata` serializes; `TestMarkStepCompletedMetadataOmittedWhenNil` asserts absence when nil.
- `runtime-e2e/mark_step_completed_metadata/`: the live-stack leg from #188. **Delta:** import path updated `/v8` -> `/v9` (the leg predated the 9.0.0 module-path bump and `//go:build ignore` hid it from `go build ./...`; same class as the leg fixed in #187). Compile-checked explicitly.
- `testdata/wire_shape_baseline.json`: **delta vs #188** - main still pins `openapi_specs_sha` `8c8d6c9c`, which predates the field, so instead of #188's baseline-entry drop this adds a curated `per_type_drift` entry (`sdk_only: ["metadata"]`) with a `_note` naming the spec revisions that declare it and the burn-down condition (drop when the pin advances past v9.6.1; tracked by #185). `openapi_specs_sha` unchanged - no `spec-pin-bump` label needed.
- CHANGELOG bullet under `[Unreleased]`.

## Verification

- Gate discrimination (local, specs at the pinned `8c8d6c9c`): WITHOUT the baseline entry, `TestWireShapeNoNewSDKVsSpecDrift` fails naming exactly `MarkStepCompletedRequest: NEW, only in SDK struct: [metadata]`; WITH it, the full suite passes (`go test ./...` all ok, `gofmt`/`go vet` clean).
- Spec currency: v9.13.0 `orchestrator-api.yaml` declares the identical `metadata` schema (checked at tag `df027c788`).
- Live runtime evidence for the leg is in #188's description (enterprise stack round-trip: create -> gate -> MarkStepCompleted(metadata) accepted -> re-gate confirms completion processed).

Refs #188, #185, getaxonflow/axonflow-enterprise#2861
